### PR TITLE
feat: implement midori-core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,8 +3,23 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "midori-core"
 version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "midori-driver-midi"
@@ -33,3 +48,86 @@ version = "0.1.0"
 dependencies = [
  "midori-core",
 ]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/midori-core/Cargo.toml
+++ b/crates/midori-core/Cargo.toml
@@ -6,5 +6,8 @@ description = "Shared types and protocol definitions for the Midori signal bridg
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/mew-ton/midori"
 
+[dependencies]
+serde_json = "1"
+
 [lints]
 workspace = true

--- a/crates/midori-core/Cargo.toml
+++ b/crates/midori-core/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/mew-ton/midori"
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [lints]

--- a/crates/midori-core/src/ipc.rs
+++ b/crates/midori-core/src/ipc.rs
@@ -30,10 +30,8 @@ pub enum IpcEvent {
     DeviceState {
         direction: Direction,
         device: String,
-        component: String,
-        /// Present for keyboard components.
-        note: Option<u8>,
-        value_name: String,
+        /// Full dot-separated specifier, e.g. `"upper.60.pressed"` or `"rightHand.index.proximal.bend"`.
+        specifier: String,
         value: Value,
     },
 
@@ -66,6 +64,7 @@ pub enum IpcEvent {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignalRef {
     pub device: String,
+    /// Full dot-separated specifier string.
     pub name: String,
 }
 
@@ -74,9 +73,8 @@ pub struct SignalRef {
 pub struct ComponentRef {
     pub direction: Direction,
     pub device: String,
-    pub component: String,
-    pub note: Option<u8>,
-    pub value_name: String,
+    /// Full dot-separated specifier string.
+    pub specifier: String,
 }
 
 #[cfg(test)]
@@ -92,5 +90,16 @@ mod tests {
             message: "unknown component".into(),
         };
         assert!(matches!(e, IpcEvent::Log { .. }));
+    }
+
+    #[test]
+    fn device_state_dynamic_specifier() {
+        let e = IpcEvent::DeviceState {
+            direction: Direction::Input,
+            device: "els03".into(),
+            specifier: "upper.60.pressed".into(),
+            value: Value::Bool(true),
+        };
+        assert!(matches!(e, IpcEvent::DeviceState { .. }));
     }
 }

--- a/crates/midori-core/src/ipc.rs
+++ b/crates/midori-core/src/ipc.rs
@@ -1,14 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+use crate::pipeline::SignalSpecifier;
 use crate::value::Value;
 
 /// Direction of data flow through the pipeline.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum Direction {
     Input,
     Output,
 }
 
 /// Log severity level.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum LogLevel {
     Error,
     Warn,
@@ -16,7 +21,8 @@ pub enum LogLevel {
 }
 
 /// Events streamed as JSON Lines from the runtime to the GUI over stdout.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
 pub enum IpcEvent {
     /// Raw hardware event from a driver (Layer 1 / Layer 5).
     RawEvent {
@@ -30,16 +36,14 @@ pub enum IpcEvent {
     DeviceState {
         direction: Direction,
         device: String,
-        /// Full dot-separated specifier, e.g. `"upper.60.pressed"` or `"rightHand.index.proximal.bend"`.
-        specifier: String,
+        specifier: SignalSpecifier,
         value: Value,
     },
 
     /// Mapper output signal (Layer 3).
     Signal {
         device: String,
-        /// Signal specifier string, e.g. `"upper.60.pressed"`.
-        name: String,
+        specifier: SignalSpecifier,
         value: Value,
     },
 
@@ -61,20 +65,18 @@ pub enum IpcEvent {
 }
 
 /// Reference to a signal in an error-path event.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SignalRef {
     pub device: String,
-    /// Full dot-separated specifier string.
-    pub name: String,
+    pub specifier: String,
 }
 
 /// Reference to a component in an error-path event.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ComponentRef {
     pub direction: Direction,
     pub device: String,
-    /// Full dot-separated specifier string.
-    pub specifier: String,
+    pub specifier: SignalSpecifier,
 }
 
 #[cfg(test)]
@@ -97,9 +99,22 @@ mod tests {
         let e = IpcEvent::DeviceState {
             direction: Direction::Input,
             device: "els03".into(),
-            specifier: "upper.60.pressed".into(),
+            specifier: "upper.60.pressed".parse().unwrap(),
             value: Value::Bool(true),
         };
         assert!(matches!(e, IpcEvent::DeviceState { .. }));
+    }
+
+    #[test]
+    fn ipc_event_json_roundtrip() {
+        let e = IpcEvent::DeviceState {
+            direction: Direction::Input,
+            device: "els03".into(),
+            specifier: "upper.60.pressed".parse().unwrap(),
+            value: Value::Bool(true),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        let decoded: IpcEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, decoded);
     }
 }

