### PR TITLE
feat(core)!: RingSlot を raw event payload 形式に差し替え（MEW-41）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "midori-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ missing_errors_doc      = "allow"
 missing_panics_doc      = "allow"
 
 [workspace.dependencies]
-midori-core = { path = "crates/midori-core", version = "0.1.0" }
+midori-core = { path = "crates/midori-core", version = "0.2.0" }
 midori-sdk  = { path = "crates/midori-sdk",  version = "0.1.0" }

--- a/crates/midori-core/CHANGELOG.md
+++ b/crates/midori-core/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Breaking changes
 
 - **`shm::RingSlot` のレイアウトを raw event payload 形式に差し替え**（MEW-41 / `design/15-sdk-bindings-api.md`）。
-  - 削除されたフィールド: `value_tag` / `_pad` (旧 6 byte) / `device_id` / `specifier` / `value_i64` / `value_f64`
-  - 追加されたフィールド: `payload_len: u32` / `side_offset: u64` / `side_len: u32` / `_pad2: [u8; 4]` / `payload: [u8; PAYLOAD_INLINE_MAX]`
+  - 削除されたフィールド: `value_tag` / `device_id` / `specifier` / `value_i64` / `value_f64`
+  - 追加されたフィールド: `payload_len: u32` / `side_offset: u64` / `side_len: u32` / `payload: [u8; PAYLOAD_INLINE_MAX]`
+  - 内部 padding（`_pad`）は サイズ 6 byte → 3 byte に変更し、新たに `_pad2: [u8; 4]` を追加（レイアウト調整用、API として参照される想定なし）
   - 旧スロットは Layer 2 binding 後の post-binding 形（`device_id` + `specifier` + `value`）だったが、新スロットは Driver → Bridge 間で msgpack バイト列を運ぶ raw event 形式となる。binding 適用は Bridge 側の責務へ移動（`design/layers/02-input-recognition/binding-requirements.md` 参照）
 - **`shm::value_tag` モジュールを削除**。`BOOL_FALSE` / `BOOL_TRUE` / `PULSE` / `INT` / `FLOAT` / `NULL` の定数も合わせて廃止
 - **`shm::DEVICE_ID_MAX` / `shm::SPECIFIER_MAX` を削除**。スロットに device id / specifier フィールドが存在しなくなったため

--- a/crates/midori-core/CHANGELOG.md
+++ b/crates/midori-core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- **`shm::RingSlot` のレイアウトを raw event payload 形式に差し替え**（MEW-41 / `design/15-sdk-bindings-api.md`）。
+- **`shm::RingSlot` のレイアウトを raw event payload 形式に差し替え**（設計: `design/15-sdk-bindings-api.md`「SPSC スロットレイアウトの変更」）。
   - 削除されたフィールド: `value_tag` / `device_id` / `specifier` / `value_i64` / `value_f64`
   - 追加されたフィールド: `payload_len: u32` / `side_offset: u64` / `side_len: u32` / `payload: [u8; PAYLOAD_INLINE_MAX]`
   - 内部 padding（`_pad`）は サイズ 6 byte → 3 byte に変更し、新たに `_pad2: [u8; 4]` を追加（レイアウト調整用、API として参照される想定なし）
@@ -15,7 +15,7 @@
 ### Added
 
 - `shm::PAYLOAD_INLINE_MAX` 定数（240 byte）— inline payload の最大サイズ
-- `RingSlot::side_offset` / `side_len` フィールド — `payload_len > PAYLOAD_INLINE_MAX` の payload を side channel（mmap プール）に逃すためのポインタ枠。side channel 本体の確保・割り当て・GC は別 Issue（MEW-43）で実装
+- `RingSlot::side_offset` / `side_len` フィールド — `payload_len > PAYLOAD_INLINE_MAX` の payload を side channel（mmap プール）に逃すためのポインタ枠。side channel 本体の確保・割り当て・GC は別途実装する（本クレートのスコープ外）
 
 ### Notes
 

--- a/crates/midori-core/CHANGELOG.md
+++ b/crates/midori-core/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog — midori-core
+
+## 0.2.0 — 2026-04-27
+
+### Breaking changes
+
+- **`shm::RingSlot` のレイアウトを raw event payload 形式に差し替え**（MEW-41 / `design/15-sdk-bindings-api.md`）。
+  - 削除されたフィールド: `value_tag` / `_pad` (旧 6 byte) / `device_id` / `specifier` / `value_i64` / `value_f64`
+  - 追加されたフィールド: `payload_len: u32` / `side_offset: u64` / `side_len: u32` / `_pad2: [u8; 4]` / `payload: [u8; PAYLOAD_INLINE_MAX]`
+  - 旧スロットは Layer 2 binding 後の post-binding 形（`device_id` + `specifier` + `value`）だったが、新スロットは Driver → Bridge 間で msgpack バイト列を運ぶ raw event 形式となる。binding 適用は Bridge 側の責務へ移動（`design/layers/02-input-recognition/binding-requirements.md` 参照）
+- **`shm::value_tag` モジュールを削除**。`BOOL_FALSE` / `BOOL_TRUE` / `PULSE` / `INT` / `FLOAT` / `NULL` の定数も合わせて廃止
+- **`shm::DEVICE_ID_MAX` / `shm::SPECIFIER_MAX` を削除**。スロットに device id / specifier フィールドが存在しなくなったため
+
+### Added
+
+- `shm::PAYLOAD_INLINE_MAX` 定数（240 byte）— inline payload の最大サイズ
+- `RingSlot::side_offset` / `side_len` フィールド — `payload_len > PAYLOAD_INLINE_MAX` の payload を side channel（mmap プール）に逃すためのポインタ枠。side channel 本体の確保・割り当て・GC は別 Issue（MEW-43）で実装
+
+### Notes
+
+- 旧 `RingSlot` を引数に取っていた `midori-sdk` の SPSC FFI（`midori_sdk_spsc_*`）は 新 `RingSlot` レイアウトに追従し、C ヘッダ（`midori_sdk.h`）も再生成される
+- side channel が未実装の段階では `payload_len > PAYLOAD_INLINE_MAX` の emit はサポートされず、driver は inline 範囲（240 byte）内に収まる payload のみ送出する運用とする
+
+## 0.1.0 — 2026-04-23
+
+初版。`Value` / `ValueType` / `ValueRange` / `OutOfRange` / `SignalSpecifier` / `ComponentState` / `Signal` / `IpcEvent` / 旧 `RingSlot`（post-binding 形）/ `ShmHeader` を提供。

