### PR TITLE
feat(runtime): CLI 骨格に run サブコマンドと共通オプションを追加（MEW-24）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,114 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +148,7 @@ dependencies = [
 name = "midori-runtime"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "midori-core",
 ]
 
@@ -49,6 +158,12 @@ version = "0.1.0"
 dependencies = [
  "midori-core",
 ]
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "proc-macro2"
@@ -112,6 +227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +248,27 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 midori-core = { workspace = true }
+clap = { version = "4", features = ["derive"] }
 
 [lints]
 workspace = true

--- a/crates/midori-runtime/src/error.rs
+++ b/crates/midori-runtime/src/error.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub enum CliError {
+    ReadProfile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadProfile { path, source } => {
+                write!(
+                    f,
+                    "プロファイルの読み込みに失敗しました ({}): {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CliError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ReadProfile { source, .. } => Some(source),
+        }
+    }
+}

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -1,7 +1,204 @@
-fn main() {}
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "midori",
+    version,
+    about = "Midori signal bridge CLI",
+    propagate_version = true
+)]
+struct Cli {
+    /// アプリデータディレクトリ。省略時は OS 標準の場所を使用する
+    #[arg(long, value_name = "PATH", global = true)]
+    app_data_dir: Option<PathBuf>,
+
+    /// stdout に出力するログのレベル
+    #[arg(long, value_enum, default_value_t = LogLevel::Info, global = true)]
+    log_level: LogLevel,
+
+    /// stdout に出力するログのフォーマット
+    #[arg(long, value_enum, default_value_t = LogFormat::Json, global = true)]
+    log_format: LogFormat,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// プロファイル YAML を読み込んでパイプラインを起動する
+    Run {
+        /// プロファイル YAML へのパス
+        #[arg(value_name = "PROFILE")]
+        profile: PathBuf,
+    },
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+enum LogFormat {
+    Text,
+    Json,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match dispatch(&cli) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("midori: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn dispatch(cli: &Cli) -> Result<(), CliError> {
+    match &cli.command {
+        Command::Run { profile } => run(profile),
+    }
+}
+
+// パイプライン本体は MEW-23 以降で実装する。
+// ここではプロファイルが読み込めることだけを確認する骨格を置く。
+fn run(profile_path: &Path) -> Result<(), CliError> {
+    let _profile_yaml =
+        std::fs::read_to_string(profile_path).map_err(|source| CliError::ReadProfile {
+            path: profile_path.to_path_buf(),
+            source,
+        })?;
+    Ok(())
+}
+
+#[derive(Debug)]
+enum CliError {
+    ReadProfile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadProfile { path, source } => {
+                write!(
+                    f,
+                    "プロファイルの読み込みに失敗しました ({}): {source}",
+                    path.display()
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for CliError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ReadProfile { source, .. } => Some(source),
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
+    use super::{Cli, Command, LogFormat, LogLevel};
+    use clap::{CommandFactory, Parser};
+    use std::path::PathBuf;
+
     #[test]
-    fn it_works() {}
+    fn it_should_render_help_listing_run_subcommand() {
+        let mut cmd = Cli::command();
+        let help = cmd.render_long_help().to_string();
+        assert!(help.contains("run"), "help should list the run subcommand");
+        assert!(
+            help.contains("--app-data-dir"),
+            "help should list --app-data-dir"
+        );
+        assert!(help.contains("--log-level"), "help should list --log-level");
+        assert!(
+            help.contains("--log-format"),
+            "help should list --log-format"
+        );
+    }
+
+    #[test]
+    fn it_should_parse_run_with_profile_path() {
+        let cli = Cli::try_parse_from(["midori", "run", "/tmp/profile.yaml"])
+            .expect("run subcommand with positional profile must parse");
+
+        match cli.command {
+            Command::Run { profile } => {
+                assert_eq!(profile, PathBuf::from("/tmp/profile.yaml"));
+            }
+        }
+    }
+
+    #[test]
+    fn it_should_default_log_options_to_info_and_json() {
+        let cli = Cli::try_parse_from(["midori", "run", "p.yaml"])
+            .expect("default log options must apply");
+        assert_eq!(cli.log_level, LogLevel::Info);
+        assert_eq!(cli.log_format, LogFormat::Json);
+    }
+
+    #[test]
+    fn it_should_accept_global_options_before_subcommand() {
+        let cli = Cli::try_parse_from([
+            "midori",
+            "--log-level",
+            "debug",
+            "--log-format",
+            "text",
+            "--app-data-dir",
+            "/var/midori",
+            "run",
+            "p.yaml",
+        ])
+        .expect("global options before subcommand must parse");
+        assert_eq!(cli.log_level, LogLevel::Debug);
+        assert_eq!(cli.log_format, LogFormat::Text);
+        assert_eq!(cli.app_data_dir, Some(PathBuf::from("/var/midori")));
+    }
+
+    #[test]
+    fn it_should_reject_run_without_profile_argument() {
+        let result = Cli::try_parse_from(["midori", "run"]);
+        assert!(result.is_err(), "run requires a positional profile arg");
+    }
+
+    #[test]
+    fn it_should_succeed_when_profile_file_exists() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("midori-runtime-test-{}.yaml", std::process::id()));
+        std::fs::write(&path, "name: test\n").expect("write tmp profile");
+
+        let cli = Cli::try_parse_from(["midori", "run", path.to_str().expect("tmp path is utf-8")])
+            .expect("parse");
+        let result = super::dispatch(&cli);
+
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_ok(), "existing profile should load");
+    }
+
+    #[test]
+    fn it_should_fail_when_profile_file_is_missing() {
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            "/nonexistent/midori-runtime-test/profile.yaml",
+        ])
+        .expect("parse");
+        let result = super::dispatch(&cli);
+        assert!(result.is_err(), "missing profile should fail");
+    }
 }

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -1,7 +1,11 @@
+mod error;
+
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand, ValueEnum};
+
+use crate::error::CliError;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -77,36 +81,6 @@ fn run(profile_path: &Path) -> Result<(), CliError> {
             source,
         })?;
     Ok(())