--- a/crates/midori-core/src/ipc.rs
+++ b/crates/midori-core/src/ipc.rs
@@ -1,1 +1,96 @@
+use crate::value::Value;
 
+/// Direction of data flow through the pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Input,
+    Output,
+}
+
+/// Log severity level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+}
+
+/// Events streamed as JSON Lines from the runtime to the GUI over stdout.
+#[derive(Debug, Clone, PartialEq)]
+pub enum IpcEvent {
+    /// Raw hardware event from a driver (Layer 1 / Layer 5).
+    RawEvent {
+        direction: Direction,
+        driver: String,
+        /// Opaque driver-specific payload (e.g. MIDI bytes, OSC path).
+        payload: serde_json::Value,
+    },
+
+    /// Normalised component state after Layer 2 / Layer 4 processing.
+    DeviceState {
+        direction: Direction,
+        device: String,
+        component: String,
+        /// Present for keyboard components.
+        note: Option<u8>,
+        value_name: String,
+        value: Value,
+    },
+
+    /// Mapper output signal (Layer 3).
+    Signal {
+        device: String,
+        /// Signal specifier string, e.g. `"upper.60.pressed"`.
+        name: String,
+        value: Value,
+    },
+
+    /// Diagnostic log from any layer.
+    Log {
+        level: LogLevel,
+        /// Which pipeline layer emitted this message.
+        layer: String,
+        device: Option<String>,
+        message: String,
+    },
+
+    /// Highlights nodes/signals/components involved in an error propagation path.
+    ErrorPath {
+        nodes: Vec<String>,
+        signals: Vec<SignalRef>,
+        components: Vec<ComponentRef>,
+    },
+}
+
+/// Reference to a signal in an error-path event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignalRef {
+    pub device: String,
+    pub name: String,
+}
+
+/// Reference to a component in an error-path event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentRef {
+    pub direction: Direction,
+    pub device: String,
+    pub component: String,
+    pub note: Option<u8>,
+    pub value_name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_event_fields() {
+        let e = IpcEvent::Log {
+            level: LogLevel::Error,
+            layer: "input-recognition".into(),
+            device: Some("els03".into()),
+            message: "unknown component".into(),
+        };
+        assert!(matches!(e, IpcEvent::Log { .. }));
+    }
+}

--- a/crates/midori-core/src/pipeline.rs
+++ b/crates/midori-core/src/pipeline.rs
@@ -1,35 +1,42 @@
 use crate::value::Value;
 
-/// Identifies a single value field on a device component.
+/// Identifies a value within a component via a dynamic dot-separated path.
 ///
-/// Format: `<component_id>.<value_name>` or `<component_id>.<note>.<value_name>` for keyboards.
+/// The structure under `component_id` is component-type-dependent:
+///
+/// ```text
+/// slider / knob:  component_id="expression"  path=["value"]
+/// keyboard key:   component_id="upper"        path=["60", "pressed"]
+/// hand tracking:  component_id="rightHand"    path=["index", "proximal", "bend"]
+/// ```
+///
+/// Full string form: `<component_id>.<path[0]>.<path[1]>...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SignalSpecifier {
     pub component_id: String,
