### PR TITLE
feat(runtime): runtime feature-availability check for tier: streamed (MEW-51)

### DIFF
--- a/crates/midori-runtime/src/events_schema/feature_check.rs
+++ b/crates/midori-runtime/src/events_schema/feature_check.rs
@@ -1,0 +1,60 @@
+//! Runtime feature-availability check for events.yaml.
+//!
+//! Schema validator が構文上は受理する宣言のうち、Bridge runtime のキャパビリティが
+//! 未到達なものを起動時に reject する。streamed tier のように「将来実装予定だが
+//! 現状未着手」な機能を **driver 作者が events.yaml に書ける** ようにしつつ、
+//! 実利用は明示エラーで止める。
+
+use super::types::{EventsSchema, Tier};
+
+/// Streamed tier の説明文（エラーメッセージで利用）。
+const STREAMED_FEATURE_LABEL: &str = "streamed";
+const STREAMED_REASON: &str = "streamed tier is not implemented yet";
+
+/// Runtime に未対応な機能宣言を一件単位で表す。
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FeatureUnavailable {
+    pub driver_name: String,
+    pub event_name: String,
+    pub feature: &'static str,
+    pub reason: &'static str,
+}
+
+impl std::fmt::Display for FeatureUnavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "driver `{}` event `{}` declares feature `{}` which the Bridge runtime cannot accept: {}",
+            self.driver_name, self.event_name, self.feature, self.reason
+        )
+    }
+}
+
+impl std::error::Error for FeatureUnavailable {}
+
+/// `schema` の宣言が現在の Bridge runtime で全て利用可能か検査する。
+///
+/// 1 driver につき 1 回、events.yaml ロード + `validate` 通過後に呼ぶ想定。
+/// 全違反を集約して返すため、複数イベントで同じ未対応機能が宣言されている
+/// 場合も一括で報告できる。
+pub fn check_runtime_features(
+    driver_name: &str,
+    schema: &EventsSchema,
+) -> Result<(), Vec<FeatureUnavailable>> {
+    let mut errors = Vec::new();
+    for (event_name, event) in &schema.events {
+        if matches!(event.tier, Tier::Streamed) {
+            errors.push(FeatureUnavailable {
+                driver_name: driver_name.to_owned(),
+                event_name: event_name.clone(),
+                feature: STREAMED_FEATURE_LABEL,
+                reason: STREAMED_REASON,
+            });
+        }
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}

--- a/crates/midori-runtime/src/events_schema/mod.rs
+++ b/crates/midori-runtime/src/events_schema/mod.rs
@@ -5,9 +5,8 @@
 //! startup. Schema violations are reported as startup errors (callers fail
 //! fast) rather than runtime drops.
 //!
-//! Out of scope here: msgpack decode of raw events, runtime feature-availability
-//! check for `tier: streamed`, and Layer 2 binding wiring. Those live in
-//! sibling modules.
+//! Out of scope here: msgpack decode of raw events, and Layer 2 binding wiring.
+//! Those live in sibling modules.
 //!
 //! 構成（責務別 sub-module + テスト分離）:
 //!

--- a/crates/midori-runtime/src/events_schema/mod.rs
+++ b/crates/midori-runtime/src/events_schema/mod.rs
@@ -11,20 +11,23 @@
 //!
 //! 構成（責務別 sub-module + テスト分離）:
 //!
-//! - [`types`]:     events.yaml の Rust 表現と serde 周辺
-//! - [`loader`]:    YAML パース I/O とエラー
-//! - [`validator`]: schema 違反検出ルール
-//! - `tests`:       sub-module すべての単体テスト
+//! - [`types`]:         events.yaml の Rust 表現と serde 周辺
+//! - [`loader`]:        YAML パース I/O とエラー
+//! - [`validator`]:     schema 違反検出ルール（構文・意味論レベル）
+//! - [`feature_check`]: Bridge runtime が現状サポートしていない宣言の reject
+//! - `tests`:           sub-module すべての単体テスト
 
 // この module の公開 API は Bridge パイプラインからまだ呼び出されておらず
 // （後続 subtask で接続予定）、binary crate 内の dead_code / unused_imports
 // 検出に引っかかるため module 全体で抑制する。実体は単体テストで網羅している。
 #![allow(dead_code, unused_imports)]
 
+mod feature_check;
 mod loader;
 mod types;
 mod validator;
 
+pub use feature_check::{check_runtime_features, FeatureUnavailable};
 pub use loader::{load_from_path, resolve_events_yaml_path, LoadError, LoadOutcome};
 pub use types::{EventDef, EventsSchema, FieldSpec, FieldType, RangeBound, Tier};
 pub use validator::{validate, ValidationError};

--- a/crates/midori-runtime/src/events_schema/tests.rs
+++ b/crates/midori-runtime/src/events_schema/tests.rs
@@ -666,8 +666,11 @@ events:
     assert_eq!(err.feature, "streamed");
     let rendered = err.to_string();
     assert!(
-        rendered.contains("driver `osc`") && rendered.contains("event `oscBlob`"),
-        "display must include driver name and event name, got: {rendered}"
+        rendered.contains("driver `osc`")
+            && rendered.contains("event `oscBlob`")
+            && rendered.contains("feature `streamed`")
+            && rendered.contains("streamed tier is not implemented yet"),
+        "display must include driver, event, feature and reason, got: {rendered}"
     );
 }
 