--- a/crates/midori-core/Cargo.toml
+++ b/crates/midori-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midori-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Shared types and protocol definitions for the Midori signal bridge"
 license = "MIT OR Apache-2.0"

--- a/crates/midori-core/src/shm.rs
+++ b/crates/midori-core/src/shm.rs
@@ -1,72 +1,89 @@
-/// Capacity of the SPSC ring buffer (number of slots).
+//! 共有メモリ上の SPSC リングバッファレイアウト定義。
+//!
+//! Driver から Bridge へ raw event を運ぶための **post-MEW-40** のスロット
+//! 形式。raw event は driver の `events.yaml` に沿った key-value 構造を
+//! msgpack で encode したバイト列として `payload` に格納する。inline 容量
+//! ([`PAYLOAD_INLINE_MAX`]) を超える payload は side channel（mmap プール、
+//! 別 Issue MEW-43 で実装）に書き出し、スロットには `side_offset` /
+//! `side_len` のみを格納する。
+//!
+//! 詳細設計: `design/15-sdk-bindings-api.md` 「SPSC スロットレイアウトの変更」。
+//!
+//! 旧スロット（`device_id` / `specifier` / `value_tag` / `value_i64` /
+//! `value_f64` を持つ post-binding 形）は本リリースで撤廃され、
+//! `midori-core` は major bump（0.2.0）となる。
+
+/// SPSC リングバッファのスロット数。
 ///
-/// One slot per raw event; sized to absorb a full tick's worth of driver output
-/// without blocking the producer.
+/// raw event 1 件 = 1 スロット。1 tick 分のドライバー出力を満杯にせず
+/// 受け取れるサイズを目安にしている。
 pub const RING_CAPACITY: usize = 256;
 
-/// Maximum byte length of a device id stored in a [`RingSlot`] (excluding NUL terminator).
-pub const DEVICE_ID_MAX: usize = 63;
-
-/// Maximum byte length of a dot-separated specifier stored in a [`RingSlot`] (excluding NUL terminator).
-pub const SPECIFIER_MAX: usize = 127;
-
-/// Value discriminant stored in [`RingSlot::value_tag`].
+/// 単一スロットに inline で格納できる msgpack バイト列の最大長。
 ///
-/// - 0: `Value::Bool(false)`
-/// - 1: `Value::Bool(true)`
-/// - 2: `Value::Pulse`
-/// - 3: `Value::Int` — integer in `value_i64`
-/// - 4: `Value::Float` — float in `value_f64`
-/// - 5: `Value::Null`
-pub mod value_tag {
-    pub const BOOL_FALSE: u8 = 0;
-    pub const BOOL_TRUE: u8 = 1;
-    pub const PULSE: u8 = 2;
-    pub const INT: u8 = 3;
-    pub const FLOAT: u8 = 4;
-    pub const NULL: u8 = 5;
-}
+/// この値を超える payload は side channel（別 mmap 領域）に書き出し、
+/// `RingSlot::side_offset` / `RingSlot::side_len` のみがスロットに残る。
+///
+/// MIDI / OSC の通常イベントが余裕で収まる範囲として 240 byte に設定。
+/// `SysEx` 1KB 級などはここを超えるため side channel 経由となる。
+pub const PAYLOAD_INLINE_MAX: usize = 240;
 
-/// A single slot in the SPSC ring buffer.
+/// SPSC リングバッファの単一スロット。
 ///
-/// All fields are fixed-size so the struct is safe to place in a cross-process
-/// `mmap` region.  `occupied == 0` means the slot is empty.
+/// `#[repr(C)]` により mmap 可能な固定レイアウトを保証する。FFI で他言語
+/// バインディングからも同レイアウトでアクセスする。
 ///
-/// Strings are stored NUL-terminated and truncated to their respective `*_MAX` constants.
+/// # フィールド
+///
+/// - `occupied`: 0 = 空、1 = 占有。空判定は本来 `write_index` /
+///   `read_index` の比較で十分だが、C 側の利便性（pop した直後に
+///   `slot.occupied == 1` で成功と判定）のために残す
+/// - `payload_len`: msgpack バイト列の実長。`<= PAYLOAD_INLINE_MAX` のとき
+///   inline 格納、超える場合は 0 を立てて side channel 経由とする
+/// - `side_offset` / `side_len`: side channel オフセットとバイト長。
+///   side channel 未使用時は両方 0
+/// - `payload`: msgpack バイト列の inline 領域。`payload_len` バイト分のみ
+///   有効で、それ以降の領域は未定義
+///
+/// # サイズ
+///
+/// 1 + 3 + 4 + 8 + 4 + 4 + 240 = 264 byte。
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct RingSlot {
-    /// 0 = empty, 1 = occupied.
+    /// 0 = 空、1 = 占有。
     pub occupied: u8,
-    /// Value discriminant; see [`value_tag`].
-    pub value_tag: u8,
     #[allow(clippy::pub_underscore_fields)]
-    pub _pad: [u8; 6],
-    /// NUL-terminated device id.
-    pub device_id: [u8; DEVICE_ID_MAX + 1],
-    /// NUL-terminated dot-separated specifier.
-    pub specifier: [u8; SPECIFIER_MAX + 1],
-    /// Used when `value_tag` is [`value_tag::INT`].
-    pub value_i64: i64,
-    /// Used when `value_tag` is [`value_tag::FLOAT`].
-    pub value_f64: f64,
+    pub _pad: [u8; 3],
+    /// inline payload に書かれた msgpack バイト列の長さ（`<= PAYLOAD_INLINE_MAX`）。
+    /// side channel を使う場合は 0 にし、`side_len` 側を立てる。
+    pub payload_len: u32,
+    /// side channel 上の payload 開始オフセット（バイト）。0 = side channel 未使用。
+    pub side_offset: u64,
+    /// side channel 上の payload バイト長。0 = side channel 未使用。
+    pub side_len: u32,
+    #[allow(clippy::pub_underscore_fields)]
+    pub _pad2: [u8; 4],
+    /// inline 格納用の msgpack バイト列。`payload_len` バイト目までが有効。
+    pub payload: [u8; PAYLOAD_INLINE_MAX],
 }
 
-/// Header written at the start of the shared memory region.
+/// 共有メモリ領域の先頭に置かれるヘッダ。
 ///
-/// Layout (`AtomicU64` is `#[repr(C, align(8))]`, so both fields are 8 bytes):
+/// レイアウト（`AtomicU64` は `#[repr(C, align(8))]`、両フィールドとも 8 byte）:
+///
 /// ```text
 /// offset 0:  write_index (AtomicU64)
 /// offset 8:  read_index  (AtomicU64)
