### PR TITLE
feat(sdk): midori-core 再エクスポートと SPSC リングバッファ実装（MEW-35）

### DIFF
--- a/crates/midori-sdk/Cargo.toml
+++ b/crates/midori-sdk/Cargo.toml
@@ -9,5 +9,16 @@ repository = "https://github.com/mew-ton/midori"
 [dependencies]
 midori-core = { workspace = true }
 
-[lints]
-workspace = true
+# midori-sdk は SPSC リングバッファ実装で UnsafeCell を扱うため、
+# workspace の `unsafe_code = "forbid"` をクレート単位で `deny` に緩める。
+# unsafe を使う箇所には個別に `#[allow(unsafe_code)]` を付け、SAFETY コメントで根拠を示す。
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+all         = { level = "warn", priority = -1 }
+pedantic    = { level = "warn", priority = -1 }
+correctness = { level = "deny", priority = -1 }
+module_name_repetitions = "allow"
+missing_errors_doc      = "allow"
+missing_panics_doc      = "allow"

--- a/crates/midori-sdk/src/lib.rs
+++ b/crates/midori-sdk/src/lib.rs
@@ -1,7 +1,60 @@
+//! Driver SDK for the Midori signal bridge.
+//!
+//! Re-exports all public types from [`midori_core`] so driver authors can depend
+//! on `midori-sdk` alone. The shared-memory SPSC ring buffer implementation
+//! lives in this crate (the layout itself is defined in `midori_core::shm`).
+
 pub use midori_core as core;
+
+pub use midori_core::ipc::*;
+pub use midori_core::pipeline::*;
+pub use midori_core::shm::*;
+pub use midori_core::value::*;
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    // ドライバー作者が midori_sdk::* だけで midori_core の型に到達できることを示す。
     #[test]
-    fn it_works() {}
+    fn it_should_expose_value_types_at_top_level() {
+        let _: Value = Value::Bool(true);
+        let _: ValueType = ValueType::Float;
+        let _: OutOfRange = OutOfRange::default();
+    }
+
+    #[test]
+    fn it_should_expose_pipeline_types_at_top_level() {
+        let spec = SignalSpecifier::leaf("expression", "value");
+        let _: ComponentState = ComponentState {
+            device_id: "test".into(),
+            specifier: spec.clone(),
+            value: Value::Float(0.5),
+        };
+        let _: Signal = Signal {
+            device_id: "test".into(),
+            specifier: spec,
+            value: Value::Float(0.5),
+        };
+    }
+
+    #[test]
+    fn it_should_expose_ipc_types_at_top_level() {
+        let _: Direction = Direction::Input;
+        let _: LogLevel = LogLevel::Info;
+        let _: IpcEvent = IpcEvent::Log {
+            level: LogLevel::Info,
+            layer: "test".into(),
+            device: None,
+            message: "hello".into(),
+        };
+    }
+
+    #[test]
+    fn it_should_expose_shm_layout_at_top_level() {
+        let _ = RING_CAPACITY;
+        let _ = DEVICE_ID_MAX;
+        let _ = SPECIFIER_MAX;
+        let _: u8 = value_tag::PULSE;
+    }
 }

--- a/crates/midori-sdk/src/lib.rs
+++ b/crates/midori-sdk/src/lib.rs
@@ -4,12 +4,16 @@
 //! on `midori-sdk` alone. The shared-memory SPSC ring buffer implementation
 //! lives in this crate (the layout itself is defined in `midori_core::shm`).
 
+pub mod spsc;
+
 pub use midori_core as core;
 
 pub use midori_core::ipc::*;
 pub use midori_core::pipeline::*;
 pub use midori_core::shm::*;
 pub use midori_core::value::*;