--- a/crates/midori-runtime/src/events_schema/tests.rs
+++ b/crates/midori-runtime/src/events_schema/tests.rs
@@ -623,3 +623,76 @@ fn it_should_resolve_events_yaml_next_to_driver_yaml() {
         PathBuf::from("/path/to/drivers/midi/events.yaml")
     );
 }
+
+// ---------------------------------------------------------------------------
+// feature_check::check_runtime_features
+// ---------------------------------------------------------------------------
+
+#[test]
+fn it_should_pass_runtime_check_for_inline_only_schema() {
+    let schema = parse(
+        r"
+schema_version: 1
+events:
+  noteOn:
+    fields:
+      channel: { type: uint8, range: [1, 16] }
+",
+    );
+    assert!(check_runtime_features("midi", &schema).is_ok());
+}
+
+#[test]
+fn it_should_reject_runtime_check_when_any_event_is_streamed() {
+    let schema = parse(
+        r"
+schema_version: 1
+events:
+  noteOn:
+    fields:
+      channel: { type: uint8, range: [1, 16] }
+  oscBlob:
+    tier: streamed
+    fields:
+      payload: { type: bytes, max_length: 65536 }
+",
+    );
+    let errors = check_runtime_features("osc", &schema)
+        .expect_err("streamed-tier event must be rejected at runtime");
+    assert_eq!(errors.len(), 1);
+    let err = &errors[0];
+    assert_eq!(err.driver_name, "osc");
+    assert_eq!(err.event_name, "oscBlob");
+    assert_eq!(err.feature, "streamed");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("driver `osc`") && rendered.contains("event `oscBlob`"),
+        "display must include driver name and event name, got: {rendered}"
+    );
+}
+
+#[test]
+fn it_should_collect_all_streamed_tier_violations() {
+    let schema = parse(
+        r"
+schema_version: 1
+events:
+  big1:
+    tier: streamed
+    fields:
+      payload: { type: bytes, max_length: 4096 }
+  big2:
+    tier: streamed
+    fields:
+      payload: { type: bytes, max_length: 4096 }
+  small:
+    fields:
+      x: { type: uint8 }
+",
+    );
+    let errors = check_runtime_features("driver-x", &schema).expect_err("must collect all");
+    assert_eq!(errors.len(), 2);
+    let names: Vec<&str> = errors.iter().map(|e| e.event_name.as_str()).collect();
+    assert!(names.contains(&"big1"));
+    assert!(names.contains(&"big2"));
+}


### PR DESCRIPTION
## Summary

- events.yaml schema validator は `tier: streamed` を構文上は受理する一方、streamed tier 経路（shm 外 IPC）は未実装のため、Bridge 起動時の **runtime feature-availability check** として 1 件でも streamed event を含む driver を明示エラーで reject する `check_runtime_features` を追加した。
- `events_schema::feature_check` を sub-module として新規追加し、driver 名と全違反 event 名を含む `FeatureUnavailable` を集約 (`Result<(), Vec<FeatureUnavailable>>`) して返す。`Display` は driver 名 + event 名 + reason を含む。
- `mod.rs` から `check_runtime_features` / `FeatureUnavailable` を re-export。
- 単体テスト: inline-only 通過 / single streamed reject / multiple streamed 全件集約 の 3 件。
- 既存 module 冒頭の "Out of scope here" doc から feature-availability check の項目を削除（pre-push self-review 反映）。

## AC mapping

- [x] Bridge 起動時、`tier: streamed` を含む event が 1 つでもあれば runtime feature-availability check で起動を reject — `check_runtime_features` 関数として提供。Bridge パイプラインへの実配線は MEW-49 同様 dead_code allow で別 subtask に切り出し
- [x] reject 時のエラーメッセージに driver 名 / 該当 event 名を含む — `FeatureUnavailable::Display` で "driver \`X\` event \`Y\` declares feature \`streamed\` ..." 形式
- [x] static schema validator では `tier: streamed` を構文上は受理 — 既存 validator 動作は変更なし
- [x] 単体テスト: inline-only 通過 / streamed を含む場合 reject

## Test plan

- [x] `cargo test -p midori-runtime` (49 passed)
- [x] `cargo clippy -p midori-runtime --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] pre-push: `/code-review:code-review`（1 件 doc 矛盾 → 修正済）
- [x] pre-push: `coderabbit review --agent -t committed --base main` (findings: 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 実行時のイベント設定検証を追加。サポート外の「Streamed」ティアを検出し、ドライバ名・イベント名・理由を含む詳細なエラーメッセージで報告します。

* **テスト**
  * 検証機能の単体テストを追加（正常系、単一エラー、複数エラーの集約を確認）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->