### PR TITLE
feat: configure git worktree for parallel development

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "worktree": {
+    "symlinkDirectories": ["node_modules", "target"]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /node_modules/
 **/node_modules/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- `.claude/settings.json` に worktree 設定を追加
- `node_modules` と `target` をシンボリックリンクで共有し、ビルドキャッシュを再利用
- `.claude/settings.local.json` を `.gitignore` に追加

Closes MEW-32

## Test plan
- [ ] worktree 作成時に `node_modules`・`target` がシンボリックリンクになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)