+
+pub use spsc::{Consumer, Full, Producer, SpscStorage};
 
 #[cfg(test)]
 mod tests {

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -1,0 +1,267 @@
+//! Single-producer single-consumer ring buffer over the shared-memory layout
+//! defined in [`midori_core::shm`].
+//!
+//! # 同期モデル
+//!
+//! - `write_index` と `read_index` は単調増加する [`AtomicU64`]。スロットの
+//!   位置は `index % RING_CAPACITY` で得る。
+//! - 生産者は (1) スロットへ書き込み → (2) `write_index` を `Release` で公開
+//!   する。消費者は (1) `write_index` を `Acquire` で読み → (2) スロットを
+//!   読む。Release/Acquire ペアによりスロットへの書き込みが消費側から正しく
+//!   観測できる。
+//! - SPSC 規律（生産者 1・消費者 1）は [`SpscStorage::split`] が
+//!   `&mut self` を取ることで型レベルに enforce している。両ハンドルが生存
+//!   する間は `split` を再呼び出しできない。
+//!
+//! # ロックフリー性
+//!
+//! 生産者と消費者は分離したインデックスをそれぞれ排他的に書き込むだけで、
+//! 競合する書き込みは発生しない。スロット側は同じインデックスへの同時
+//! アクセスをインデックス比較で排除している。
+
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use midori_core::shm::{RingSlot, ShmHeader, DEVICE_ID_MAX, RING_CAPACITY, SPECIFIER_MAX};
+
+/// 共有メモリ上に置かれることを意図した SPSC リングバッファのストレージ。
+///
+/// `#[repr(C)]` により mmap 可能な固定レイアウトを保証する。FFI（MEW-37）
+/// で他言語からも同レイアウトでアクセスする予定。
+#[repr(C)]
+pub struct SpscStorage {
+    header: ShmHeader,
+    slots: [UnsafeCell<RingSlot>; RING_CAPACITY],
+}
+
+// SAFETY: SpscStorage は SPSC 規律下で 1 スレッド (生産者) と 1 スレッド (消費者) に
+// より共有される。`split(&mut self)` がペアの一意性を保証し、各スレッドは
+// 異なるスロットインデックス（write/read）にしかアクセスしないため、
+// UnsafeCell 経由の同時アクセスはレースしない。インデックス更新は AtomicU64
+// で同期される。
+#[allow(unsafe_code)]
+unsafe impl Sync for SpscStorage {}
+
+impl SpscStorage {
+    /// すべてのスロットがゼロ埋めの空のストレージを生成する。
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            header: ShmHeader {
+                write_index: AtomicU64::new(0),
+                read_index: AtomicU64::new(0),
+            },
+            slots: std::array::from_fn(|_| UnsafeCell::new(EMPTY_SLOT)),
+        }
+    }
+
+    /// SPSC 規律に従って Producer / Consumer のペアに分割する。
+    ///
+    /// `&mut self` を取るため、ペアが生存する間は再分割が型レベルで禁止される。
+    pub fn split(&mut self) -> (Producer<'_>, Consumer<'_>) {
+        let storage: &Self = self;
+        (Producer { storage }, Consumer { storage })
+    }
+}
+
+impl Default for SpscStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// バッファが満杯で push できなかったことを示すエラー。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Full;
+
+impl std::fmt::Display for Full {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SPSC ring buffer is full")
+    }
+}
+
+impl std::error::Error for Full {}
+
+/// 単一の生産者ハンドル。`push` のみを提供する。
+pub struct Producer<'a> {
+    storage: &'a SpscStorage,
+}
+
+impl Producer<'_> {
+    /// スロットを末尾に追加する。バッファが満杯なら [`Full`] を返す。
+    pub fn push(&mut self, slot: RingSlot) -> Result<(), Full> {
+        let header = &self.storage.header;
+        // 自プロセス内の生産者専用インデックスは Relaxed で十分（書き手は自分だけ）。
+        let write = header.write_index.load(Ordering::Relaxed);
+        // 消費者の進捗を Acquire で取得し、満杯判定の根拠とする。
+        let read = header.read_index.load(Ordering::Acquire);
+        if write.wrapping_sub(read) >= RING_CAPACITY as u64 {
+            return Err(Full);
+        }
+        // `as usize` は 32-bit ターゲットで上位ビットを落とすが、
+        // `RING_CAPACITY` は 2 のべき乗のため `% RING_CAPACITY` でその差は消える。
+        #[allow(clippy::cast_possible_truncation)]
+        let idx = (write as usize) % RING_CAPACITY;
+        // SAFETY: SPSC 規律により消費者は `slots[read % CAP]` までしか読まず、
+        // ここで書く `slots[write % CAP]` は満杯判定により消費者の追跡範囲外。
+        // よって同一スロットへの同時アクセスは発生しない。
+        #[allow(unsafe_code)]
+        unsafe {
+            *self.storage.slots[idx].get() = slot;
+        }
+        // スロット書き込みより後に必ず観測されるよう Release で公開する。
+        header
+            .write_index
+            .store(write.wrapping_add(1), Ordering::Release);
+        Ok(())
+    }
+}
+
+/// 単一の消費者ハンドル。`pop` のみを提供する。
+pub struct Consumer<'a> {
+    storage: &'a SpscStorage,
+}
+
+impl Consumer<'_> {
+    /// 先頭スロットを取り出す。バッファが空なら `None` を返す。
+    pub fn pop(&mut self) -> Option<RingSlot> {
+        let header = &self.storage.header;
+        // 自プロセス内の消費者専用インデックスは Relaxed で十分。
+        let read = header.read_index.load(Ordering::Relaxed);
+        // 生産者の進捗を Acquire で取得（対応する Release はスロット書き込みの後）。
+        let write = header.write_index.load(Ordering::Acquire);
+        if read == write {
+            return None;
+        }
+        // 同上: 2 のべき乗での剰余に守られているのでターゲット間で結果は同じ。
+        #[allow(clippy::cast_possible_truncation)]
+        let idx = (read as usize) % RING_CAPACITY;
+        // SAFETY: SPSC 規律により生産者は `slots[write % CAP]` までしか書かず、
+        // ここで読む `slots[read % CAP]` は read < write の不変条件より既に
+        // 書き込みが完了している。Acquire ロードによりその書き込みが可視。
+        #[allow(unsafe_code)]
+        let slot = unsafe { *self.storage.slots[idx].get() };
+        header
+            .read_index
+            .store(read.wrapping_add(1), Ordering::Release);
+        Some(slot)
+    }
+}
+
+const EMPTY_SLOT: RingSlot = RingSlot {
+    occupied: 0,
+    value_tag: 0,
+    _pad: [0; 6],
+    device_id: [0; DEVICE_ID_MAX + 1],
+    specifier: [0; SPECIFIER_MAX + 1],
+    value_i64: 0,
+    value_f64: 0.0,
+};
+
+#[cfg(test)]
+#[allow(clippy::cast_possible_wrap, clippy::items_after_statements)]
+mod tests {
+    use super::*;
+    use midori_core::shm::value_tag;
+
+    const THREAD_TEST_COUNT: i64 = 10_000;
+
+    fn slot_with_int(n: i64) -> RingSlot {
+        let mut s = EMPTY_SLOT;
+        s.occupied = 1;
+        s.value_tag = value_tag::INT;
+        s.value_i64 = n;
+        s
+    }
+
+    #[test]
+    fn it_should_return_none_when_consumer_pops_empty_buffer() {
+        let mut storage = SpscStorage::new();
+        let (_p, mut c) = storage.split();
+        assert_eq!(c.pop().map(|s| s.value_i64), None);
+    }
+
+    #[test]
+    fn it_should_pop_pushed_slots_in_fifo_order() {
+        let mut storage = SpscStorage::new();
+        let (mut p, mut c) = storage.split();
+        p.push(slot_with_int(1)).unwrap();
+        p.push(slot_with_int(2)).unwrap();
+        p.push(slot_with_int(3)).unwrap();
+        assert_eq!(c.pop().unwrap().value_i64, 1);
+        assert_eq!(c.pop().unwrap().value_i64, 2);
+        assert_eq!(c.pop().unwrap().value_i64, 3);
+        assert!(c.pop().is_none());
+    }
+
+    #[test]
+    fn it_should_return_full_when_buffer_holds_capacity_items() {
+        let mut storage = SpscStorage::new();
+        let (mut p, _c) = storage.split();
+        for i in 0..RING_CAPACITY {
+            p.push(slot_with_int(i as i64)).unwrap();
+        }
+        assert_eq!(p.push(slot_with_int(-1)), Err(Full));
+    }
+
+    #[test]
+    fn it_should_wrap_around_after_consuming() {
+        let mut storage = SpscStorage::new();
+        let (mut p, mut c) = storage.split();
+        // 3 周分書いて読む。インデックスは 3 * RING_CAPACITY まで進む。
+        let total = (RING_CAPACITY * 3) as i64;
+        for i in 0..total {
+            p.push(slot_with_int(i)).unwrap();
+            assert_eq!(c.pop().unwrap().value_i64, i);
+        }
+    }
+
+    #[test]
+    fn it_should_allow_refill_after_drain() {
+        let mut storage = SpscStorage::new();
+        let (mut p, mut c) = storage.split();
+        // 一度満杯にし、全部抜き、再度満杯にできる
+        for i in 0..RING_CAPACITY {
+            p.push(slot_with_int(i as i64)).unwrap();
+        }
+        for i in 0..RING_CAPACITY {
+            assert_eq!(c.pop().unwrap().value_i64, i as i64);
+        }
+        for i in 0..RING_CAPACITY {
+            p.push(slot_with_int((i + 1000) as i64)).unwrap();
+        }
+        for i in 0..RING_CAPACITY {
+            assert_eq!(c.pop().unwrap().value_i64, (i + 1000) as i64);
+        }
+    }
+
+    #[test]
+    fn it_should_transfer_data_between_threads() {
+        let mut storage = SpscStorage::new();
+        let (mut p, mut c) = storage.split();
+
+        std::thread::scope(|s| {
+            s.spawn(move || {
+                let mut sent = 0_i64;
+                while sent < THREAD_TEST_COUNT {
+                    if p.push(slot_with_int(sent)).is_ok() {
+                        sent += 1;
+                    } else {
+                        std::thread::yield_now();
+                    }
+                }
+            });
+            s.spawn(move || {
+                let mut expected = 0_i64;
+                while expected < THREAD_TEST_COUNT {
+                    if let Some(slot) = c.pop() {
+                        assert_eq!(slot.value_i64, expected);
+                        expected += 1;
+                    } else {
+                        std::thread::yield_now();
+                    }
+                }
+            });
+        });
+    }
+}


