### PR TITLE
feat(sdk): ドライバー CLI スキャフォールドを追加（MEW-36）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +125,12 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "memchr"
@@ -157,6 +173,9 @@ name = "midori-sdk"
 version = "0.1.0"
 dependencies = [
  "midori-core",
+ "serde",
+ "serde_json",
+ "signal-hook",
 ]
 
 [[package]]
@@ -224,6 +243,26 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
 ]
 
 [[package]]

--- a/crates/midori-sdk/Cargo.toml
+++ b/crates/midori-sdk/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/mew-ton/midori"
 
 [dependencies]
 midori-core = { workspace = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+signal-hook = "0.3"
 
 # midori-sdk は SPSC リングバッファ実装で UnsafeCell を扱うため、
 # workspace の `unsafe_code = "forbid"` をクレート単位で `deny` に緩める。

--- a/crates/midori-sdk/src/driver.rs
+++ b/crates/midori-sdk/src/driver.rs
@@ -1,0 +1,593 @@
+//! Driver CLI スキャフォールド。
+//!
+//! ドライバー作者は [`Driver`] トレイトを実装し、`main()` から [`run`] を
+//! 呼び出すだけで `<driver> list` / `<driver> start` の規約準拠 CLI が
+//! 完成する。プロトコルの詳細は `design/10-driver-plugin.md` を参照。
+//!
+//! # 通信アーキテクチャ
+//!
+//! - **stdin** (Bridge → Driver): JSON Lines の制御コマンド
+//! - **stdout** (Driver → Bridge): `hello` メッセージ + 非 JSON はデバッグログ
+//! - **共有メモリ** (Driver → Bridge): リアルタイムイベント（[`crate::spsc`]）
+//!
+//! 本モジュールは制御チャンネル（stdin/stdout）のみを扱う。リアルタイム
+//! イベントの送出は呼び出し側（[`Driver::handle_command`] の `Connect`
+//! コマンド処理など）が `Producer` を起動する責務を負う。
+
+use std::io::{BufRead, Write};
+use std::process::ExitCode;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+/// `<driver> list` の出力エントリ。
+///
+/// `value` はドライバー固有の識別子（`start` 時の `Connect` コマンドで参照される）、
+/// `label` はユーザー表示名。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeviceInfo {
+    pub value: String,
+    pub label: String,
+}
+
+/// Driver → Bridge の起動メッセージ（stdout 1 行目）。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Hello {
+    #[serde(rename = "type")]
+    message_type: HelloTag,
+    sdk_version: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+enum HelloTag {
+    #[serde(rename = "hello")]
+    Hello,
+}
+
+/// Bridge → Driver のハンドシェイク応答（stdin 1 行目）。
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct HelloAck {
+    pub compatible: bool,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// Bridge → Driver の制御コマンド（ハンドシェイク完了後の stdin）。
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ControlCommand {
+    /// 指定デバイスへの接続を開始する。
+    Connect {
+        device: String,
+        #[serde(default)]
+        config: serde_json::Value,
+    },
+    /// 現在の接続を切断する。
+    Disconnect,
+    /// 実行中の接続パラメータを更新する。
+    Configure { config: serde_json::Value },
+}
+
+/// Bridge → Driver で受信しうる stdin メッセージの内訳。
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum BridgeMessage {
+    #[serde(rename = "hello_ack")]
+    HelloAck {
+        compatible: bool,
+        #[serde(default)]
+        reason: Option<String>,
+    },
+    #[serde(rename = "connect")]
+    Connect {
+        device: String,
+        #[serde(default)]
+        config: serde_json::Value,
+    },
+    #[serde(rename = "disconnect")]
+    Disconnect,
+    #[serde(rename = "configure")]
+    Configure { config: serde_json::Value },
+}
+
+impl BridgeMessage {
+    fn into_command(self) -> Option<ControlCommand> {
+        match self {
+            Self::HelloAck { .. } => None,
+            Self::Connect { device, config } => Some(ControlCommand::Connect { device, config }),
+            Self::Disconnect => Some(ControlCommand::Disconnect),
+            Self::Configure { config } => Some(ControlCommand::Configure { config }),
+        }
+    }
+}
+
+/// ドライバー作者が実装するハンドラ群。
+///
+/// すべてのメソッドは `&mut self` を取るため、ドライバー固有の状態
+/// （接続ハンドル・スレッドハンドル等）を保持できる。
+pub trait Driver {
+    /// `<driver> list` で返すデバイス一覧。
+    fn list_devices(&mut self) -> Vec<DeviceInfo>;
+
+    /// 制御コマンドのディスパッチ先。
+    /// 戻り値の `Err` は致命的とみなし、CLI を終了させる。
+    fn handle_command(&mut self, command: ControlCommand) -> Result<(), DriverError>;
+
+    /// graceful shutdown 開始時に呼ばれる。共有メモリの解放やワーカー停止を行う。
+    fn shutdown(&mut self) -> Result<(), DriverError>;
+}
+
+/// ドライバー実装が返すエラー。SDK 側はメッセージを stderr に流すだけ。
+#[derive(Debug)]
+pub struct DriverError {
+    message: String,
+}
+
+impl DriverError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for DriverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for DriverError {}
+
+/// プロトコル進行中に発生したエラー。
+#[derive(Debug)]
+pub enum ProtocolError {
+    /// stdin/stdout への書き込み・読み込みに失敗。
+    Io(std::io::Error),
+    /// 受信した行が JSON としてパースできなかった。
+    Parse {
+        line: String,
+        source: serde_json::Error,
+    },
+    /// `hello_ack` を待っていたのに stdin が EOF した。
+    HandshakeMissing,
+    /// `hello_ack` の前に別メッセージが届いた。
+    HandshakeOutOfOrder,
+    /// Bridge から `hello_ack(compatible:false)` を受信した。
+    Incompatible(Option<String>),
+    /// `Driver::handle_command` / `Driver::shutdown` がエラーを返した。
+    Driver(DriverError),
+}
+
+impl std::fmt::Display for ProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "io error: {e}"),
+            Self::Parse { line, source } => {
+                write!(f, "failed to parse stdin line ({source}): {line}")
+            }
+            Self::HandshakeMissing => f.write_str("stdin closed before hello_ack"),
+            Self::HandshakeOutOfOrder => f.write_str("expected hello_ack as first stdin message"),
+            Self::Incompatible(reason) => match reason {
+                Some(r) => write!(f, "Bridge reported incompatibility: {r}"),
+                None => f.write_str("Bridge reported incompatibility"),
+            },
+            Self::Driver(e) => write!(f, "driver error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ProtocolError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Parse { source, .. } => Some(source),
+            Self::Driver(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for ProtocolError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+/// `<driver> list` を実行する。pure 関数版（テスト用）。
+pub fn write_device_list<W: Write, D: Driver>(driver: &mut D, out: &mut W) -> std::io::Result<()> {
+    let devices = driver.list_devices();
+    serde_json::to_writer(&mut *out, &devices)?;
+    out.write_all(b"\n")?;
+    out.flush()
+}
+
+/// hello メッセージを 1 行で書き出す。
+pub fn write_hello<W: Write>(out: &mut W, sdk_version: &str) -> std::io::Result<()> {
+    let hello = Hello {
+        message_type: HelloTag::Hello,
+        sdk_version: sdk_version.to_owned(),
+    };
+    serde_json::to_writer(&mut *out, &hello)?;
+    out.write_all(b"\n")?;
+    out.flush()
+}
+
+/// stdin の 1 行を [`BridgeMessage`] にパースする。
+fn parse_bridge_message(line: &str) -> Result<BridgeMessage, ProtocolError> {
+    serde_json::from_str(line).map_err(|source| ProtocolError::Parse {
+        line: line.to_owned(),
+        source,
+    })
+}
+
+/// `<driver> start` のプロトコル本体。シグナル・スレッドに依存しないため、
+/// テストから直接呼び出してハンドシェイクとコマンド分配を検証できる。
+///
+/// `lines` は stdin から 1 行ずつ供給するイテレータ。`shutdown` は外部
+/// （シグナルハンドラ等）から立てるフラグで、true になればコマンド消費を
+/// 停止して [`Driver::shutdown`] を呼ぶ。
+pub fn run_protocol<D, I, W>(
+    driver: &mut D,
+    lines: I,
+    out: &mut W,
+    sdk_version: &str,
+    shutdown: &Arc<AtomicBool>,
+) -> Result<(), ProtocolError>
+where
+    D: Driver,
+    I: IntoIterator<Item = std::io::Result<String>>,
+    W: Write,
+{
+    write_hello(out, sdk_version)?;
+
+    let mut iter = lines.into_iter();
+
+    // 最初の 1 行は必ず hello_ack
+    let first = iter.next().ok_or(ProtocolError::HandshakeMissing)??;
+    match parse_bridge_message(&first)? {
+        BridgeMessage::HelloAck {
+            compatible: false,
+            reason,
+        } => return Err(ProtocolError::Incompatible(reason)),
+        BridgeMessage::HelloAck {
+            compatible: true, ..
+        } => {}
+        _ => return Err(ProtocolError::HandshakeOutOfOrder),
+    }
+
+    // 以降はコマンドループ
+    for line in iter {
+        if shutdown.load(Ordering::Acquire) {
+            break;
+        }
+        let line = line?;
+        let message = parse_bridge_message(&line)?;
+        if let Some(cmd) = message.into_command() {
+            driver.handle_command(cmd).map_err(ProtocolError::Driver)?;
+        }
+        // hello_ack が再度来るのは仕様外だが、エラーにせず無視する。
+    }
+
+    driver.shutdown().map_err(ProtocolError::Driver)?;
+    Ok(())
+}
+
+/// `<driver>` バイナリのエントリポイント。`fn main()` から呼び出す。
+///
+/// argv を見て `list` / `start` をディスパッチし、`start` ではシグナル
+/// ハンドラを設定し stdin リーダースレッドを起動して [`run_protocol`] を
+/// 駆動する。`sdk_version` には呼び出し元クレートで `env!("CARGO_PKG_VERSION")`
+/// を渡すのが基本だが、本 SDK 自身のバージョンを埋め込みたければ
+/// `midori_sdk::driver::SDK_VERSION` を使う。
+pub fn run<D: Driver>(mut driver: D, sdk_version: &str) -> ExitCode {
+    let mut args = std::env::args();
+    let _bin = args.next();
+    match args.next().as_deref() {
+        Some("list") => match exec_list(&mut driver) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(err) => {
+                eprintln!("midori-sdk: list failed: {err}");
+                ExitCode::FAILURE
+            }
+        },
+        Some("start") => exec_start(&mut driver, sdk_version),
+        Some(other) => {
+            eprintln!("midori-sdk: unknown subcommand: {other}");
+            print_usage();
+            ExitCode::FAILURE
+        }
+        None => {
+            print_usage();
+            ExitCode::FAILURE
+        }
+    }
+}
+
+/// 本 SDK クレート自身のバージョン（`<package>.version`）。
+/// ドライバー作者が `run(driver, SDK_VERSION)` の形で利用できるよう公開する。
+pub const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn exec_list<D: Driver>(driver: &mut D) -> std::io::Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    write_device_list(driver, &mut out)
+}
+
+fn exec_start<D: Driver>(driver: &mut D, sdk_version: &str) -> ExitCode {
+    let shutdown = Arc::new(AtomicBool::new(false));
+    if let Err(err) = register_termination_signals(&shutdown) {
+        eprintln!("midori-sdk: failed to install signal handlers: {err}");
+        return ExitCode::FAILURE;
+    }
+
+    let lines = stdin_lines_with_shutdown(Arc::clone(&shutdown));
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    match run_protocol(driver, lines, &mut out, sdk_version, &shutdown) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("midori-sdk: protocol error: {err}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!("usage: <driver> list|start");
+}
+
+fn register_termination_signals(shutdown: &Arc<AtomicBool>) -> std::io::Result<()> {
+    use signal_hook::consts::{SIGINT, SIGTERM};
+    signal_hook::flag::register(SIGTERM, Arc::clone(shutdown))?;
+    signal_hook::flag::register(SIGINT, Arc::clone(shutdown))?;
+    Ok(())
+}
+
+/// stdin から行を読み取りつつ、`shutdown` フラグが立ったら供給を打ち切る
+/// イテレータを返す。
+///
+/// 内部でリーダースレッドを 1 本立て、行を `mpsc` チャンネル経由で渡す。
+/// チャンネル受信時は 100ms タイムアウトでポーリングし、shutdown 立っていれば
+/// `None` を返す。
+fn stdin_lines_with_shutdown(shutdown: Arc<AtomicBool>) -> ShutdownAwareLines {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let stdin = std::io::stdin();
+        let handle = stdin.lock();
+        for line in handle.lines() {
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    ShutdownAwareLines { rx, shutdown }
+}
+
+struct ShutdownAwareLines {
+    rx: mpsc::Receiver<std::io::Result<String>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl Iterator for ShutdownAwareLines {
+    type Item = std::io::Result<String>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.shutdown.load(Ordering::Acquire) {
+                return None;
+            }
+            match self.rx.recv_timeout(Duration::from_millis(100)) {
+                Ok(line) => return Some(line),
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+                Err(mpsc::RecvTimeoutError::Disconnected) => return None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    struct StubDriver {
+        devices: Vec<DeviceInfo>,
+        commands: Vec<ControlCommand>,
+        shutdown_called: bool,
+    }
+
+    impl StubDriver {
+        fn new(devices: Vec<DeviceInfo>) -> Self {
+            Self {
+                devices,
+                commands: Vec::new(),
+                shutdown_called: false,
+            }
+        }
+    }
+
+    impl Driver for StubDriver {
+        fn list_devices(&mut self) -> Vec<DeviceInfo> {
+            self.devices.clone()
+        }
+
+        fn handle_command(&mut self, command: ControlCommand) -> Result<(), DriverError> {
+            self.commands.push(command);
+            Ok(())
+        }
+
+        fn shutdown(&mut self) -> Result<(), DriverError> {
+            self.shutdown_called = true;
+            Ok(())
+        }
+    }
+
+    fn lines_from(items: &[&str]) -> Vec<std::io::Result<String>> {
+        items.iter().map(|s| Ok((*s).to_owned())).collect()
+    }
+
+    #[test]
+    fn it_should_write_device_list_as_json_array() {
+        let mut driver = StubDriver::new(vec![
+            DeviceInfo {
+                value: "ELS-03 Series".into(),
+                label: "Yamaha ELS-03".into(),
+            },
+            DeviceInfo {
+                value: "IAC Driver Bus 1".into(),
+                label: "IAC Driver".into(),
+            },
+        ]);
+        let mut out = Vec::new();
+        write_device_list(&mut driver, &mut out).unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(
+            text.trim_end(),
+            r#"[{"value":"ELS-03 Series","label":"Yamaha ELS-03"},{"value":"IAC Driver Bus 1","label":"IAC Driver"}]"#
+        );
+    }
+
+    #[test]
+    fn it_should_write_hello_with_sdk_version() {
+        let mut out = Vec::new();
+        write_hello(&mut out, "1.2.3").unwrap();
+        let text = String::from_utf8(out).unwrap();
+        assert_eq!(text.trim_end(), r#"{"type":"hello","sdk_version":"1.2.3"}"#);
+    }
+
+    #[test]
+    fn it_should_parse_compatible_hello_ack() {
+        let m = parse_bridge_message(r#"{"type":"hello_ack","compatible":true}"#).unwrap();
+        assert!(matches!(
+            m,
+            BridgeMessage::HelloAck {
+                compatible: true,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn it_should_parse_incompatible_hello_ack_with_reason() {
+        let m =
+            parse_bridge_message(r#"{"type":"hello_ack","compatible":false,"reason":"too old"}"#)
+                .unwrap();
+        match m {
+            BridgeMessage::HelloAck {
+                compatible: false,
+                reason,
+            } => {
+                assert_eq!(reason.as_deref(), Some("too old"));
+            }
+            _ => panic!("unexpected variant"),
+        }
+    }
+
+    #[test]
+    fn it_should_parse_connect_command() {
+        let m =
+            parse_bridge_message(r#"{"type":"connect","device":"ELS-03","config":{"channel":1}}"#)
+                .unwrap();
+        match m.into_command() {
+            Some(ControlCommand::Connect { device, config }) => {
+                assert_eq!(device, "ELS-03");
+                assert_eq!(config["channel"], 1);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn it_should_parse_disconnect_command() {
+        let m = parse_bridge_message(r#"{"type":"disconnect"}"#).unwrap();
+        assert!(matches!(m.into_command(), Some(ControlCommand::Disconnect)));
+    }
+
+    #[test]
+    fn it_should_run_handshake_then_dispatch_commands_then_shutdown() {
+        let mut driver = StubDriver::new(vec![]);
+        let mut out: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let lines = lines_from(&[
+            r#"{"type":"hello_ack","compatible":true}"#,
+            r#"{"type":"connect","device":"x"}"#,
+            r#"{"type":"disconnect"}"#,
+        ]);
+        run_protocol(&mut driver, lines, &mut out, "1.0.0", &shutdown).unwrap();
+
+        assert!(driver.shutdown_called);
+        assert_eq!(driver.commands.len(), 2);
+        assert!(matches!(driver.commands[0], ControlCommand::Connect { .. }));
+        assert!(matches!(driver.commands[1], ControlCommand::Disconnect));
+
+        // hello が 1 行目に出ていること
+        let written = String::from_utf8(out.into_inner()).unwrap();
+        let first_line = written.lines().next().unwrap();
+        assert!(first_line.contains(r#""type":"hello""#));
+        assert!(first_line.contains(r#""sdk_version":"1.0.0""#));
+    }
+
+    #[test]
+    fn it_should_fail_when_hello_ack_reports_incompatible() {
+        let mut driver = StubDriver::new(vec![]);
+        let mut out = Vec::new();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let lines = lines_from(&[r#"{"type":"hello_ack","compatible":false,"reason":"too old"}"#]);
+        let err = run_protocol(&mut driver, lines, &mut out, "1.0.0", &shutdown).unwrap_err();
+
+        match err {
+            ProtocolError::Incompatible(reason) => {
+                assert_eq!(reason.as_deref(), Some("too old"));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(!driver.shutdown_called);
+    }
+
+    #[test]
+    fn it_should_fail_when_first_message_is_not_hello_ack() {
+        let mut driver = StubDriver::new(vec![]);
+        let mut out = Vec::new();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let lines = lines_from(&[r#"{"type":"connect","device":"x"}"#]);
+        let err = run_protocol(&mut driver, lines, &mut out, "1.0.0", &shutdown).unwrap_err();
+        assert!(matches!(err, ProtocolError::HandshakeOutOfOrder));
+    }
+
+    #[test]
+    fn it_should_fail_when_stdin_closes_before_hello_ack() {
+        let mut driver = StubDriver::new(vec![]);
+        let mut out = Vec::new();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let lines: Vec<std::io::Result<String>> = vec![];
+        let err = run_protocol(&mut driver, lines, &mut out, "1.0.0", &shutdown).unwrap_err();
+        assert!(matches!(err, ProtocolError::HandshakeMissing));
+    }
+
+    #[test]
+    fn it_should_stop_command_loop_when_shutdown_flag_is_set() {
+        let mut driver = StubDriver::new(vec![]);
+        let mut out = Vec::new();
+        let shutdown = Arc::new(AtomicBool::new(true));
+
+        // hello_ack 後すぐに shutdown が true なので、後続コマンドは消費されない
+        let lines = lines_from(&[
+            r#"{"type":"hello_ack","compatible":true}"#,
+            r#"{"type":"connect","device":"x"}"#,
+        ]);
+        run_protocol(&mut driver, lines, &mut out, "1.0.0", &shutdown).unwrap();
+
+        assert!(driver.shutdown_called);
+        assert!(driver.commands.is_empty());
+    }
+}

--- a/crates/midori-sdk/src/driver.rs
+++ b/crates/midori-sdk/src/driver.rs
@@ -47,14 +47,6 @@ enum HelloTag {
     Hello,
 }
 
-/// Bridge → Driver のハンドシェイク応答（stdin 1 行目）。
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
-pub struct HelloAck {
-    pub compatible: bool,
-    #[serde(default)]
-    pub reason: Option<String>,
-}
-
 /// Bridge → Driver の制御コマンド（ハンドシェイク完了後の stdin）。
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -74,24 +66,22 @@ pub enum ControlCommand {
 
 /// Bridge → Driver で受信しうる stdin メッセージの内訳。
 #[derive(Debug, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "type", rename_all = "snake_case")]
 enum BridgeMessage {
-    #[serde(rename = "hello_ack")]
     HelloAck {
         compatible: bool,
         #[serde(default)]
         reason: Option<String>,
     },
-    #[serde(rename = "connect")]
     Connect {
         device: String,
         #[serde(default)]
         config: serde_json::Value,
     },
-    #[serde(rename = "disconnect")]
     Disconnect,
-    #[serde(rename = "configure")]
-    Configure { config: serde_json::Value },
+    Configure {
+        config: serde_json::Value,
+    },
 }
 
 impl BridgeMessage {
@@ -243,48 +233,62 @@ where
     I: IntoIterator<Item = std::io::Result<String>>,
     W: Write,
 {
-    write_hello(out, sdk_version)?;
+    // ハンドシェイク + コマンドループ本体。エラーで早期 return しても
+    // クロージャを抜けるだけで、後続の shutdown 呼び出しはスキップされない。
+    let main_result = (|| -> Result<(), ProtocolError> {
+        write_hello(out, sdk_version)?;
 
-    let mut iter = lines.into_iter();
+        let mut iter = lines.into_iter();
 
-    // 最初の 1 行は必ず hello_ack
-    let first = iter.next().ok_or(ProtocolError::HandshakeMissing)??;
-    match parse_bridge_message(&first)? {
-        BridgeMessage::HelloAck {
-            compatible: false,
-            reason,
-        } => return Err(ProtocolError::Incompatible(reason)),
-        BridgeMessage::HelloAck {
-            compatible: true, ..
-        } => {}
-        _ => return Err(ProtocolError::HandshakeOutOfOrder),
-    }
-
-    // 以降はコマンドループ
-    for line in iter {
-        if shutdown.load(Ordering::Acquire) {
-            break;
+        // 最初の 1 行は必ず hello_ack
+        let first = iter.next().ok_or(ProtocolError::HandshakeMissing)??;
+        match parse_bridge_message(&first)? {
+            BridgeMessage::HelloAck {
+                compatible: false,
+                reason,
+            } => return Err(ProtocolError::Incompatible(reason)),
+            BridgeMessage::HelloAck {
+                compatible: true, ..
+            } => {}
+            _ => return Err(ProtocolError::HandshakeOutOfOrder),
         }
-        let line = line?;
-        let message = parse_bridge_message(&line)?;
-        if let Some(cmd) = message.into_command() {
-            driver.handle_command(cmd).map_err(ProtocolError::Driver)?;
-        }
-        // hello_ack が再度来るのは仕様外だが、エラーにせず無視する。
-    }
 
-    driver.shutdown().map_err(ProtocolError::Driver)?;
-    Ok(())
+        // 以降はコマンドループ
+        for line in iter {
+            if shutdown.load(Ordering::Acquire) {
+                break;
+            }
+            let line = line?;
+            let message = parse_bridge_message(&line)?;
+            if let Some(cmd) = message.into_command() {
+                driver.handle_command(cmd).map_err(ProtocolError::Driver)?;
+            }
+            // hello_ack が再度来るのは仕様外だが、エラーにせず無視する。
+        }
+
+        Ok(())
+    })();
+
+    // ハンドシェイク前のエラーでも、Driver::new 等で確保された資源を解放させるため
+    // shutdown は無条件で呼び出す。元のエラーを優先しつつ、shutdown 単独の失敗も報告する。
+    let shutdown_result = driver.shutdown().map_err(ProtocolError::Driver);
+    match (main_result, shutdown_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(e), _) | (Ok(()), Err(e)) => Err(e),
+    }
 }
 
 /// `<driver>` バイナリのエントリポイント。`fn main()` から呼び出す。
 ///
 /// argv を見て `list` / `start` をディスパッチし、`start` ではシグナル
 /// ハンドラを設定し stdin リーダースレッドを起動して [`run_protocol`] を
-/// 駆動する。`sdk_version` には呼び出し元クレートで `env!("CARGO_PKG_VERSION")`
-/// を渡すのが基本だが、本 SDK 自身のバージョンを埋め込みたければ
-/// `midori_sdk::driver::SDK_VERSION` を使う。
-pub fn run<D: Driver>(mut driver: D, sdk_version: &str) -> ExitCode {
+/// 駆動する。
+///
+/// `start` 時に Bridge へ送る `sdk_version` には常に SDK 自身のバージョン
+/// （[`SDK_VERSION`]）を埋め込む。これは Bridge 側の互換性検証
+/// （`design/10-driver-plugin.md` の「バージョン互換性」）に使われる値で、
+/// 各ドライバークレート自身のバージョンとは独立している。
+pub fn run<D: Driver>(mut driver: D) -> ExitCode {
     let mut args = std::env::args();
     let _bin = args.next();
     match args.next().as_deref() {
@@ -295,7 +299,7 @@ pub fn run<D: Driver>(mut driver: D, sdk_version: &str) -> ExitCode {
                 ExitCode::FAILURE
             }
         },
-        Some("start") => exec_start(&mut driver, sdk_version),
+        Some("start") => exec_start(&mut driver),
         Some(other) => {
             eprintln!("midori-sdk: unknown subcommand: {other}");
             print_usage();
@@ -309,7 +313,13 @@ pub fn run<D: Driver>(mut driver: D, sdk_version: &str) -> ExitCode {
 }
 
 /// 本 SDK クレート自身のバージョン（`<package>.version`）。
-/// ドライバー作者が `run(driver, SDK_VERSION)` の形で利用できるよう公開する。
+///
+/// [`run`] が `<driver> start` 時に Bridge へ送る `hello.sdk_version` の値として
+/// 自動で使われる。Bridge はこのバージョン文字列で SDK 互換性を検証する
+/// （`design/10-driver-plugin.md` の「バージョン互換性」を参照）。
+///
+/// 互換性検証は SDK のバージョンに対して行うため、ドライバークレート側の
+/// `CARGO_PKG_VERSION` ではなく必ずこの値を使用する。
 pub const SDK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn exec_list<D: Driver>(driver: &mut D) -> std::io::Result<()> {
@@ -318,7 +328,7 @@ fn exec_list<D: Driver>(driver: &mut D) -> std::io::Result<()> {
     write_device_list(driver, &mut out)
 }
 
-fn exec_start<D: Driver>(driver: &mut D, sdk_version: &str) -> ExitCode {
+fn exec_start<D: Driver>(driver: &mut D) -> ExitCode {
     let shutdown = Arc::new(AtomicBool::new(false));
     if let Err(err) = register_termination_signals(&shutdown) {
         eprintln!("midori-sdk: failed to install signal handlers: {err}");
@@ -329,7 +339,7 @@ fn exec_start<D: Driver>(driver: &mut D, sdk_version: &str) -> ExitCode {
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
 
-    match run_protocol(driver, lines, &mut out, sdk_version, &shutdown) {
+    match run_protocol(driver, lines, &mut out, SDK_VERSION, &shutdown) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             eprintln!("midori-sdk: protocol error: {err}");
@@ -549,7 +559,8 @@ mod tests {
             }
             other => panic!("unexpected: {other:?}"),
         }
-        assert!(!driver.shutdown_called);
+        // ハンドシェイク前のエラーでもコンストラクタで確保した資源解放が走るよう shutdown を保証する
+        assert!(driver.shutdown_called);
     }
 
     #[test]
@@ -561,6 +572,7 @@ mod tests {
         let lines = lines_from(&[r#"{"type":"connect","device":"x"}"#]);
         let err = run_protocol(&mut driver, lines, &mut out, "1.0.0", &shutdown).unwrap_err();
         assert!(matches!(err, ProtocolError::HandshakeOutOfOrder));
+        assert!(driver.shutdown_called);
     }
 
     #[test]
@@ -572,6 +584,40 @@ mod tests {
         let lines: Vec<std::io::Result<String>> = vec![];
         let err = run_protocol(&mut driver, lines, &mut out, "1.0.0", &shutdown).unwrap_err();
         assert!(matches!(err, ProtocolError::HandshakeMissing));
+        assert!(driver.shutdown_called);
+    }
+
+    #[test]
+    fn it_should_call_shutdown_when_command_handler_returns_error() {
+        struct FailingDriver {
+            shutdown_called: bool,
+        }
+        impl Driver for FailingDriver {
+            fn list_devices(&mut self) -> Vec<DeviceEntry> {
+                Vec::new()
+            }
+            fn handle_command(&mut self, _: ControlCommand) -> Result<(), DriverError> {
+                Err(DriverError::new("boom"))
+            }
+            fn shutdown(&mut self) -> Result<(), DriverError> {
+                self.shutdown_called = true;
+                Ok(())
+            }
+        }
+
+        let mut driver = FailingDriver {
+            shutdown_called: false,
+        };
+        let mut out = Vec::new();
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let lines = lines_from(&[
+            r#"{"type":"hello_ack","compatible":true}"#,
+            r#"{"type":"connect","device":"x"}"#,
+        ]);
+        let err = run_protocol(&mut driver, lines, &mut out, "1.0.0", &shutdown).unwrap_err();
+        assert!(matches!(err, ProtocolError::Driver(_)));
+        assert!(driver.shutdown_called);
     }
 
     #[test]

--- a/crates/midori-sdk/src/driver.rs
+++ b/crates/midori-sdk/src/driver.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 /// `value` はドライバー固有の識別子（`start` 時の `Connect` コマンドで参照される）、
 /// `label` はユーザー表示名。
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DeviceInfo {
+pub struct DeviceEntry {
     pub value: String,
     pub label: String,
 }
@@ -111,7 +111,7 @@ impl BridgeMessage {
 /// （接続ハンドル・スレッドハンドル等）を保持できる。
 pub trait Driver {
     /// `<driver> list` で返すデバイス一覧。
-    fn list_devices(&mut self) -> Vec<DeviceInfo>;
+    fn list_devices(&mut self) -> Vec<DeviceEntry>;
 
     /// 制御コマンドのディスパッチ先。
     /// 戻り値の `Err` は致命的とみなし、CLI を終了させる。
@@ -397,13 +397,13 @@ mod tests {
     use std::io::Cursor;
 
     struct StubDriver {
-        devices: Vec<DeviceInfo>,
+        devices: Vec<DeviceEntry>,
         commands: Vec<ControlCommand>,
         shutdown_called: bool,
     }
 
     impl StubDriver {
-        fn new(devices: Vec<DeviceInfo>) -> Self {
+        fn new(devices: Vec<DeviceEntry>) -> Self {
             Self {
                 devices,
                 commands: Vec::new(),
@@ -413,7 +413,7 @@ mod tests {
     }
 
     impl Driver for StubDriver {
-        fn list_devices(&mut self) -> Vec<DeviceInfo> {
+        fn list_devices(&mut self) -> Vec<DeviceEntry> {
             self.devices.clone()
         }
 
@@ -435,11 +435,11 @@ mod tests {
     #[test]
     fn it_should_write_device_list_as_json_array() {
         let mut driver = StubDriver::new(vec![
-            DeviceInfo {
+            DeviceEntry {
                 value: "ELS-03 Series".into(),
                 label: "Yamaha ELS-03".into(),
             },
-            DeviceInfo {
+            DeviceEntry {
                 value: "IAC Driver Bus 1".into(),
                 label: "IAC Driver".into(),
             },

--- a/crates/midori-sdk/src/lib.rs
+++ b/crates/midori-sdk/src/lib.rs
@@ -14,7 +14,7 @@ pub use midori_core::pipeline::*;
 pub use midori_core::shm::*;
 pub use midori_core::value::*;
 
-pub use driver::{ControlCommand, DeviceEntry, Driver, DriverError, ProtocolError};
+pub use driver::{ControlCommand, DeviceEntry, Driver, DriverError, ProtocolError, SDK_VERSION};
 pub use spsc::{Consumer, Full, Producer, SpscStorage};
 
 #[cfg(test)]

--- a/crates/midori-sdk/src/lib.rs
+++ b/crates/midori-sdk/src/lib.rs
@@ -14,7 +14,7 @@ pub use midori_core::pipeline::*;
 pub use midori_core::shm::*;
 pub use midori_core::value::*;
 
-pub use driver::{ControlCommand, DeviceInfo, Driver, DriverError, ProtocolError};
+pub use driver::{ControlCommand, DeviceEntry, Driver, DriverError, ProtocolError};
 pub use spsc::{Consumer, Full, Producer, SpscStorage};
 
 #[cfg(test)]

--- a/crates/midori-sdk/src/lib.rs
+++ b/crates/midori-sdk/src/lib.rs
@@ -4,6 +4,7 @@
 //! on `midori-sdk` alone. The shared-memory SPSC ring buffer implementation
 //! lives in this crate (the layout itself is defined in `midori_core::shm`).
 
+pub mod driver;
 pub mod spsc;
 
 pub use midori_core as core;
@@ -13,6 +14,7 @@ pub use midori_core::pipeline::*;
 pub use midori_core::shm::*;
 pub use midori_core::value::*;
 
+pub use driver::{ControlCommand, DeviceInfo, Driver, DriverError, ProtocolError};
 pub use spsc::{Consumer, Full, Producer, SpscStorage};
 
 #[cfg(test)]


### PR DESCRIPTION
Closes MEW-36

## Summary

ドライバー作者が `Driver` トレイトを実装し `midori_sdk::driver::run(my_driver, SDK_VERSION)` を呼ぶだけで `<driver> list` / `<driver> start` の規約準拠 CLI が完成する API を提供。

```rust
use midori_sdk::driver::{self, ControlCommand, DeviceInfo, Driver, DriverError, SDK_VERSION};

struct MyDriver;
impl Driver for MyDriver {
    fn list_devices(&mut self) -> Vec<DeviceInfo> { vec![/* ... */] }
    fn handle_command(&mut self, cmd: ControlCommand) -> Result<(), DriverError> { Ok(()) }
    fn shutdown(&mut self) -> Result<(), DriverError> { Ok(()) }
}

fn main() -> std::process::ExitCode {
    driver::run(MyDriver, SDK_VERSION)
}
```

## Acceptance Criteria

- [x] `<driver> list` がデバイス列挙結果を `[{value, label}]` 形式の JSON で stdout 出力して終了する
- [x] `<driver> start` が起動直後に `{"type":"hello","sdk_version":"..."}` を stdout に送出する
- [x] Bridge からの `hello_ack`（compatible:false）を stdin で受信したらエラー終了する
- [x] stdin から JSON Lines 制御コマンド（connect / disconnect / configure）を受け取って `Driver::handle_command` に dispatch できる
- [x] SIGTERM/SIGINT 受信で graceful shutdown（`Driver::shutdown` 経由で共有メモリ等を解放させる）
- [x] `cargo test -p midori-sdk` がパスする（20 件中 11 件が driver スキャフォールド）

## アーキテクチャの分離

| 層 | 役割 | テスト戦略 |
|---|---|---|
| pure helpers (`write_device_list` / `write_hello` / `parse_bridge_message`) | JSON 入出力 | 入出力を `Vec<u8>` で観測 |
| `run_protocol` | プロトコル状態遷移（hello → ack → コマンドループ → shutdown） | mock `Driver` + `Cursor` |
| `run()` / `exec_start` | argv パース、シグナル登録、stdin スレッド配線 | 統合は手動検証（自動化は次フェーズ） |

`run_protocol` は I/O とイテレータをジェネリック化したため、シグナル・スレッドに依存せず単体テストで全パスを覆える。

## SIGTERM 配線

- `signal-hook` で SIGTERM/SIGINT を `Arc<AtomicBool>` フラグに繋ぐ
- 別スレッドで stdin をブロッキング read し、行を `mpsc::channel` に push
- `ShutdownAwareLines` イテレータが 100ms ごとに shutdown フラグをポーリング、立っていれば `None` を返してループ脱出 → `Driver::shutdown` を呼んで終了

## Out of Scope

- 公式ドライバー（midori-driver-midi / midori-driver-osc）の実装
- C FFI 経由でのスキャフォールド呼び出し（MEW-37）
- ハートビート（設計書未確定のため将来対応）
- 接続コマンドからの `Producer` 起動例（呼び出し側責務、SDK は API のみ提供）

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`（midori-sdk 20件、runtime 7件、driver-midi/osc 各1件、すべて green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* ドライバプロトコルフレームワークが追加されました。デバイスの列挙・接続制御・設定管理に対応しています。
* SDKドライバ作成者向けの公開APIが新たに利用可能になりました。
* グレースフルシャットダウン機能が実装されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->