-/// offset 16: slots[RING_CAPACITY] (RingSlot array)
+/// offset 16: slots[RING_CAPACITY] (RingSlot 配列)
 /// ```
 ///
-/// Both indices are monotonically increasing. Actual slot index is `index % RING_CAPACITY`.
-/// The buffer is full when `write_index - read_index == RING_CAPACITY`.
+/// 両インデックスは単調増加。実際のスロット位置は `index % RING_CAPACITY`。
+/// バッファ満杯条件は `write_index - read_index == RING_CAPACITY`。
 ///
-/// The producer must store slot data before publishing `write_index` with
-/// [`Ordering::Release`]; the consumer must load `write_index` with
-/// [`Ordering::Acquire`] before reading slot data.
+/// 生産者はスロット書き込み後に `write_index` を [`Ordering::Release`] で
+/// 公開し、消費者は `write_index` を [`Ordering::Acquire`] で読んだ後に
+/// スロットを読む。
 #[repr(C)]
 pub struct ShmHeader {
     pub write_index: std::sync::atomic::AtomicU64,
@@ -83,16 +100,23 @@ mod tests {
     }
 
     #[test]
+    fn payload_inline_max_is_positive() {
+        const { assert!(PAYLOAD_INLINE_MAX > 0) };
+    }
+
+    #[test]
     fn shm_header_size_and_align() {
         assert_eq!(std::mem::size_of::<ShmHeader>(), 16);
         assert_eq!(std::mem::align_of::<ShmHeader>(), 8);
     }
 
     #[test]
-    fn ring_slot_is_repr_c() {
-        // Verify the slot is a fixed size (not dependent on heap types).
+    fn ring_slot_is_repr_c_and_fixed_size() {
         let size = std::mem::size_of::<RingSlot>();
         assert!(size > 0);
+        // payload[PAYLOAD_INLINE_MAX] を含む全領域が見えていること。
+        assert!(size >= PAYLOAD_INLINE_MAX);
+        // アラインメントの倍数で表現可能な構造体サイズになっていること。
         assert_eq!(size % std::mem::align_of::<RingSlot>(), 0);
     }
 }

--- a/crates/midori-core/src/shm.rs
+++ b/crates/midori-core/src/shm.rs
@@ -40,8 +40,9 @@ pub const PAYLOAD_INLINE_MAX: usize = 240;
 ///   `slot.occupied == 1` で成功と判定）のために残す
 /// - `payload_len`: msgpack バイト列の実長。`<= PAYLOAD_INLINE_MAX` のとき
 ///   inline 格納、超える場合は 0 を立てて side channel 経由とする
-/// - `side_offset` / `side_len`: side channel オフセットとバイト長。
-///   side channel 未使用時は両方 0
+/// - `side_offset` / `side_len`: side channel 上の位置とバイト長。**side
+///   channel の使用判定は `side_len > 0` を canonical とする**（`side_offset`
+///   は 0 が side channel 先頭を指す有効値となるため、未使用フラグには使えない）
 /// - `payload`: msgpack バイト列の inline 領域。`payload_len` バイト分のみ
 ///   有効で、それ以降の領域は未定義
 ///
@@ -58,9 +59,12 @@ pub struct RingSlot {
     /// inline payload に書かれた msgpack バイト列の長さ（`<= PAYLOAD_INLINE_MAX`）。
     /// side channel を使う場合は 0 にし、`side_len` 側を立てる。
     pub payload_len: u32,
-    /// side channel 上の payload 開始オフセット（バイト）。0 = side channel 未使用。
+    /// side channel 上の payload 開始オフセット（バイト）。`side_len > 0` の
+    /// ときのみ有効（`side_offset == 0` でも `side_len > 0` なら side channel
+    /// 先頭を指す有効ポインタ）。
     pub side_offset: u64,
-    /// side channel 上の payload バイト長。0 = side channel 未使用。
+    /// side channel 上の payload バイト長。**0 = side channel 未使用**。
+    /// side channel 使用判定はこのフィールドを canonical とする。
     pub side_len: u32,
     #[allow(clippy::pub_underscore_fields)]
     pub _pad2: [u8; 4],
@@ -81,8 +85,8 @@ pub struct RingSlot {
 /// 両インデックスは単調増加。実際のスロット位置は `index % RING_CAPACITY`。
 /// バッファ満杯条件は `write_index - read_index == RING_CAPACITY`。
 ///
-/// 生産者はスロット書き込み後に `write_index` を [`Ordering::Release`] で
-/// 公開し、消費者は `write_index` を [`Ordering::Acquire`] で読んだ後に
+/// 生産者はスロット書き込み後に `write_index` を [`std::sync::atomic::Ordering::Release`] で
+/// 公開し、消費者は `write_index` を [`std::sync::atomic::Ordering::Acquire`] で読んだ後に
 /// スロットを読む。
 #[repr(C)]
 pub struct ShmHeader {
@@ -112,11 +116,14 @@ mod tests {
 
     #[test]
     fn ring_slot_is_repr_c_and_fixed_size() {
-        let size = std::mem::size_of::<RingSlot>();
-        assert!(size > 0);
-        // payload[PAYLOAD_INLINE_MAX] を含む全領域が見えていること。
-        assert!(size >= PAYLOAD_INLINE_MAX);
-        // アラインメントの倍数で表現可能な構造体サイズになっていること。
-        assert_eq!(size % std::mem::align_of::<RingSlot>(), 0);
+        // ドキュメントの 1 + 3 + 4 + 8 + 4 + 4 + 240 = 264 byte に固定。
+        // C ヘッダ（cbindgen 生成）と共有されるレイアウトなので、padding の
+        // 追加・並びの変更による ABI ドリフトをコンパイル時にも検出する。
+        const { assert!(std::mem::size_of::<RingSlot>() == 264) };
+        assert_eq!(std::mem::size_of::<RingSlot>(), 264);
+        assert_eq!(
+            std::mem::size_of::<RingSlot>() % std::mem::align_of::<RingSlot>(),
+            0
+        );
     }
 }

--- a/crates/midori-core/src/shm.rs
+++ b/crates/midori-core/src/shm.rs
@@ -1,17 +1,14 @@
 //! 共有メモリ上の SPSC リングバッファレイアウト定義。
 //!
-//! Driver から Bridge へ raw event を運ぶための **post-MEW-40** のスロット
-//! 形式。raw event は driver の `events.yaml` に沿った key-value 構造を
-//! msgpack で encode したバイト列として `payload` に格納する。inline 容量
-//! ([`PAYLOAD_INLINE_MAX`]) を超える payload は side channel（mmap プール、
-//! 別 Issue MEW-43 で実装）に書き出し、スロットには `side_offset` /
-//! `side_len` のみを格納する。
+//! Driver から Bridge へ raw event を運ぶスロット形式。raw event は driver の
+//! `events.yaml` に沿った key-value 構造を msgpack で encode したバイト列
+//! として [`RingSlot::payload`] に格納する。inline 容量
+//! ([`PAYLOAD_INLINE_MAX`]) を超える payload は別 mmap 領域（side channel）
+//! に書き出し、スロットには [`RingSlot::side_offset`] / [`RingSlot::side_len`]
+//! のみを格納する。side channel 本体の確保・割り当て・GC は本ファイルでは
+//! 扱わない。
 //!
-//! 詳細設計: `design/15-sdk-bindings-api.md` 「SPSC スロットレイアウトの変更」。
-//!
-//! 旧スロット（`device_id` / `specifier` / `value_tag` / `value_i64` /
-//! `value_f64` を持つ post-binding 形）は本リリースで撤廃され、
-//! `midori-core` は major bump（0.2.0）となる。
+//! 詳細設計: `design/15-sdk-bindings-api.md`「SPSC スロットレイアウトの変更」。
 
 /// SPSC リングバッファのスロット数。
 ///

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -236,7 +236,8 @@ mod tests {
 
     /// `payload_len` > [`PAYLOAD_INLINE_MAX`] 相当のケース: `payload_len` = 0 で
     /// `side_offset` / `side_len` のみ立てたスロットがそのまま運ばれることを検証。
-    /// side channel 本体の確保は MEW-43。本テストはフィールド輸送のみを確認する。
+    /// 本テストは FFI 経由のフィールド輸送のみを確認する（side channel 本体の
+    /// 確保は本クレートのスコープ外）。
     #[test]
     fn it_should_carry_side_channel_offsets_through_ffi() {
         let layout = std::alloc::Layout::from_size_align(

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn midori_sdk_spsc_pop(
 #[allow(unsafe_code, clippy::cast_possible_truncation)]
 mod tests {
     use super::*;
-    use midori_core::shm::{PAYLOAD_INLINE_MAX, RING_CAPACITY};
+    use midori_core::shm::{ShmHeader, PAYLOAD_INLINE_MAX, RING_CAPACITY};
 
     /// inline payload に 4 byte の little-endian シーケンス番号を詰めた
     /// テスト用 [`RingSlot`] を作る。
@@ -222,6 +222,7 @@ mod tests {
         let ok =
             unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
         assert_eq!(ok, 1);
+        assert_eq!(popped.occupied, 1);
         assert_eq!(popped.payload_len as usize, PAYLOAD_INLINE_MAX);
         for (i, byte) in popped.payload.iter().enumerate() {
             assert_eq!(*byte, (i % 251) as u8, "byte at {i} mismatched");
@@ -344,7 +345,10 @@ mod tests {
         let align = midori_sdk_spsc_storage_alignment();
         assert!(size > 0);
         assert!(align.is_power_of_two());
-        // SpscStorage の中身は ShmHeader (16 byte) + RING_CAPACITY 個の RingSlot
-        assert!(size >= 16 + RING_CAPACITY * std::mem::size_of::<RingSlot>());
+        // SpscStorage の中身は ShmHeader + RING_CAPACITY 個の RingSlot
+        assert!(
+            size >= std::mem::size_of::<ShmHeader>()
+                + RING_CAPACITY * std::mem::size_of::<RingSlot>()
+        );
     }
 }

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn midori_sdk_spsc_push(storage: *const c_void, slot: *con
     // C 側で `#pragma pack` 等によりパックされたポインタを渡されても UB を
     // 起こさないよう unaligned read を採用する。
     let slot = std::ptr::read_unaligned(slot);
-    u8::from(spsc::try_push(storage, slot).is_ok())
+    u8::from(spsc::try_push(storage, &slot).is_ok())
 }
 
 /// スロットを 1 つ pop する。
@@ -123,17 +123,27 @@ pub unsafe extern "C" fn midori_sdk_spsc_pop(
 }
 
 #[cfg(test)]
-#[allow(unsafe_code)]
+#[allow(unsafe_code, clippy::cast_possible_truncation)]
 mod tests {
     use super::*;
-    use midori_core::shm::value_tag;
+    use midori_core::shm::PAYLOAD_INLINE_MAX;
 
-    fn slot_with_int(n: i64) -> RingSlot {
+    /// inline payload に 4 byte の little-endian シーケンス番号を詰めた
+    /// テスト用 [`RingSlot`] を作る。
+    fn slot_with_seq(seq: u32) -> RingSlot {
         let mut s: RingSlot = unsafe { std::mem::zeroed() };
         s.occupied = 1;
-        s.value_tag = value_tag::INT;
-        s.value_i64 = n;
+        s.payload_len = 4;
+        s.payload[..4].copy_from_slice(&seq.to_le_bytes());
         s
+    }
+
+    fn read_seq(slot: &RingSlot) -> u32 {
+        assert_eq!(slot.occupied, 1);
+        assert_eq!(slot.payload_len, 4);
+        let mut buf = [0u8; 4];
+        buf.copy_from_slice(&slot.payload[..4]);
+        u32::from_le_bytes(buf)
     }
 
     /// FFI 経由で確保→初期化→push→pop が成立することを検証する結合テスト。
@@ -154,7 +164,7 @@ mod tests {
             midori_sdk_spsc_init(raw.cast::<c_void>());
         }
 
-        let pushed = slot_with_int(42);
+        let pushed = slot_with_seq(42);
         let ok = unsafe {
             midori_sdk_spsc_push(
                 raw.cast::<c_void>(),
@@ -167,8 +177,7 @@ mod tests {
         let ok =
             unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
         assert_eq!(ok, 1);
-        assert_eq!(popped.value_i64, 42);
-        assert_eq!(popped.value_tag, value_tag::INT);
+        assert_eq!(read_seq(&popped), 42);
 
         // 空状態では pop が 0 を返す
         let ok =
@@ -181,10 +190,98 @@ mod tests {
         }
     }
 
+    /// `payload_len` = [`PAYLOAD_INLINE_MAX`] 上限ぴったりで FFI 経由のラウンドトリップを検証。
+    #[test]
+    fn it_should_round_trip_inline_payload_at_max_through_ffi() {
+        let layout = std::alloc::Layout::from_size_align(
+            midori_sdk_spsc_storage_size(),
+            midori_sdk_spsc_storage_alignment(),
+        )
+        .expect("valid layout");
+        // SAFETY: layout は size/alignment 共に正で、後で同じ layout で dealloc する
+        let raw = unsafe { std::alloc::alloc(layout) };
+        assert!(!raw.is_null());
+        unsafe { midori_sdk_spsc_init(raw.cast::<c_void>()) };
+
+        let mut pushed: RingSlot = unsafe { std::mem::zeroed() };
+        pushed.occupied = 1;
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            pushed.payload_len = PAYLOAD_INLINE_MAX as u32;
+        }
+        for (i, byte) in pushed.payload.iter_mut().enumerate() {
+            *byte = (i % 251) as u8;
+        }
+
+        let ok = unsafe {
+            midori_sdk_spsc_push(
+                raw.cast::<c_void>(),
+                std::ptr::from_ref::<RingSlot>(&pushed),
+            )
+        };
+        assert_eq!(ok, 1);
+
+        let mut popped: RingSlot = unsafe { std::mem::zeroed() };
+        let ok =
+            unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
+        assert_eq!(ok, 1);
+        assert_eq!(popped.payload_len as usize, PAYLOAD_INLINE_MAX);
+        for (i, byte) in popped.payload.iter().enumerate() {
+            assert_eq!(*byte, (i % 251) as u8, "byte at {i} mismatched");
+        }
+        // side channel は未使用
+        assert_eq!(popped.side_offset, 0);
+        assert_eq!(popped.side_len, 0);
+
+        // SAFETY: 同じ layout で dealloc
+        unsafe { std::alloc::dealloc(raw, layout) };
+    }
+
+    /// `payload_len` > [`PAYLOAD_INLINE_MAX`] 相当のケース: `payload_len` = 0 で
+    /// `side_offset` / `side_len` のみ立てたスロットがそのまま運ばれることを検証。
+    /// side channel 本体の確保は MEW-43。本テストはフィールド輸送のみを確認する。
+    #[test]
+    fn it_should_carry_side_channel_offsets_through_ffi() {
+        let layout = std::alloc::Layout::from_size_align(
+            midori_sdk_spsc_storage_size(),
+            midori_sdk_spsc_storage_alignment(),
+        )
+        .expect("valid layout");
+        // SAFETY: layout は size/alignment 共に正で、後で同じ layout で dealloc する
+        let raw = unsafe { std::alloc::alloc(layout) };
+        assert!(!raw.is_null());
+        unsafe { midori_sdk_spsc_init(raw.cast::<c_void>()) };
+
+        let mut pushed: RingSlot = unsafe { std::mem::zeroed() };
+        pushed.occupied = 1;
+        pushed.payload_len = 0;
+        pushed.side_offset = 4096;
+        pushed.side_len = 1024;
+
+        let ok = unsafe {
+            midori_sdk_spsc_push(
+                raw.cast::<c_void>(),
+                std::ptr::from_ref::<RingSlot>(&pushed),
+            )
+        };
+        assert_eq!(ok, 1);
+
+        let mut popped: RingSlot = unsafe { std::mem::zeroed() };
+        let ok =
+            unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
+        assert_eq!(ok, 1);
+        assert_eq!(popped.payload_len, 0);
+        assert_eq!(popped.side_offset, 4096);
+        assert_eq!(popped.side_len, 1024);
+
+        // SAFETY: 同じ layout で dealloc
+        unsafe { std::alloc::dealloc(raw, layout) };
+    }
+
     #[test]
     fn it_should_return_zero_when_called_with_null_pointers() {
         let mut slot: RingSlot = unsafe { std::mem::zeroed() };
-        let dummy_slot = slot_with_int(1);
+        let dummy_slot = slot_with_seq(1);
         let nul = std::ptr::null::<c_void>();
 
         // storage が NULL のケース
@@ -222,8 +319,8 @@ mod tests {
         unsafe { std::alloc::dealloc(raw, layout) };
     }
 
-    /// `build.rs` が生成した C ヘッダに想定の関数宣言が含まれていることを検証する。
-    /// ヘッダ生成自体（`cargo build` で発火）はビルド時にチェック済み。
+    /// `build.rs` が生成した C ヘッダに想定の関数宣言と新 [`RingSlot`] フィールドが
+    /// 含まれていることを検証する。ヘッダ生成自体は `cargo build` 時にチェック済み。
     #[test]
     fn it_should_generate_c_header_with_expected_ffi_symbols() {
         const GENERATED_HEADER: &str = include_str!(concat!(env!("OUT_DIR"), "/midori_sdk.h"));
@@ -234,6 +331,12 @@ mod tests {
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_push"));
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_pop"));
         assert!(GENERATED_HEADER.contains("RingSlot"));
+        // 新レイアウトのフィールドがヘッダに公開されていること
+        assert!(GENERATED_HEADER.contains("payload_len"));
+        assert!(GENERATED_HEADER.contains("side_offset"));
+        assert!(GENERATED_HEADER.contains("side_len"));
+        assert!(GENERATED_HEADER.contains("payload"));
+        assert!(GENERATED_HEADER.contains("PAYLOAD_INLINE_MAX"));
     }
 
     #[test]
@@ -242,7 +345,7 @@ mod tests {
         let align = midori_sdk_spsc_storage_alignment();
         assert!(size > 0);
         assert!(align.is_power_of_two());
-        // SpscStorage の中身は ShmHeader (16 byte) + 256 個の RingSlot
+        // SpscStorage の中身は ShmHeader (16 byte) + RING_CAPACITY 個の RingSlot
         assert!(size >= 16 + 256 * std::mem::size_of::<RingSlot>());
     }
 }

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn midori_sdk_spsc_pop(
 #[allow(unsafe_code, clippy::cast_possible_truncation)]
 mod tests {
     use super::*;
-    use midori_core::shm::PAYLOAD_INLINE_MAX;
+    use midori_core::shm::{PAYLOAD_INLINE_MAX, RING_CAPACITY};
 
     /// inline payload に 4 byte の little-endian シーケンス番号を詰めた
     /// テスト用 [`RingSlot`] を作る。
@@ -205,10 +205,7 @@ mod tests {
 
         let mut pushed: RingSlot = unsafe { std::mem::zeroed() };
         pushed.occupied = 1;
-        #[allow(clippy::cast_possible_truncation)]
-        {
-            pushed.payload_len = PAYLOAD_INLINE_MAX as u32;
-        }
+        pushed.payload_len = PAYLOAD_INLINE_MAX as u32;
         for (i, byte) in pushed.payload.iter_mut().enumerate() {
             *byte = (i % 251) as u8;
         }
@@ -270,6 +267,7 @@ mod tests {
         let ok =
             unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
         assert_eq!(ok, 1);
+        assert_eq!(popped.occupied, 1);
         assert_eq!(popped.payload_len, 0);
         assert_eq!(popped.side_offset, 4096);
         assert_eq!(popped.side_len, 1024);
@@ -346,6 +344,6 @@ mod tests {
         assert!(size > 0);
         assert!(align.is_power_of_two());
         // SpscStorage の中身は ShmHeader (16 byte) + RING_CAPACITY 個の RingSlot
-        assert!(size >= 16 + 256 * std::mem::size_of::<RingSlot>());
+        assert!(size >= 16 + RING_CAPACITY * std::mem::size_of::<RingSlot>());
     }
 }

--- a/crates/midori-sdk/src/lib.rs
+++ b/crates/midori-sdk/src/lib.rs
@@ -60,8 +60,6 @@ mod tests {
     #[test]
     fn it_should_expose_shm_layout_at_top_level() {
         let _ = RING_CAPACITY;
-        let _ = DEVICE_ID_MAX;
-        let _ = SPECIFIER_MAX;
-        let _: u8 = value_tag::PULSE;
+        let _ = PAYLOAD_INLINE_MAX;
     }
 }

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -116,7 +116,7 @@ impl std::error::Error for Full {}
 /// 生産者の push 処理本体。`Producer::push` と FFI からの両方で呼ばれる。
 ///
 /// `slot` は `&RingSlot` を受け取り内部でコピーする。新レイアウト
-/// （`PAYLOAD_INLINE_MAX = 240` 込みで ~264 byte）の値渡しはスタックを
+/// （`PAYLOAD_INLINE_MAX = 240` 込みで 264 byte 固定）の値渡しはスタックを
 /// 無駄に消費するため。
 ///
 /// 呼び出し側は SPSC 規律（任意の時刻に生産者は 1 つだけ）を守ること。
@@ -210,11 +210,7 @@ const EMPTY_SLOT: RingSlot = RingSlot {
 };
 
 #[cfg(test)]
-#[allow(
-    clippy::cast_possible_wrap,
-    clippy::cast_possible_truncation,
-    clippy::items_after_statements
-)]
+#[allow(clippy::cast_possible_truncation, clippy::items_after_statements)]
 mod tests {
     use super::*;
 

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -22,7 +22,7 @@
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use midori_core::shm::{RingSlot, ShmHeader, DEVICE_ID_MAX, RING_CAPACITY, SPECIFIER_MAX};
+use midori_core::shm::{RingSlot, ShmHeader, PAYLOAD_INLINE_MAX, RING_CAPACITY};
 
 /// 共有メモリ上に置かれることを意図した SPSC リングバッファのストレージ。
 ///
@@ -115,10 +115,14 @@ impl std::error::Error for Full {}
 
 /// 生産者の push 処理本体。`Producer::push` と FFI からの両方で呼ばれる。
 ///
+/// `slot` は `&RingSlot` を受け取り内部でコピーする。新レイアウト
+/// （`PAYLOAD_INLINE_MAX = 240` 込みで ~264 byte）の値渡しはスタックを
+/// 無駄に消費するため。
+///
 /// 呼び出し側は SPSC 規律（任意の時刻に生産者は 1 つだけ）を守ること。
 /// Rust API では [`SpscStorage::split`] が型レベルで保証する。FFI からの
 /// 呼び出しでは C 側が規律を守る責務を負う。
-pub(crate) fn try_push(storage: &SpscStorage, slot: RingSlot) -> Result<(), Full> {
+pub(crate) fn try_push(storage: &SpscStorage, slot: &RingSlot) -> Result<(), Full> {
     let header = &storage.header;
     // 自プロセス内の生産者専用インデックスは Relaxed で十分（書き手は自分だけ）。
     let write = header.write_index.load(Ordering::Relaxed);
@@ -136,7 +140,7 @@ pub(crate) fn try_push(storage: &SpscStorage, slot: RingSlot) -> Result<(), Full
     // よって同一スロットへの同時アクセスは発生しない。
     #[allow(unsafe_code)]
     unsafe {
-        *storage.slots[idx].get() = slot;
+        *storage.slots[idx].get() = *slot;
     }
     // スロット書き込みより後に必ず観測されるよう Release で公開する。
     header
@@ -178,7 +182,7 @@ pub struct Producer<'a> {
 
 impl Producer<'_> {
     /// スロットを末尾に追加する。バッファが満杯なら [`Full`] を返す。
-    pub fn push(&mut self, slot: RingSlot) -> Result<(), Full> {
+    pub fn push(&mut self, slot: &RingSlot) -> Result<(), Full> {
         try_push(self.storage, slot)
     }
 }
@@ -197,47 +201,61 @@ impl Consumer<'_> {
 
 const EMPTY_SLOT: RingSlot = RingSlot {
     occupied: 0,
-    value_tag: 0,
-    _pad: [0; 6],
-    device_id: [0; DEVICE_ID_MAX + 1],
-    specifier: [0; SPECIFIER_MAX + 1],
-    value_i64: 0,
-    value_f64: 0.0,
+    _pad: [0; 3],
+    payload_len: 0,
+    side_offset: 0,
+    side_len: 0,
+    _pad2: [0; 4],
+    payload: [0; PAYLOAD_INLINE_MAX],
 };
 
 #[cfg(test)]
-#[allow(clippy::cast_possible_wrap, clippy::items_after_statements)]
+#[allow(
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::items_after_statements
+)]
 mod tests {
     use super::*;
-    use midori_core::shm::value_tag;
 
-    const THREAD_TEST_COUNT: i64 = 10_000;
+    const THREAD_TEST_COUNT: usize = 10_000;
 
-    fn slot_with_int(n: i64) -> RingSlot {
+    /// inline payload に「seq の下位バイトを 4 byte little-endian で詰めた」
+    /// テスト用 [`RingSlot`] を作る。msgpack そのものではなく、test 用にバイト列の
+    /// ラウンドトリップだけを確認するためのプレースホルダ。
+    fn slot_with_seq(seq: u32) -> RingSlot {
         let mut s = EMPTY_SLOT;
         s.occupied = 1;
-        s.value_tag = value_tag::INT;
-        s.value_i64 = n;
+        s.payload_len = 4;
+        s.payload[..4].copy_from_slice(&seq.to_le_bytes());
         s
+    }
+
+    fn read_seq(slot: &RingSlot) -> u32 {
+        assert_eq!(slot.occupied, 1);
+        assert_eq!(slot.payload_len, 4);
+        let mut buf = [0u8; 4];
+        buf.copy_from_slice(&slot.payload[..4]);
+        u32::from_le_bytes(buf)
     }
 
     #[test]
     fn it_should_return_none_when_consumer_pops_empty_buffer() {
         let mut storage = SpscStorage::new();
         let (_p, mut c) = storage.split();
-        assert_eq!(c.pop().map(|s| s.value_i64), None);
+        assert!(c.pop().is_none());
     }
 
     #[test]
     fn it_should_pop_pushed_slots_in_fifo_order() {
         let mut storage = SpscStorage::new();
         let (mut p, mut c) = storage.split();
-        p.push(slot_with_int(1)).unwrap();
-        p.push(slot_with_int(2)).unwrap();
-        p.push(slot_with_int(3)).unwrap();
-        assert_eq!(c.pop().unwrap().value_i64, 1);
-        assert_eq!(c.pop().unwrap().value_i64, 2);
-        assert_eq!(c.pop().unwrap().value_i64, 3);
+        p.push(&slot_with_seq(1)).unwrap();
+        p.push(&slot_with_seq(2)).unwrap();
+        p.push(&slot_with_seq(3)).unwrap();
+        assert_eq!(read_seq(&c.pop().unwrap()), 1);
+        assert_eq!(read_seq(&c.pop().unwrap()), 2);
+        assert_eq!(read_seq(&c.pop().unwrap()), 3);
         assert!(c.pop().is_none());
     }
 
@@ -246,9 +264,9 @@ mod tests {
         let mut storage = SpscStorage::new();
         let (mut p, _c) = storage.split();
         for i in 0..RING_CAPACITY {
-            p.push(slot_with_int(i as i64)).unwrap();
+            p.push(&slot_with_seq(i as u32)).unwrap();
         }
-        assert_eq!(p.push(slot_with_int(-1)), Err(Full));
+        assert_eq!(p.push(&slot_with_seq(u32::MAX)), Err(Full));
     }
 
     #[test]
@@ -256,10 +274,10 @@ mod tests {
         let mut storage = SpscStorage::new();
         let (mut p, mut c) = storage.split();
         // 3 周分書いて読む。インデックスは 3 * RING_CAPACITY まで進む。
-        let total = (RING_CAPACITY * 3) as i64;
+        let total = RING_CAPACITY * 3;
         for i in 0..total {
-            p.push(slot_with_int(i)).unwrap();
-            assert_eq!(c.pop().unwrap().value_i64, i);
+            p.push(&slot_with_seq(i as u32)).unwrap();
+            assert_eq!(read_seq(&c.pop().unwrap()), i as u32);
         }
     }
 
@@ -269,17 +287,68 @@ mod tests {
         let (mut p, mut c) = storage.split();
         // 一度満杯にし、全部抜き、再度満杯にできる
         for i in 0..RING_CAPACITY {
-            p.push(slot_with_int(i as i64)).unwrap();
+            p.push(&slot_with_seq(i as u32)).unwrap();
         }
         for i in 0..RING_CAPACITY {
-            assert_eq!(c.pop().unwrap().value_i64, i as i64);
+            assert_eq!(read_seq(&c.pop().unwrap()), i as u32);
         }
         for i in 0..RING_CAPACITY {
-            p.push(slot_with_int((i + 1000) as i64)).unwrap();
+            p.push(&slot_with_seq((i + 1000) as u32)).unwrap();
         }
         for i in 0..RING_CAPACITY {
-            assert_eq!(c.pop().unwrap().value_i64, (i + 1000) as i64);
+            assert_eq!(read_seq(&c.pop().unwrap()), (i + 1000) as u32);
         }
+    }
+
+    #[test]
+    fn it_should_round_trip_inline_payload_at_max_capacity() {
+        // payload_len <= PAYLOAD_INLINE_MAX のラウンドトリップ（バイト列が一致）
+        let mut storage = SpscStorage::new();
+        let (mut p, mut c) = storage.split();
+
+        let mut slot = EMPTY_SLOT;
+        slot.occupied = 1;
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            slot.payload_len = PAYLOAD_INLINE_MAX as u32;
+        }
+        for (i, byte) in slot.payload.iter_mut().enumerate() {
+            *byte = (i % 251) as u8;
+        }
+        p.push(&slot).unwrap();
+
+        let popped = c.pop().expect("slot should be available");
+        assert_eq!(popped.occupied, 1);
+        assert_eq!(popped.payload_len as usize, PAYLOAD_INLINE_MAX);
+        for (i, byte) in popped.payload.iter().enumerate() {
+            assert_eq!(*byte, (i % 251) as u8, "byte at {i} mismatched");
+        }
+        // side channel は使用していない
+        assert_eq!(popped.side_offset, 0);
+        assert_eq!(popped.side_len, 0);
+    }
+
+    #[test]
+    fn it_should_carry_side_channel_offsets_when_inline_is_unused() {
+        // payload_len > PAYLOAD_INLINE_MAX 相当のケース: payload_len=0 で
+        // side_offset/side_len のみが立ち、inline payload 領域は使われない。
+        // side channel 本体の確保は MEW-43 のスコープ。本テストはフィールドの
+        // セマンティクスのみを検証する。
+        let mut storage = SpscStorage::new();
+        let (mut p, mut c) = storage.split();
+
+        let mut slot = EMPTY_SLOT;
+        slot.occupied = 1;
+        slot.payload_len = 0;
+        slot.side_offset = 4096;
+        slot.side_len = 1024;
+        p.push(&slot).unwrap();
+
+        let popped = c.pop().expect("slot should be available");
+        assert_eq!(popped.occupied, 1);
+        assert_eq!(popped.payload_len, 0);
+        assert_eq!(popped.side_offset, 4096);
+        assert_eq!(popped.side_len, 1024);
     }
 
     #[test]
@@ -289,9 +358,9 @@ mod tests {
 
         std::thread::scope(|s| {
             s.spawn(move || {
-                let mut sent = 0_i64;
-                while sent < THREAD_TEST_COUNT {
-                    if p.push(slot_with_int(sent)).is_ok() {
+                let mut sent: u32 = 0;
+                while (sent as usize) < THREAD_TEST_COUNT {
+                    if p.push(&slot_with_seq(sent)).is_ok() {
                         sent += 1;
                     } else {
                         std::thread::yield_now();
@@ -299,10 +368,10 @@ mod tests {
                 }
             });
             s.spawn(move || {
-                let mut expected = 0_i64;
-                while expected < THREAD_TEST_COUNT {
+                let mut expected: u32 = 0;
+                while (expected as usize) < THREAD_TEST_COUNT {
                     if let Some(slot) = c.pop() {
-                        assert_eq!(slot.value_i64, expected);
+                        assert_eq!(read_seq(&slot), expected);
                         expected += 1;
                     } else {
                         std::thread::yield_now();

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -26,8 +26,8 @@ use midori_core::shm::{RingSlot, ShmHeader, PAYLOAD_INLINE_MAX, RING_CAPACITY};
 
 /// 共有メモリ上に置かれることを意図した SPSC リングバッファのストレージ。
 ///
-/// `#[repr(C)]` により mmap 可能な固定レイアウトを保証する。FFI（MEW-37）
-/// で他言語からも同レイアウトでアクセスする予定。
+/// `#[repr(C)]` により mmap 可能な固定レイアウトを保証し、C FFI 経由で他言語
+/// からも同レイアウトでアクセスできる。
 #[repr(C)]
 pub struct SpscStorage {
     header: ShmHeader,
@@ -329,8 +329,8 @@ mod tests {
     fn it_should_carry_side_channel_offsets_when_inline_is_unused() {
         // payload_len > PAYLOAD_INLINE_MAX 相当のケース: payload_len=0 で
         // side_offset/side_len のみが立ち、inline payload 領域は使われない。
-        // side channel 本体の確保は MEW-43 のスコープ。本テストはフィールドの
-        // セマンティクスのみを検証する。
+        // 本テストは RingSlot フィールドのセマンティクスのみを検証する
+        // （side channel 本体の確保は本クレートのスコープ外）。
         let mut storage = SpscStorage::new();
         let (mut p, mut c) = storage.split();
 

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -308,10 +308,7 @@ mod tests {
 
         let mut slot = EMPTY_SLOT;
         slot.occupied = 1;
-        #[allow(clippy::cast_possible_truncation)]
-        {
-            slot.payload_len = PAYLOAD_INLINE_MAX as u32;
-        }
+        slot.payload_len = PAYLOAD_INLINE_MAX as u32;
         for (i, byte) in slot.payload.iter_mut().enumerate() {
             *byte = (i % 251) as u8;
         }


### PR DESCRIPTION
## Summary

- `midori-core::shm::RingSlot` を **raw event payload 形式** に全面差し替え（MEW-40 で確定した設計）。`payload_len` / `side_offset` / `side_len` / `payload[PAYLOAD_INLINE_MAX]` を持つ msgpack バイト列輸送スロットに変更。
- `midori-core` を **0.1.0 → 0.2.0 に major bump**。CHANGELOG.md を新規作成。
- `midori-sdk` の SPSC 実装と FFI を新レイアウトに追従。`Producer::push` / `try_push` は `&RingSlot` 受け取りに変更（264 byte の値渡しを避けるため）。
- C ヘッダ `midori_sdk.h` は cbindgen で自動再生成。`payload_len` / `side_offset` / `side_len` / `payload` フィールドが公開される。

Closes MEW-41

## 削除されたフィールド / 定数

- `RingSlot::{value_tag, device_id, specifier, value_i64, value_f64}` 旧 _pad
- `shm::value_tag` モジュール
- `shm::DEVICE_ID_MAX`, `shm::SPECIFIER_MAX`

これらは Layer 2 binding 後の post-binding 形に対応していたが、Driver → Bridge の SPSC は raw event を運ぶ設計（MEW-40）に変わったため不要。binding 適用は Bridge 側の責務（`design/layers/02-input-recognition/binding-requirements.md`）。

## 追加されたフィールド / 定数

- `shm::PAYLOAD_INLINE_MAX = 240`（inline payload の最大バイト長）
- `RingSlot::side_offset` / `side_len`（PAYLOAD_INLINE_MAX 超過時の side channel ポインタ枠。本体実装は MEW-43）

## 後続 Issue を **アンブロック**

| Issue | アンブロック理由 |
|---|---|
| MEW-42 (Side channel 設計) | RingSlot の `side_offset` / `side_len` 枠が確定 |
| MEW-43 (Side channel 実装) | 同上 |
| MEW-45 (Bridge schema ローダー) | RingSlot の payload バイト列形式が確定 |

## 検証

- [x] `cargo build --workspace` Pass
- [x] `cargo test --workspace` Pass（30 件、新テスト 4 件追加: inline 上限ラウンドトリップ / side channel フィールド輸送 × spsc + ffi）
- [x] `cargo clippy --workspace --all-targets -- -D warnings` Pass
- [x] `cargo fmt --all -- --check` Pass
- [x] cbindgen 生成 `midori_sdk.h` に新 `RingSlot` 定義（payload_len / side_offset / side_len / payload）が出力されている

## Out of Scope

- side channel（mmap プール）本体（MEW-43）
- Bridge 側 events.yaml schema ローダー（MEW-45）
- L1 FFI 拡張 `midori_sdk_emit_event`（後続 Phase 1）
- `PAYLOAD_INLINE_MAX` を C ヘッダに `#define` として export する作業（MEW-39 で対応）

## Test plan

- [ ] レビュー観点: 新 RingSlot レイアウトのフィールド配置・サイズ計算（264 byte）
- [ ] レビュー観点: `try_push(&RingSlot)` 化に伴う SPSC 規律・SAFETY コメントの妥当性
- [ ] レビュー観点: side_offset / side_len のセマンティクス（payload_len = 0 + side_len > 0 で side channel 経由）が後続 Issue (MEW-43) に渡せる形になっているか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **破壊的変更**
  * RingSlot 共有メモリレイアウトを再設計し、旧来の値タグ／デバイス指定子を削除、インラインペイロード表現へ移行しました（大きいペイロードはサイドチャネル想定）。
* **新機能**
  * インライン最大サイズ定数（PAYLOAD_INLINE_MAX）を導入。
* **テスト**
  * 新しいペイロード表現向けのラウンドトリップ／境界テストを追加。
* **Chore**
  * midori-core を v0.2.0 に更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->