-}
-
-#[derive(Debug)]
-enum CliError {
-    ReadProfile {
-        path: PathBuf,
-        source: std::io::Error,
-    },
-}
-
-impl std::fmt::Display for CliError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ReadProfile { path, source } => {
-                write!(
-                    f,
-                    "プロファイルの読み込みに失敗しました ({}): {source}",
-                    path.display()
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for CliError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::ReadProfile { source, .. } => Some(source),
-        }
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes MEW-24

## Summary

- `crates/midori-runtime` に CLI 骨格を実装。`clap` derive で `midori run <PROFILE>` サブコマンドと共通オプション（`--app-data-dir` / `--log-level` / `--log-format`）を提供
- `midori run <PROFILE>` はプロファイル YAML を `read_to_string` で読み込む骨格のみ。パイプライン本体は Out of Scope（MEW-23 以降で実装）
- 単体テスト 7 ケース: `--help` 出力にサブコマンド・オプションが含まれること、`run` の引数パース、デフォルト値、グローバルオプションの位置、必須引数欠落、プロファイル存在/不存在時の振る舞いを検証

## Acceptance Criteria

- [x] `midori` バイナリがビルドできる（`cargo build -p midori-runtime`）
- [x] `--help` でサブコマンドと主要オプションが表示される
- [x] `midori run <profile>` でプロファイルファイルを読み込む骨格が動作する
- [x] `cargo test` がパスする（7 件）

## Out of Scope

- パイプライン実装（L1〜L5 の処理ロジック）
- ドライバープロセスの起動・監視
- IPC JSON Lines ストリーム
- ログ実装本体（フラグの受け付けのみで、ログ出力は MEW-23 以降の Issue で扱う）

## 設計書との整合性メモ

`design/04-runtime-cli.md` ではプロファイル指定が `--profile <path>` オプション形式だが、本 Issue の AC は `midori run <profile>` のサブコマンド形式を要求している。AC を契約として優先し、サブコマンド形式で実装した。設計書は別途 `find-contradiction` または専用 Issue で更新する想定。

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `./target/debug/midori --help` でサブコマンドとオプションが表示されることを確認
- [x] `./target/debug/midori run /nonexistent.yaml` で日本語エラーメッセージが stderr に出力され exit code 1 で終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- `midori` コマンドに CLI インターフェースを追加しました
- グローバルオプションでアプリケーションデータディレクトリを指定可能に
- ロギング設定（ログレベルおよびログ形式）をカスタマイズ可能に
- `run` サブコマンドでプロファイルファイルパスを指定して実行可能に

<!-- end of auto-generated comment: release notes by coderabbit.ai -->