### PR DESCRIPTION
Closes MEW-35

## Summary

サブ Issue 1（MEW-23 umbrella の最初の 1 件）。midori-sdk に以下を追加。

1. **midori-core の公開型を flat に再エクスポート**: `value` / `pipeline` / `ipc` / `shm` を glob で `pub use`。ドライバー作者は `midori_sdk::*` だけで `midori_core` の型に到達できる。
2. **SPSC リングバッファ実装**: `midori_core::shm::ShmHeader` / `RingSlot` のレイアウト上に Producer/Consumer を実装。`#[repr(C)]` を保ち、将来 mmap でクロスプロセス共有可能。

## Acceptance Criteria

- [x] `midori-core` の全公開型（`ValueType` / `ComponentState` / `Signal` / `SignalSpecifier` / 各 IPC イベント / 共有メモリレイアウト）が `midori-sdk` から再エクスポートされている
- [x] ドライバーが `midori_sdk::*` のみで `midori_core` を直接参照せずに型を使える
- [x] SPSC リングバッファの Producer / Consumer 実装が含まれ、単一プロデューサ・単一コンシューマの読み書きができる
- [x] SPSC のラップアラウンド・空・満杯境界条件が単体テストでカバーされている
- [x] `cargo test -p midori-sdk` がパスする（10 件）