-    /// MIDI note number; `Some` only for keyboard components.
-    pub note: Option<u8>,
-    pub value_name: String,
+    /// Path segments beneath the component. Must contain at least one element (the leaf value name).
+    pub path: Vec<String>,
 }
 
 impl SignalSpecifier {
-    pub fn new(component_id: impl Into<String>, value_name: impl Into<String>) -> Self {
+    /// Build from a component id and path segments. `path` must be non-empty.
+    pub fn new(component_id: impl Into<String>, path: Vec<String>) -> Self {
+        assert!(!path.is_empty(), "SignalSpecifier path must not be empty");
         Self {
             component_id: component_id.into(),
-            note: None,
-            value_name: value_name.into(),
+            path,
         }
     }
 
-    pub fn with_note(
-        component_id: impl Into<String>,
-        note: u8,
-        value_name: impl Into<String>,
-    ) -> Self {
-        Self {
-            component_id: component_id.into(),
-            note: Some(note),
-            value_name: value_name.into(),
-        }
+    /// Convenience constructor for a single-segment path (e.g. slider `.value`).
+    pub fn leaf(component_id: impl Into<String>, value_name: impl Into<String>) -> Self {
+        Self::new(component_id, vec![value_name.into()])
+    }
+
+    /// Returns the full dot-separated string representation.
+    #[must_use]
+    pub fn to_dot_string(&self) -> String {
+        format!("{}.{}", self.component_id, self.path.join("."))
     }
 }
 
@@ -55,17 +62,31 @@ mod tests {
     use crate::value::Value;
 
     #[test]
-    fn signal_specifier_keyboard() {
-        let s = SignalSpecifier::with_note("upper", 60, "pressed");
-        assert_eq!(s.note, Some(60));
-        assert_eq!(s.value_name, "pressed");
+    fn specifier_keyboard_key() {
+        let s = SignalSpecifier::new("upper", vec!["60".into(), "pressed".into()]);
+        assert_eq!(s.to_dot_string(), "upper.60.pressed");
+    }
+
+    #[test]
+    fn specifier_slider() {
+        let s = SignalSpecifier::leaf("expression", "value");
+        assert_eq!(s.to_dot_string(), "expression.value");
+    }
+
+    #[test]
+    fn specifier_hand_tracking() {
+        let s = SignalSpecifier::new(
+            "rightHand",
+            vec!["index".into(), "proximal".into(), "bend".into()],
+        );
+        assert_eq!(s.to_dot_string(), "rightHand.index.proximal.bend");
     }
 
     #[test]
     fn component_state_fields() {
         let cs = ComponentState {
             device_id: "els03".into(),
-            specifier: SignalSpecifier::new("expression", "value"),
+            specifier: SignalSpecifier::leaf("expression", "value"),
             value: Value::Float(0.8),
         };
         assert_eq!(cs.device_id, "els03");

--- a/crates/midori-core/src/pipeline.rs
+++ b/crates/midori-core/src/pipeline.rs
@@ -1,1 +1,73 @@
+use crate::value::Value;
 
+/// Identifies a single value field on a device component.
+///
+/// Format: `<component_id>.<value_name>` or `<component_id>.<note>.<value_name>` for keyboards.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SignalSpecifier {
+    pub component_id: String,
+    /// MIDI note number; `Some` only for keyboard components.
+    pub note: Option<u8>,
+    pub value_name: String,
+}
+
+impl SignalSpecifier {
+    pub fn new(component_id: impl Into<String>, value_name: impl Into<String>) -> Self {
+        Self {
+            component_id: component_id.into(),
+            note: None,
+            value_name: value_name.into(),
+        }
+    }
+
+    pub fn with_note(
+        component_id: impl Into<String>,
+        note: u8,
+        value_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            component_id: component_id.into(),
+            note: Some(note),
+            value_name: value_name.into(),
+        }
+    }
+}
+
+/// Normalised device event produced by Layer 2 and consumed by Layer 3 (mapper).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ComponentState {
+    pub device_id: String,
+    pub specifier: SignalSpecifier,
+    pub value: Value,
+}
+
+/// Mapper output produced by Layer 3 and consumed by Layer 4 (output recognition).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Signal {
+    pub device_id: String,
+    pub specifier: SignalSpecifier,
+    pub value: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::value::Value;
+
+    #[test]
+    fn signal_specifier_keyboard() {
+        let s = SignalSpecifier::with_note("upper", 60, "pressed");
+        assert_eq!(s.note, Some(60));
+        assert_eq!(s.value_name, "pressed");
+    }
+
+    #[test]
+    fn component_state_fields() {
+        let cs = ComponentState {
+            device_id: "els03".into(),
+            specifier: SignalSpecifier::new("expression", "value"),
+            value: Value::Float(0.8),
+        };
+        assert_eq!(cs.device_id, "els03");
+    }
+}

--- a/crates/midori-core/src/pipeline.rs
+++ b/crates/midori-core/src/pipeline.rs
@@ -36,18 +36,16 @@ impl std::fmt::Display for SignalSpecifierError {
 impl std::error::Error for SignalSpecifierError {}
 
 impl SignalSpecifier {
-    /// Fallible constructor. Returns `Err` when `path` is empty.
+    /// Fallible constructor. Returns `Err` when `component_id`, `path`, or any path segment is empty.
     pub fn try_new(
         component_id: impl Into<String>,
         path: Vec<String>,
     ) -> Result<Self, SignalSpecifierError> {
-        if path.is_empty() {
+        let component_id = component_id.into();
+        if component_id.is_empty() || path.is_empty() || path.iter().any(String::is_empty) {
             return Err(SignalSpecifierError);
         }
-        Ok(Self {
-            component_id: component_id.into(),
-            path,
-        })
+        Ok(Self { component_id, path })
     }
 
     /// Panicking constructor for use-sites where the caller guarantees a non-empty path.
@@ -79,11 +77,8 @@ impl std::str::FromStr for SignalSpecifier {
         let mut parts = s.splitn(2, '.');
         let component_id = parts.next().ok_or(SignalSpecifierError)?.to_owned();
         let rest = parts.next().ok_or(SignalSpecifierError)?;
-        if rest.is_empty() {
-            return Err(SignalSpecifierError);
-        }
         let path = rest.split('.').map(str::to_owned).collect();
-        Ok(Self { component_id, path })
+        Self::try_new(component_id, path)
     }
 }
 
@@ -152,6 +147,19 @@ mod tests {
     #[test]
     fn specifier_try_new_empty_path() {
         assert!(SignalSpecifier::try_new("upper", vec![]).is_err());
+    }
+
+    #[test]
+    fn specifier_rejects_empty_component_id() {
+        assert!("".parse::<SignalSpecifier>().is_err());
+        assert!(SignalSpecifier::try_new("", vec!["pressed".into()]).is_err());
+    }
+
+    #[test]
+    fn specifier_rejects_empty_segment() {
+        assert!(".foo".parse::<SignalSpecifier>().is_err());
+        assert!("a..b".parse::<SignalSpecifier>().is_err());
+        assert!(SignalSpecifier::try_new("upper", vec!["60".into(), String::new()]).is_err());
     }
 
     #[test]

--- a/crates/midori-core/src/pipeline.rs
+++ b/crates/midori-core/src/pipeline.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
 use crate::value::Value;
 
 /// Identifies a value within a component via a dynamic dot-separated path.
@@ -18,10 +20,40 @@ pub struct SignalSpecifier {
     pub path: Vec<String>,
 }
 
+/// Error returned by [`SignalSpecifier::try_new`] and [`str::parse`].
+#[derive(Debug)]
+pub struct SignalSpecifierError;
+
+impl std::fmt::Display for SignalSpecifierError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "invalid signal specifier: expected '<component_id>.<path...>'"
+        )
+    }
+}
+
+impl std::error::Error for SignalSpecifierError {}
+
 impl SignalSpecifier {
-    /// Build from a component id and path segments. `path` must be non-empty.
+    /// Fallible constructor. Returns `Err` when `path` is empty.
+    pub fn try_new(
+        component_id: impl Into<String>,
+        path: Vec<String>,
+    ) -> Result<Self, SignalSpecifierError> {
+        if path.is_empty() {
+            return Err(SignalSpecifierError);
+        }
+        Ok(Self {
+            component_id: component_id.into(),
+            path,
+        })
+    }
+
+    /// Panicking constructor for use-sites where the caller guarantees a non-empty path.
+    /// Panics in debug builds; UB-free but unchecked in release.
     pub fn new(component_id: impl Into<String>, path: Vec<String>) -> Self {
-        assert!(!path.is_empty(), "SignalSpecifier path must not be empty");
+        debug_assert!(!path.is_empty(), "SignalSpecifier path must not be empty");
         Self {
             component_id: component_id.into(),
             path,
@@ -32,16 +64,44 @@ impl SignalSpecifier {
     pub fn leaf(component_id: impl Into<String>, value_name: impl Into<String>) -> Self {
         Self::new(component_id, vec![value_name.into()])
     }
+}
 
-    /// Returns the full dot-separated string representation.
-    #[must_use]
-    pub fn to_dot_string(&self) -> String {
-        format!("{}.{}", self.component_id, self.path.join("."))
+impl std::fmt::Display for SignalSpecifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.component_id, self.path.join("."))
+    }
+}
+
+impl std::str::FromStr for SignalSpecifier {
+    type Err = SignalSpecifierError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.splitn(2, '.');
+        let component_id = parts.next().ok_or(SignalSpecifierError)?.to_owned();
+        let rest = parts.next().ok_or(SignalSpecifierError)?;
+        if rest.is_empty() {
+            return Err(SignalSpecifierError);
+        }
+        let path = rest.split('.').map(str::to_owned).collect();
+        Ok(Self { component_id, path })
+    }
+}
+
+impl Serialize for SignalSpecifier {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for SignalSpecifier {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
     }
 }
 
 /// Normalised device event produced by Layer 2 and consumed by Layer 3 (mapper).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ComponentState {
     pub device_id: String,
     pub specifier: SignalSpecifier,
@@ -49,7 +109,7 @@ pub struct ComponentState {
 }
 
 /// Mapper output produced by Layer 3 and consumed by Layer 4 (output recognition).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Signal {
     pub device_id: String,
     pub specifier: SignalSpecifier,
@@ -64,13 +124,13 @@ mod tests {
     #[test]
     fn specifier_keyboard_key() {
         let s = SignalSpecifier::new("upper", vec!["60".into(), "pressed".into()]);
-        assert_eq!(s.to_dot_string(), "upper.60.pressed");
+        assert_eq!(s.to_string(), "upper.60.pressed");
     }
 
     #[test]
     fn specifier_slider() {
         let s = SignalSpecifier::leaf("expression", "value");
-        assert_eq!(s.to_dot_string(), "expression.value");
+        assert_eq!(s.to_string(), "expression.value");
     }
 
     #[test]
@@ -79,7 +139,19 @@ mod tests {
             "rightHand",
             vec!["index".into(), "proximal".into(), "bend".into()],
         );
-        assert_eq!(s.to_dot_string(), "rightHand.index.proximal.bend");
+        assert_eq!(s.to_string(), "rightHand.index.proximal.bend");
+    }
+
+    #[test]
+    fn specifier_roundtrip() {
+        let original = SignalSpecifier::new("upper", vec!["60".into(), "pressed".into()]);
+        let parsed: SignalSpecifier = original.to_string().parse().unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn specifier_try_new_empty_path() {
+        assert!(SignalSpecifier::try_new("upper", vec![]).is_err());
     }
 
     #[test]

--- a/crates/midori-core/src/pipeline.rs
+++ b/crates/midori-core/src/pipeline.rs
@@ -42,7 +42,11 @@ impl SignalSpecifier {
         path: Vec<String>,
     ) -> Result<Self, SignalSpecifierError> {
         let component_id = component_id.into();
-        if component_id.is_empty() || path.is_empty() || path.iter().any(String::is_empty) {
+        if component_id.is_empty()
+            || component_id.contains('.')
+            || path.is_empty()
+            || path.iter().any(|s| s.is_empty() || s.contains('.'))
+        {
             return Err(SignalSpecifierError);
         }
         Ok(Self { component_id, path })
@@ -160,6 +164,19 @@ mod tests {
         assert!(".foo".parse::<SignalSpecifier>().is_err());
         assert!("a..b".parse::<SignalSpecifier>().is_err());
         assert!(SignalSpecifier::try_new("upper", vec!["60".into(), String::new()]).is_err());
+    }
+
+    #[test]
+    fn specifier_rejects_dot_in_segment() {
+        assert!(SignalSpecifier::try_new("up.per", vec!["pressed".into()]).is_err());
+        assert!(SignalSpecifier::try_new("upper", vec!["60.pressed".into()]).is_err());
+    }
+
+    #[test]
+    fn specifier_roundtrip_no_dot_in_segment() {
+        let s = SignalSpecifier::new("upper", vec!["60".into(), "pressed".into()]);
+        let parsed: SignalSpecifier = s.to_string().parse().unwrap();
+        assert_eq!(s, parsed);
     }
 
     #[test]

--- a/crates/midori-core/src/shm.rs
+++ b/crates/midori-core/src/shm.rs
@@ -1,1 +1,46 @@
+use crate::pipeline::ComponentState;
 
+/// Capacity of the SPSC ring buffer (number of slots).
+///
+/// One slot per raw event; sized to absorb a full tick's worth of driver output
+/// without blocking the producer.
+pub const RING_CAPACITY: usize = 256;
+
+/// A single slot in the ring buffer.
+///
+/// `None` represents an empty slot. The runtime drains the buffer each tick
+/// and processes events in FIFO order; multiple writes to the same component
+/// field within one tick are last-write-wins.
+pub type RingSlot = Option<ComponentState>;
+
+/// Header written at the start of the shared memory region.
+///
+/// Layout (all fields are `usize`-aligned):
+/// ```text
+/// offset 0: write_index (usize)
+/// offset 8: read_index  (usize)
+/// offset 16: slots[RING_CAPACITY] (RingSlot array)
+/// ```
+///
+/// Both indices are monotonically increasing. Actual slot index is `index % RING_CAPACITY`.
+/// The buffer is full when `write_index - read_index == RING_CAPACITY`.
+#[repr(C)]
+pub struct ShmHeader {
+    pub write_index: usize,
+    pub read_index: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ring_capacity_nonzero() {
+        const { assert!(RING_CAPACITY > 0) };
+    }
+
+    #[test]
+    fn shm_header_size() {
+        assert_eq!(std::mem::size_of::<ShmHeader>(), 16);
+    }
+}

--- a/crates/midori-core/src/shm.rs
+++ b/crates/midori-core/src/shm.rs
@@ -54,19 +54,23 @@ pub struct RingSlot {
 
 /// Header written at the start of the shared memory region.
 ///
-/// Layout (all fields are 8-byte aligned):
+/// Layout (`AtomicU64` is `#[repr(C, align(8))]`, so both fields are 8 bytes):
 /// ```text
-/// offset 0:  write_index (u64)
-/// offset 8:  read_index  (u64)
+/// offset 0:  write_index (AtomicU64)
+/// offset 8:  read_index  (AtomicU64)
 /// offset 16: slots[RING_CAPACITY] (RingSlot array)
 /// ```
 ///
 /// Both indices are monotonically increasing. Actual slot index is `index % RING_CAPACITY`.
 /// The buffer is full when `write_index - read_index == RING_CAPACITY`.
+///
+/// The producer must store slot data before publishing `write_index` with
+/// [`Ordering::Release`]; the consumer must load `write_index` with
+/// [`Ordering::Acquire`] before reading slot data.
 #[repr(C)]
 pub struct ShmHeader {
-    pub write_index: u64,
-    pub read_index: u64,
+    pub write_index: std::sync::atomic::AtomicU64,
+    pub read_index: std::sync::atomic::AtomicU64,
 }
 
 #[cfg(test)]
@@ -79,8 +83,9 @@ mod tests {
     }
 
     #[test]
-    fn shm_header_size() {
+    fn shm_header_size_and_align() {
         assert_eq!(std::mem::size_of::<ShmHeader>(), 16);
+        assert_eq!(std::mem::align_of::<ShmHeader>(), 8);
     }
 
     #[test]

--- a/crates/midori-core/src/shm.rs
+++ b/crates/midori-core/src/shm.rs
@@ -1,24 +1,63 @@
-use crate::pipeline::ComponentState;
-
 /// Capacity of the SPSC ring buffer (number of slots).
 ///
 /// One slot per raw event; sized to absorb a full tick's worth of driver output
 /// without blocking the producer.
 pub const RING_CAPACITY: usize = 256;
 
-/// A single slot in the ring buffer.
+/// Maximum byte length of a device id stored in a [`RingSlot`] (excluding NUL terminator).
+pub const DEVICE_ID_MAX: usize = 63;
+
+/// Maximum byte length of a dot-separated specifier stored in a [`RingSlot`] (excluding NUL terminator).
+pub const SPECIFIER_MAX: usize = 127;
+
+/// Value discriminant stored in [`RingSlot::value_tag`].
 ///
-/// `None` represents an empty slot. The runtime drains the buffer each tick
-/// and processes events in FIFO order; multiple writes to the same component
-/// field within one tick are last-write-wins.
-pub type RingSlot = Option<ComponentState>;
+/// - 0: `Value::Bool(false)`
+/// - 1: `Value::Bool(true)`
+/// - 2: `Value::Pulse`
+/// - 3: `Value::Int` — integer in `value_i64`
+/// - 4: `Value::Float` — float in `value_f64`
+/// - 5: `Value::Null`
+pub mod value_tag {
+    pub const BOOL_FALSE: u8 = 0;
+    pub const BOOL_TRUE: u8 = 1;
+    pub const PULSE: u8 = 2;
+    pub const INT: u8 = 3;
+    pub const FLOAT: u8 = 4;
+    pub const NULL: u8 = 5;
+}
+
+/// A single slot in the SPSC ring buffer.
+///
+/// All fields are fixed-size so the struct is safe to place in a cross-process
+/// `mmap` region.  `occupied == 0` means the slot is empty.
+///
+/// Strings are stored NUL-terminated and truncated to their respective `*_MAX` constants.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct RingSlot {
+    /// 0 = empty, 1 = occupied.
+    pub occupied: u8,
+    /// Value discriminant; see [`value_tag`].
+    pub value_tag: u8,
+    #[allow(clippy::pub_underscore_fields)]
+    pub _pad: [u8; 6],
+    /// NUL-terminated device id.
+    pub device_id: [u8; DEVICE_ID_MAX + 1],
+    /// NUL-terminated dot-separated specifier.
+    pub specifier: [u8; SPECIFIER_MAX + 1],
+    /// Used when `value_tag` is [`value_tag::INT`].
+    pub value_i64: i64,
+    /// Used when `value_tag` is [`value_tag::FLOAT`].
+    pub value_f64: f64,
+}
 
 /// Header written at the start of the shared memory region.
 ///
-/// Layout (all fields are `usize`-aligned):
+/// Layout (all fields are 8-byte aligned):
 /// ```text
-/// offset 0: write_index (usize)
-/// offset 8: read_index  (usize)
+/// offset 0:  write_index (u64)
+/// offset 8:  read_index  (u64)
 /// offset 16: slots[RING_CAPACITY] (RingSlot array)
 /// ```
 ///
@@ -26,8 +65,8 @@ pub type RingSlot = Option<ComponentState>;
 /// The buffer is full when `write_index - read_index == RING_CAPACITY`.
 #[repr(C)]
 pub struct ShmHeader {
-    pub write_index: usize,
-    pub read_index: usize,
+    pub write_index: u64,
+    pub read_index: u64,
 }
 
 #[cfg(test)]
@@ -42,5 +81,13 @@ mod tests {
     #[test]
     fn shm_header_size() {
         assert_eq!(std::mem::size_of::<ShmHeader>(), 16);
+    }
+
+    #[test]
+    fn ring_slot_is_repr_c() {
+        // Verify the slot is a fixed size (not dependent on heap types).
+        let size = std::mem::size_of::<RingSlot>();
+        assert!(size > 0);
+        assert_eq!(size % std::mem::align_of::<RingSlot>(), 0);
     }
 }

--- a/crates/midori-core/src/value.rs
+++ b/crates/midori-core/src/value.rs
@@ -1,8 +1,10 @@
+use serde::{Deserialize, Serialize};
+
 /// Scalar value flowing through the pipeline.
 ///
 /// `Pulse` is a momentary true that auto-resets to false after one tick.
 /// `Null` means "no value this tick" (suppressed output).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Value {
     Bool(bool),
     Pulse,
@@ -12,7 +14,7 @@ pub enum Value {
 }
 
 /// The type tag used in device definitions and node port declarations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ValueType {
     Bool,
     Pulse,
@@ -21,14 +23,36 @@ pub enum ValueType {
 }
 
 /// Range constraint for `Int` and `Float` values.
-#[derive(Debug, Clone, Copy, PartialEq)]
+///
+/// Invariant: `min <= max` and neither is NaN. Construct via [`ValueRange::new`].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ValueRange {
-    pub min: f64,
-    pub max: f64,
+    min: f64,
+    max: f64,
+}
+
+impl ValueRange {
+    /// Returns `Err` if `min > max` or either is NaN.
+    pub fn new(min: f64, max: f64) -> Result<Self, &'static str> {
+        if min.is_nan() || max.is_nan() || min > max {
+            return Err("min must be <= max and neither NaN");
+        }
+        Ok(Self { min, max })
+    }
+
+    #[must_use]
+    pub fn min(&self) -> f64 {
+        self.min
+    }
+
+    #[must_use]
+    pub fn max(&self) -> f64 {
+        self.max
+    }
 }
 
 /// What to do when a value falls outside the declared range.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum OutOfRange {
     #[default]
     Clamp,
@@ -44,5 +68,18 @@ mod tests {
     fn value_clone() {
         let v = Value::Float(0.5);
         assert_eq!(v.clone(), Value::Float(0.5));
+    }
+
+    #[test]
+    fn value_range_valid() {
+        let r = ValueRange::new(0.0, 1.0).unwrap();
+        assert!((r.min() - 0.0).abs() < f64::EPSILON);
+        assert!((r.max() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn value_range_invalid() {
+        assert!(ValueRange::new(1.0, 0.0).is_err());
+        assert!(ValueRange::new(f64::NAN, 1.0).is_err());
     }
 }

--- a/crates/midori-core/src/value.rs
+++ b/crates/midori-core/src/value.rs
@@ -1,1 +1,48 @@
+/// Scalar value flowing through the pipeline.
+///
+/// `Pulse` is a momentary true that auto-resets to false after one tick.
+/// `Null` means "no value this tick" (suppressed output).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Bool(bool),
+    Pulse,
+    Int(i64),
+    Float(f64),
+    Null,
+}
 
+/// The type tag used in device definitions and node port declarations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ValueType {
+    Bool,
+    Pulse,
+    Int,
+    Float,
+}
+
+/// Range constraint for `Int` and `Float` values.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ValueRange {
+    pub min: f64,
+    pub max: f64,
+}
+
+/// What to do when a value falls outside the declared range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutOfRange {
+    #[default]
+    Clamp,
+    Ignore,
+    Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_clone() {
+        let v = Value::Float(0.5);
+        assert_eq!(v.clone(), Value::Float(0.5));
+    }
+}


### PR DESCRIPTION
## Summary
- `value`: `Value` / `ValueType` / `ValueRange` / `OutOfRange`
- `pipeline`: `SignalSpecifier` / `ComponentState` / `Signal`
- `ipc`: `IpcEvent` の全バリアント（RawEvent / DeviceState / Signal / Log / ErrorPath）
- `shm`: SPSC リングバッファのレイアウト定義（`ShmHeader` / `RING_CAPACITY`）
- 7 unit tests パス

Closes MEW-22

## Test plan
- [ ] `cargo test -p midori-core` が全テストパス
- [ ] `cargo clippy -p midori-core -- -D warnings` がクリーン
- [ ] CI が緑になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ランタイム→GUIのIPCイベントストリーム、信号識別子とコンポーネント/信号表現、共有メモリリングバッファのABI、汎用の値型・範囲・出力挙動を追加しました（データ表現とシリアライズ対応）。
* **Chores**
  * シリアライズ/デシリアライズ用の依存関係を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->