## SPSC の同期モデル

| ステップ | Producer | Consumer |
|---|---|---|
| 1 | `read_index` を Acquire で読む（満杯判定） | `write_index` を Acquire で読む（空判定） |
| 2 | スロットへ書き込み | スロットを読み取り |
| 3 | `write_index` を Release で公開 | `read_index` を Release で公開 |

Release/Acquire ペアで「スロットへの書き込み」が消費側から正しく観測されることを保証。SPSC 規律（生産者 1・消費者 1）は `SpscStorage::split(&mut self)` が型レベルで enforce する。

## unsafe について

ワークスペースの `unsafe_code = "forbid"` を midori-sdk クレート単位で `deny` に緩め、`UnsafeCell` を使う箇所に個別 `#[allow(unsafe_code)]` を付与。各箇所に SAFETY コメントを記載済み。

## Out of Scope

- ドライバー CLI スキャフォールド（MEW-36）
- C FFI エクスポート、crates.io メタ整備（MEW-37）
- 実際の mmap によるクロスプロセス共有（MEW-37 で取り扱う）

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] SPSC 並行テスト（`std::thread::scope` で 10,000 件を生産者→消費者へ転送）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * SDK の公開 API を拡張し、IPC、パイプライン、共有メモリ、値の型に直接アクセス可能に
  * シングルプロデューサー/シングルコンシューマーキューの新機能を追加

* **Chores**
  * コード品質チェックの設定を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->