### PR TITLE
feat(runtime): msgpack decode + schema check pipeline (MEW-50)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +300,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "midori-core",
+ "rmpv",
  "serde",
  "serde_yml",
  "tempfile",
@@ -308,6 +315,15 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -355,6 +371,24 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmpv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+dependencies = [
+ "rmp",
+]
 
 [[package]]
 name = "rustix"

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 midori-core = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+rmpv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yml = "0.0.12"
 

--- a/crates/midori-runtime/src/events_pipeline/decode.rs
+++ b/crates/midori-runtime/src/events_pipeline/decode.rs
@@ -81,9 +81,12 @@ impl std::error::Error for DecodeError {
 
 /// 1 inline payload（msgpack バイト列）を decode する。
 ///
-/// 戻り値は msgpack map のキー → 値の `BTreeMap`。値はキーごとに 1 つで
-/// 重複キーは msgpack 側の挙動に従う（rmpv が後勝ちで保持するためここでは
-/// 重複検出しない。重複判定は schema check 層の責務外）。
+/// 戻り値は msgpack map のキー → 値の `BTreeMap`。rmpv は重複キーを
+/// `Vec<(Value, Value)>` のまま返すが、本層は `BTreeMap::insert` の
+/// 後勝ちで暗黙にマージする（msgpack 規格上重複キーは未定義動作で、
+/// driver SDK が dict / struct から encode する正常経路では発生しない
+/// ため、防衛的検出までは行わない）。重複検出が必要になったらここで
+/// 早期 reject に切り替える。
 pub fn decode_event(bytes: &[u8]) -> Result<DecodedPayload, DecodeError> {
     let mut cursor: &[u8] = bytes;
     let value = rmpv::decode::read_value(&mut cursor).map_err(DecodeError::Parse)?;

--- a/crates/midori-runtime/src/events_pipeline/decode.rs
+++ b/crates/midori-runtime/src/events_pipeline/decode.rs
@@ -1,0 +1,167 @@
+//! Inline payload (msgpack) → 動的 [`DecodedPayload`] への decode 層。
+//!
+//! 本層は「msgpack の bytes を events.yaml schema が扱える語彙へ落とすだけ」
+//! の責務に絞る。schema 違反（type 不一致 / range 外 / 必須欠落）の判定は
+//! 上位の `runtime_check` モジュールで行う。
+
+use std::collections::BTreeMap;
+
+use rmpv::Value;
+
+/// events.yaml の語彙に合わせた decode 後の値表現。
+///
+/// 整数は msgpack 表現に従い signed / unsigned を分離して保持する。schema
+/// 側の `int*` / `uint*` 型と照合する際に、上位層が必要な変換を行う。
+#[derive(Debug, Clone, PartialEq)]
+pub enum FieldValue {
+    Bool(bool),
+    Int(i64),
+    UInt(u64),
+    Float(f64),
+    String(String),
+    Bytes(Vec<u8>),
+    Array(Vec<FieldValue>),
+}
+
+/// 1 イベントの decode 結果。msgpack map のキー → 値。
+pub type DecodedPayload = BTreeMap<String, FieldValue>;
+
+/// Decode 失敗の原因。
+#[derive(Debug)]
+pub enum DecodeError {
+    /// msgpack 自体の解析失敗（不完全 / 破損バイト列）。
+    Parse(rmpv::decode::Error),
+    /// トップレベルが map ではない（events.yaml は map of fields のみ許容）。
+    NotAMap,
+    /// 余剰バイトが残っている（1 payload に複数 msgpack value が連結されている）。
+    TrailingBytes,
+    /// map のキーが文字列ではない。
+    NonStringKey,
+    /// UTF-8 として無効な msgpack str。
+    NonUtf8String { path: String },
+    /// events.yaml の語彙に存在しない msgpack type（nil / ext）が現れた。
+    UnsupportedValue { path: String, kind: &'static str },
+    /// map / nil / ext がフィールド値としてネストしている。events.yaml は
+    /// scalar / `bytes` / `string` / `array<scalar>` のみを許容する。
+    NestedMap { path: String },
+    /// 配列要素が array や map（= 非 scalar）。`array<scalar>` の制約に反する。
+    NonScalarArrayElement { path: String },
+}
+
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Parse(source) => write!(f, "msgpack parse failed: {source}"),
+            Self::NotAMap => f.write_str("top-level value must be a msgpack map"),
+            Self::TrailingBytes => {
+                f.write_str("payload contains trailing bytes after the top-level map")
+            }
+            Self::NonStringKey => f.write_str("map keys must be strings"),
+            Self::NonUtf8String { path } => write!(f, "{path}: string is not valid UTF-8"),
+            Self::UnsupportedValue { path, kind } => write!(
+                f,
+                "{path}: msgpack value of kind `{kind}` is not in the events.yaml vocabulary"
+            ),
+            Self::NestedMap { path } => write!(f, "{path}: nested maps are not allowed"),
+            Self::NonScalarArrayElement { path } => {
+                write!(f, "{path}: array elements must be scalar values")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Parse(source) => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// 1 inline payload（msgpack バイト列）を decode する。
+///
+/// 戻り値は msgpack map のキー → 値の `BTreeMap`。値はキーごとに 1 つで
+/// 重複キーは msgpack 側の挙動に従う（rmpv が後勝ちで保持するためここでは
+/// 重複検出しない。重複判定は schema check 層の責務外）。
+pub fn decode_event(bytes: &[u8]) -> Result<DecodedPayload, DecodeError> {
+    let mut cursor: &[u8] = bytes;
+    let value = rmpv::decode::read_value(&mut cursor).map_err(DecodeError::Parse)?;
+    if !cursor.is_empty() {
+        return Err(DecodeError::TrailingBytes);
+    }
+    let Value::Map(entries) = value else {
+        return Err(DecodeError::NotAMap);
+    };
+    let mut out = BTreeMap::new();
+    for (key_value, raw) in entries {
+        let key = key_value
+            .as_str()
+            .ok_or(DecodeError::NonStringKey)?
+            .to_owned();
+        let field = convert_value(&key, raw)?;
+        out.insert(key, field);
+    }
+    Ok(out)
+}
+
+fn convert_value(path: &str, value: Value) -> Result<FieldValue, DecodeError> {
+    Ok(match value {
+        Value::Boolean(b) => FieldValue::Bool(b),
+        Value::Integer(i) => {
+            if let Some(u) = i.as_u64() {
+                FieldValue::UInt(u)
+            } else if let Some(s) = i.as_i64() {
+                FieldValue::Int(s)
+            } else {
+                // msgpack int の規格上 [-2^63, 2^64-1] の範囲しか表現できないため、
+                // as_u64 と as_i64 が両方 None になる入力は rmpv 側で構築不能。
+                // 防衛的に reject。
+                return Err(DecodeError::UnsupportedValue {
+                    path: path.to_owned(),
+                    kind: "integer-out-of-range",
+                });
+            }
+        }
+        Value::F32(v) => FieldValue::Float(f64::from(v)),
+        Value::F64(v) => FieldValue::Float(v),
+        Value::String(s) => match s.into_str() {
+            Some(text) => FieldValue::String(text),
+            None => {
+                return Err(DecodeError::NonUtf8String {
+                    path: path.to_owned(),
+                });
+            }
+        },
+        Value::Binary(bytes) => FieldValue::Bytes(bytes),
+        Value::Array(items) => {
+            let mut elements = Vec::with_capacity(items.len());
+            for (index, item) in items.into_iter().enumerate() {
+                let elem_path = format!("{path}[{index}]");
+                let elem = convert_value(&elem_path, item)?;
+                if matches!(elem, FieldValue::Array(_)) {
+                    return Err(DecodeError::NonScalarArrayElement { path: elem_path });
+                }
+                elements.push(elem);
+            }
+            FieldValue::Array(elements)
+        }
+        Value::Map(_) => {
+            return Err(DecodeError::NestedMap {
+                path: path.to_owned(),
+            });
+        }
+        Value::Nil => {
+            return Err(DecodeError::UnsupportedValue {
+                path: path.to_owned(),
+                kind: "nil",
+            });
+        }
+        Value::Ext(_, _) => {
+            return Err(DecodeError::UnsupportedValue {
+                path: path.to_owned(),
+                kind: "ext",
+            });
+        }
+    })
+}

--- a/crates/midori-runtime/src/events_pipeline/mod.rs
+++ b/crates/midori-runtime/src/events_pipeline/mod.rs
@@ -1,0 +1,120 @@
+//! Inline payload を Layer 2 binding 入口まで運ぶ runtime パイプライン層。
+//!
+//! 役割は 3 段:
+//!
+//! 1. msgpack バイト列の decode（[`decode`] サブモジュール）
+//! 2. 1 イベント単位の events.yaml schema 照合（[`runtime_check`] サブモジュール）
+//! 3. 照合通過イベントを Layer 2 binding 側へ手渡す（本モジュールの [`EventSink`]）
+//!
+//! Layer 2 binding 本体は MEW-50 のスコープ外。本層は **stub I/F** として
+//! `EventSink` trait と最小実装 [`LoggingSink`] を提供し、後続の binding 実装
+//! で差し替える前提。
+//!
+//! 不正イベント（decode 失敗 / schema 違反 / events.yaml 未宣言 driver）は
+//! [`process_inline_payload`] が Error ログを出して drop する。パイプライン
+//! 全体は止めず、別 driver の処理は継続する。
+//!
+//! 構成:
+//!
+//! - [`decode`]: msgpack → [`DecodedPayload`]
+//! - [`runtime_check`]: [`DecodedPayload`] × `EventsSchema` → [`ValidatedEvent`]
+//! - 本ファイル: [`EventSink`] / [`LoggingSink`] / [`process_inline_payload`]
+//! - `tests`: 統合テスト
+
+// 本 module の公開 API は Bridge 起動 pipeline からまだ呼び出されておらず
+// （後続 subtask で接続予定）、binary crate 内の dead_code / unused_imports
+// 検出に引っかかるため module 全体で抑制する。実体は単体テストで網羅している。
+#![allow(dead_code, unused_imports)]
+
+mod decode;
+mod runtime_check;
+
+pub use decode::{decode_event, DecodeError, DecodedPayload, FieldValue};
+pub use runtime_check::{check_event, RuntimeCheckError, ValidatedEvent};
+
+use crate::events_schema::EventsSchema;
+
+/// Layer 2 binding が schema 照合通過後のイベントを受け取る接点。
+///
+/// 本 trait は MEW-50 段階の **stub**。実 binding 経路の I/F が固まり次第
+/// 差し替える（trait のままにするか、channel ベースへ移すかは後続 Issue で決定）。
+pub trait EventSink {
+    fn dispatch(&mut self, event: ValidatedEvent);
+}
+
+/// stderr に最小情報だけ書き出す `EventSink` の素朴実装。trace 用途。
+pub struct LoggingSink;
+
+impl EventSink for LoggingSink {
+    fn dispatch(&mut self, event: ValidatedEvent) {
+        eprintln!(
+            "midori: layer2-stub recv driver=`{}` type=`{}` fields={}",
+            event.driver_name,
+            event.event_type,
+            event.fields.len()
+        );
+    }
+}
+
+/// Decode → schema check → dispatch の 3 段を直列に実行する。
+///
+/// `schema` が `None` のとき、つまり driver の events.yaml がロード不能
+/// だったケースは 1 件単位で Error ログを出し drop する（schema が無いと
+/// 値検証ができないため、wire format が偶然正しくても受理しない）。caller
+/// が `LoadOutcome::Missing` を warning として扱いつつパイプラインを継続
+/// したい場合も、本関数は payload を sink へ流さない。
+pub fn process_inline_payload(
+    driver_name: &str,
+    schema: Option<&EventsSchema>,
+    payload: &[u8],
+    sink: &mut dyn EventSink,
+) {
+    match try_process(driver_name, schema, payload) {
+        Ok(event) => sink.dispatch(event),
+        Err(err) => eprintln!("midori: drop event from driver `{driver_name}`: {err}"),
+    }
+}
+
+/// `process_inline_payload` の純関数版。テストでログ捕捉に頼らず
+/// 失敗種別をパターンマッチで検査するために露出する。
+pub(crate) fn try_process(
+    driver_name: &str,
+    schema: Option<&EventsSchema>,
+    payload: &[u8],
+) -> Result<ValidatedEvent, ProcessError> {
+    let decoded = decode_event(payload).map_err(ProcessError::Decode)?;
+    let schema = schema.ok_or(ProcessError::SchemaMissing)?;
+    let event = check_event(driver_name, schema, decoded).map_err(ProcessError::Check)?;
+    Ok(event)
+}
+
+/// パイプラインの 3 段が出すエラーを集約した単一型（テスト・観測用）。
+#[derive(Debug)]
+pub(crate) enum ProcessError {
+    Decode(DecodeError),
+    SchemaMissing,
+    Check(RuntimeCheckError),
+}
+
+impl std::fmt::Display for ProcessError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Decode(source) => write!(f, "msgpack decode failed: {source}"),
+            Self::SchemaMissing => f.write_str("driver has no events.yaml schema loaded"),
+            Self::Check(source) => write!(f, "schema check failed: {source}"),
+        }
+    }
+}
+
+impl std::error::Error for ProcessError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Decode(source) => Some(source),
+            Self::Check(source) => Some(source),
+            Self::SchemaMissing => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/midori-runtime/src/events_pipeline/runtime_check.rs
+++ b/crates/midori-runtime/src/events_pipeline/runtime_check.rs
@@ -246,14 +246,42 @@ fn check_field(
     value: &FieldValue,
 ) -> Result<(), RuntimeCheckError> {
     match (&spec.ty, value) {
+        // 64-bit 整数は f64 経由だと precision loss で `i64::MAX + 1` 等を見逃す
+        // ため、整数演算で直接比較する。範囲は `range:` 宣言が無ければ型の最大幅。
+        (FieldType::Int64, FieldValue::Int(i)) => {
+            check_int64_bounds(event_type, field_name, spec.range.as_ref(), *i)?;
+        }
+        (FieldType::Int64, FieldValue::UInt(u)) => {
+            let Ok(i) = i64::try_from(*u) else {
+                return Err(out_of_range_for_int64(event_type, field_name, *u));
+            };
+            check_int64_bounds(event_type, field_name, spec.range.as_ref(), i)?;
+        }
+        (FieldType::Uint64, FieldValue::UInt(u)) => {
+            check_uint64_bounds(event_type, field_name, spec.range.as_ref(), *u)?;
+        }
+        (FieldType::Uint64, FieldValue::Int(i)) => {
+            // 負値は msgpack 上必ず Int になるため、ここで unsigned 型への
+            // 負値混入を弾く。正の signed は u64 へキャストして整数比較に流す。
+            if *i < 0 {
+                return Err(RuntimeCheckError::TypeMismatch {
+                    event_type: event_type.to_owned(),
+                    field: field_name.to_owned(),
+                    expected: ty_label(&spec.ty),
+                    actual: value_label(value),
+                });
+            }
+            #[allow(clippy::cast_sign_loss)]
+            let u = *i as u64;
+            check_uint64_bounds(event_type, field_name, spec.range.as_ref(), u)?;
+        }
+        // 32-bit 以下の整数 / 浮動小数は f64 比較で precision loss が起きないため
+        // 共通経路で扱う（mantissa 52 bit は i32 / u32 を完全に表現できる）。
         (
-            FieldType::Int8 | FieldType::Int16 | FieldType::Int32 | FieldType::Int64,
+            FieldType::Int8 | FieldType::Int16 | FieldType::Int32,
             FieldValue::Int(_) | FieldValue::UInt(_),
         )
-        | (
-            FieldType::Uint8 | FieldType::Uint16 | FieldType::Uint32 | FieldType::Uint64,
-            FieldValue::UInt(_),
-        )
+        | (FieldType::Uint8 | FieldType::Uint16 | FieldType::Uint32, FieldValue::UInt(_))
         | (
             FieldType::Float32 | FieldType::Float64,
             FieldValue::Float(_) | FieldValue::Int(_) | FieldValue::UInt(_),
@@ -261,10 +289,7 @@ fn check_field(
             let n = numeric_as_f64(value);
             check_numeric_range(event_type, field_name, &spec.ty, spec.range.as_ref(), n)?;
         }
-        (
-            FieldType::Uint8 | FieldType::Uint16 | FieldType::Uint32 | FieldType::Uint64,
-            FieldValue::Int(i),
-        ) => {
+        (FieldType::Uint8 | FieldType::Uint16 | FieldType::Uint32, FieldValue::Int(i)) => {
             // signed-positive を unsigned 型として受け入れる（負値は msgpack 上
             // 必ず Int になるため、ここで弾けば「unsigned 型に負値」を防げる）。
             if *i < 0 {
@@ -395,6 +420,107 @@ fn numeric_as_f64(value: &FieldValue) -> f64 {
         FieldValue::UInt(u) => *u as f64,
         FieldValue::Float(f) => *f,
         _ => unreachable!("caller has matched only on numeric variants"),
+    }
+}
+
+/// `Int64` フィールド値を整数演算で `range:`（または型のデフォルト i64 全域）
+/// と比較する。`f64` 経由だと `i64::MAX` 近傍の値が precision loss で誤って
+/// 通過してしまうため、本経路は f64 を使わない。
+fn check_int64_bounds(
+    event_type: &str,
+    field_name: &str,
+    range: Option<&RangeBound>,
+    value: i64,
+) -> Result<(), RuntimeCheckError> {
+    let (lo, hi) = int64_bounds_from_range(range);
+    if value < lo || value > hi {
+        #[allow(clippy::cast_precision_loss)]
+        return Err(RuntimeCheckError::OutOfRange {
+            event_type: event_type.to_owned(),
+            field: field_name.to_owned(),
+            value: value as f64,
+            lo: lo as f64,
+            hi: hi as f64,
+        });
+    }
+    Ok(())
+}
+
+/// `Uint64` フィールド値を整数演算で `range:`（または型のデフォルト u64 全域）
+/// と比較する。f64 を使わない理由は [`check_int64_bounds`] と同じ。
+fn check_uint64_bounds(
+    event_type: &str,
+    field_name: &str,
+    range: Option<&RangeBound>,
+    value: u64,
+) -> Result<(), RuntimeCheckError> {
+    let (lo, hi) = uint64_bounds_from_range(range);
+    if value < lo || value > hi {
+        #[allow(clippy::cast_precision_loss)]
+        return Err(RuntimeCheckError::OutOfRange {
+            event_type: event_type.to_owned(),
+            field: field_name.to_owned(),
+            value: value as f64,
+            lo: lo as f64,
+            hi: hi as f64,
+        });
+    }
+    Ok(())
+}
+
+/// `range:` を整数 i64 ペアに解決する。schema validator が範囲妥当性を担保
+/// しているため、ここでは「整数として読み取れない」（小数記法等）の場合は
+/// 安全側に倒して型のデフォルト全域へ fallback する。
+fn int64_bounds_from_range(range: Option<&RangeBound>) -> (i64, i64) {
+    range
+        .and_then(|r| {
+            let lo = yaml_as_i64(&r.min)?;
+            let hi = yaml_as_i64(&r.max)?;
+            if lo <= hi {
+                Some((lo, hi))
+            } else {
+                None
+            }
+        })
+        .unwrap_or((i64::MIN, i64::MAX))
+}
+
+fn uint64_bounds_from_range(range: Option<&RangeBound>) -> (u64, u64) {
+    range
+        .and_then(|r| {
+            let lo = yaml_as_u64(&r.min)?;
+            let hi = yaml_as_u64(&r.max)?;
+            if lo <= hi {
+                Some((lo, hi))
+            } else {
+                None
+            }
+        })
+        .unwrap_or((0, u64::MAX))
+}
+
+fn yaml_as_i64(v: &serde_yml::Value) -> Option<i64> {
+    match v {
+        serde_yml::Value::Number(n) => n.as_i64(),
+        _ => None,
+    }
+}
+
+fn yaml_as_u64(v: &serde_yml::Value) -> Option<u64> {
+    match v {
+        serde_yml::Value::Number(n) => n.as_u64(),
+        _ => None,
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn out_of_range_for_int64(event_type: &str, field_name: &str, value: u64) -> RuntimeCheckError {
+    RuntimeCheckError::OutOfRange {
+        event_type: event_type.to_owned(),
+        field: field_name.to_owned(),
+        value: value as f64,
+        lo: i64::MIN as f64,
+        hi: i64::MAX as f64,
     }
 }
 

--- a/crates/midori-runtime/src/events_pipeline/runtime_check.rs
+++ b/crates/midori-runtime/src/events_pipeline/runtime_check.rs
@@ -1,0 +1,442 @@
+//! Decode 後の payload を events.yaml schema と runtime 照合する層。
+//!
+//! 起動時 schema validator（`events_schema::validator`）が **schema 自身の
+//! 整合性** を検証するのに対し、本層は **driver が emit したイベント単位** で
+//! schema と raw event を突き合わせる。違反は `RuntimeCheckError` として
+//! 上位パイプラインに返し、上位は Error ログを出して drop する。
+//!
+//! 本層は `optional: true` のフィールドが欠落しているケースに **default 値を
+//! 埋める処理** は行わない。default 注入は Layer 2 binding 側で行う方針
+//! （wire 上で driver が省略した事実をパイプライン入口で残しておくため）。
+
+use std::collections::BTreeMap;
+
+use super::decode::{DecodedPayload, FieldValue};
+use crate::events_schema::{EventDef, EventsSchema, FieldSpec, FieldType, RangeBound};
+
+/// schema 照合を通過したイベント。Layer 2 binding の入口に渡す形。
+#[derive(Debug, PartialEq)]
+pub struct ValidatedEvent {
+    /// emit した driver の論理名（ログ／メトリクス用）。
+    pub driver_name: String,
+    /// events.yaml の最上位キーと一致するイベント種別。
+    pub event_type: String,
+    /// 検証済みフィールド。`type` discriminator は外して保持する。
+    pub fields: BTreeMap<String, FieldValue>,
+}
+
+/// Runtime 照合の失敗種別。
+#[derive(Debug, PartialEq)]
+pub enum RuntimeCheckError {
+    /// payload に `type` フィールドが無い。
+    MissingTypeField,
+    /// `type` の値が文字列ではない。
+    NonStringType,
+    /// `type` の値が events.yaml の最上位キーに存在しない。
+    UnknownEventType { event_type: String },
+    /// `optional: false` のフィールドが payload に無い。
+    RequiredFieldMissing { event_type: String, field: String },
+    /// schema に存在しないフィールドを driver が emit した。
+    UnexpectedField { event_type: String, field: String },
+    /// 値の msgpack 表現が宣言された events.yaml 型と互換でない。
+    TypeMismatch {
+        event_type: String,
+        field: String,
+        expected: &'static str,
+        actual: &'static str,
+    },
+    /// 数値が `range:` または型のデフォルト値域を外れた。
+    OutOfRange {
+        event_type: String,
+        field: String,
+        value: f64,
+        lo: f64,
+        hi: f64,
+    },
+    /// `enum` 型の値が `values:` リストに含まれていない。
+    EnumValueNotAllowed {
+        event_type: String,
+        field: String,
+        value: String,
+    },
+    /// `string` / `bytes` / `array<T>` の長さが `max_length` を超えた。
+    MaxLengthExceeded {
+        event_type: String,
+        field: String,
+        len: u64,
+        max: u64,
+    },
+}
+
+impl std::fmt::Display for RuntimeCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingTypeField => f.write_str("payload is missing the `type` field"),
+            Self::NonStringType => f.write_str("`type` field must be a string"),
+            Self::UnknownEventType { event_type } => {
+                write!(f, "unknown event type `{event_type}`")
+            }
+            Self::RequiredFieldMissing { event_type, field } => {
+                write!(f, "event `{event_type}` is missing required field `{field}`")
+            }
+            Self::UnexpectedField { event_type, field } => {
+                write!(
+                    f,
+                    "event `{event_type}` carries unexpected field `{field}`"
+                )
+            }
+            Self::TypeMismatch {
+                event_type,
+                field,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "event `{event_type}` field `{field}`: expected `{expected}`, got `{actual}`"
+            ),
+            Self::OutOfRange {
+                event_type,
+                field,
+                value,
+                lo,
+                hi,
+            } => write!(
+                f,
+                "event `{event_type}` field `{field}`: value {value} is outside [{lo}, {hi}]"
+            ),
+            Self::EnumValueNotAllowed {
+                event_type,
+                field,
+                value,
+            } => write!(
+                f,
+                "event `{event_type}` field `{field}`: enum value `{value}` is not in the declared `values:` list"
+            ),
+            Self::MaxLengthExceeded {
+                event_type,
+                field,
+                len,
+                max,
+            } => write!(
+                f,
+                "event `{event_type}` field `{field}`: length {len} exceeds `max_length` {max}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeCheckError {}
+
+/// `decoded` を `schema` と照合し、合致すれば [`ValidatedEvent`] を返す。
+///
+/// `defaults` 宣言のフィールドは「全イベント共通の暗黙フィールド」として
+/// 各 event のフィールドにマージして検査する（`event.fields` 側が同名キーで
+/// shadow できる、validator と同じ規則）。
+pub fn check_event(
+    driver_name: &str,
+    schema: &EventsSchema,
+    decoded: DecodedPayload,
+) -> Result<ValidatedEvent, RuntimeCheckError> {
+    let event_type = extract_event_type(&decoded)?;
+    let event_def =
+        schema
+            .events
+            .get(&event_type)
+            .ok_or_else(|| RuntimeCheckError::UnknownEventType {
+                event_type: event_type.clone(),
+            })?;
+
+    let merged_specs = merge_field_specs(event_def, &schema.defaults);
+
+    check_unexpected_fields(&event_type, &decoded, &merged_specs)?;
+    check_required_fields(&event_type, &decoded, &merged_specs)?;
+    check_field_values(&event_type, &decoded, &merged_specs)?;
+
+    let mut fields = decoded;
+    fields.remove("type");
+    Ok(ValidatedEvent {
+        driver_name: driver_name.to_owned(),
+        event_type,
+        fields,
+    })
+}
+
+fn extract_event_type(decoded: &DecodedPayload) -> Result<String, RuntimeCheckError> {
+    let raw = decoded
+        .get("type")
+        .ok_or(RuntimeCheckError::MissingTypeField)?;
+    match raw {
+        FieldValue::String(s) => Ok(s.clone()),
+        _ => Err(RuntimeCheckError::NonStringType),
+    }
+}
+
+fn merge_field_specs<'a>(
+    event_def: &'a EventDef,
+    defaults: &'a BTreeMap<String, FieldSpec>,
+) -> BTreeMap<&'a str, &'a FieldSpec> {
+    // defaults を base に置き、event.fields で上書き（events_schema::validator と同じ規則）
+    defaults
+        .iter()
+        .chain(event_def.fields.iter())
+        .map(|(k, v)| (k.as_str(), v))
+        .collect()
+}
+
+fn check_unexpected_fields(
+    event_type: &str,
+    decoded: &DecodedPayload,
+    merged: &BTreeMap<&str, &FieldSpec>,
+) -> Result<(), RuntimeCheckError> {
+    for field_name in decoded.keys() {
+        if field_name == "type" {
+            continue;
+        }
+        if !merged.contains_key(field_name.as_str()) {
+            return Err(RuntimeCheckError::UnexpectedField {
+                event_type: event_type.to_owned(),
+                field: field_name.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn check_required_fields(
+    event_type: &str,
+    decoded: &DecodedPayload,
+    merged: &BTreeMap<&str, &FieldSpec>,
+) -> Result<(), RuntimeCheckError> {
+    for (field_name, spec) in merged {
+        if spec.optional {
+            continue;
+        }
+        if !decoded.contains_key(*field_name) {
+            return Err(RuntimeCheckError::RequiredFieldMissing {
+                event_type: event_type.to_owned(),
+                field: (*field_name).to_owned(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn check_field_values(
+    event_type: &str,
+    decoded: &DecodedPayload,
+    merged: &BTreeMap<&str, &FieldSpec>,
+) -> Result<(), RuntimeCheckError> {
+    for (field_name, value) in decoded {
+        if field_name == "type" {
+            continue;
+        }
+        let spec = merged
+            .get(field_name.as_str())
+            .copied()
+            .expect("unexpected fields were rejected earlier");
+        check_field(event_type, field_name, spec, value)?;
+    }
+    Ok(())
+}
+
+fn check_field(
+    event_type: &str,
+    field_name: &str,
+    spec: &FieldSpec,
+    value: &FieldValue,
+) -> Result<(), RuntimeCheckError> {
+    match (&spec.ty, value) {
+        (
+            FieldType::Int8 | FieldType::Int16 | FieldType::Int32 | FieldType::Int64,
+            FieldValue::Int(_) | FieldValue::UInt(_),
+        )
+        | (
+            FieldType::Uint8 | FieldType::Uint16 | FieldType::Uint32 | FieldType::Uint64,
+            FieldValue::UInt(_),
+        )
+        | (
+            FieldType::Float32 | FieldType::Float64,
+            FieldValue::Float(_) | FieldValue::Int(_) | FieldValue::UInt(_),
+        ) => {
+            let n = numeric_as_f64(value);
+            check_numeric_range(event_type, field_name, &spec.ty, spec.range.as_ref(), n)?;
+        }
+        (
+            FieldType::Uint8 | FieldType::Uint16 | FieldType::Uint32 | FieldType::Uint64,
+            FieldValue::Int(i),
+        ) => {
+            // signed-positive を unsigned 型として受け入れる（負値は msgpack 上
+            // 必ず Int になるため、ここで弾けば「unsigned 型に負値」を防げる）。
+            if *i < 0 {
+                return Err(RuntimeCheckError::TypeMismatch {
+                    event_type: event_type.to_owned(),
+                    field: field_name.to_owned(),
+                    expected: ty_label(&spec.ty),
+                    actual: value_label(value),
+                });
+            }
+            #[allow(clippy::cast_precision_loss)]
+            let n = *i as f64;
+            check_numeric_range(event_type, field_name, &spec.ty, spec.range.as_ref(), n)?;
+        }
+        (FieldType::Bool, FieldValue::Bool(_)) => {}
+        (FieldType::String, FieldValue::String(s)) => {
+            check_max_length(event_type, field_name, spec.max_length, s.len() as u64)?;
+        }
+        (FieldType::Bytes, FieldValue::Bytes(b)) => {
+            check_max_length(event_type, field_name, spec.max_length, b.len() as u64)?;
+        }
+        (FieldType::Enum, FieldValue::String(s)) => {
+            check_enum_value(event_type, field_name, spec.values.as_deref(), s)?;
+        }
+        (FieldType::Array(inner_ty), FieldValue::Array(items)) => {
+            check_max_length(event_type, field_name, spec.max_length, items.len() as u64)?;
+            // 配列要素は `range` / `values` / `max_length` を持たない（events.yaml
+            // の `array<T>` の T はスカラー語彙なので、要素検査は型と型のデフォルト値域だけで足りる）。
+            let element_spec = FieldSpec {
+                ty: (**inner_ty).clone(),
+                range: None,
+                values: None,
+                max_length: None,
+                optional: false,
+                default: None,
+            };
+            for (index, element) in items.iter().enumerate() {
+                let element_field = format!("{field_name}[{index}]");
+                check_field(event_type, &element_field, &element_spec, element)?;
+            }
+        }
+        _ => {
+            return Err(RuntimeCheckError::TypeMismatch {
+                event_type: event_type.to_owned(),
+                field: field_name.to_owned(),
+                expected: ty_label(&spec.ty),
+                actual: value_label(value),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn check_numeric_range(
+    event_type: &str,
+    field_name: &str,
+    ty: &FieldType,
+    range: Option<&RangeBound>,
+    value: f64,
+) -> Result<(), RuntimeCheckError> {
+    let bound = range
+        .and_then(|r| {
+            let lo = yaml_to_f64(&r.min)?;
+            let hi = yaml_to_f64(&r.max)?;
+            if lo.is_finite() && hi.is_finite() && lo <= hi {
+                Some((lo, hi))
+            } else {
+                None
+            }
+        })
+        .or_else(|| ty.default_range());
+    let Some((lo, hi)) = bound else {
+        return Ok(());
+    };
+    if value.is_nan() || value < lo || value > hi {
+        return Err(RuntimeCheckError::OutOfRange {
+            event_type: event_type.to_owned(),
+            field: field_name.to_owned(),
+            value,
+            lo,
+            hi,
+        });
+    }
+    Ok(())
+}
+
+fn check_max_length(
+    event_type: &str,
+    field_name: &str,
+    max: Option<u64>,
+    len: u64,
+) -> Result<(), RuntimeCheckError> {
+    let Some(max) = max else { return Ok(()) };
+    if len > max {
+        return Err(RuntimeCheckError::MaxLengthExceeded {
+            event_type: event_type.to_owned(),
+            field: field_name.to_owned(),
+            len,
+            max,
+        });
+    }
+    Ok(())
+}
+
+fn check_enum_value(
+    event_type: &str,
+    field_name: &str,
+    values: Option<&[String]>,
+    actual: &str,
+) -> Result<(), RuntimeCheckError> {
+    // schema validator が enum に必ず values を要求するため None は schema 違反だが、
+    // 防衛的に処理する（schema check 抜きで本層を直接呼ぶ caller の保護）。
+    let Some(values) = values else { return Ok(()) };
+    if values.iter().any(|v| v == actual) {
+        return Ok(());
+    }
+    Err(RuntimeCheckError::EnumValueNotAllowed {
+        event_type: event_type.to_owned(),
+        field: field_name.to_owned(),
+        value: actual.to_owned(),
+    })
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn numeric_as_f64(value: &FieldValue) -> f64 {
+    match value {
+        FieldValue::Int(i) => *i as f64,
+        FieldValue::UInt(u) => *u as f64,
+        FieldValue::Float(f) => *f,
+        _ => unreachable!("caller has matched only on numeric variants"),
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn yaml_to_f64(v: &serde_yml::Value) -> Option<f64> {
+    match v {
+        serde_yml::Value::Number(n) => n
+            .as_f64()
+            .or_else(|| n.as_i64().map(|i| i as f64))
+            .or_else(|| n.as_u64().map(|u| u as f64)),
+        _ => None,
+    }
+}
+
+fn ty_label(ty: &FieldType) -> &'static str {
+    match ty {
+        FieldType::Int8 => "int8",
+        FieldType::Uint8 => "uint8",
+        FieldType::Int16 => "int16",
+        FieldType::Uint16 => "uint16",
+        FieldType::Int32 => "int32",
+        FieldType::Uint32 => "uint32",
+        FieldType::Int64 => "int64",
+        FieldType::Uint64 => "uint64",
+        FieldType::Float32 => "float32",
+        FieldType::Float64 => "float64",
+        FieldType::Bool => "bool",
+        FieldType::String => "string",
+        FieldType::Bytes => "bytes",
+        FieldType::Enum => "enum",
+        FieldType::Array(_) => "array",
+    }
+}
+
+fn value_label(value: &FieldValue) -> &'static str {
+    match value {
+        FieldValue::Bool(_) => "bool",
+        FieldValue::Int(_) => "int",
+        FieldValue::UInt(_) => "uint",
+        FieldValue::Float(_) => "float",
+        FieldValue::String(_) => "string",
+        FieldValue::Bytes(_) => "bytes",
+        FieldValue::Array(_) => "array",
+    }
+}

--- a/crates/midori-runtime/src/events_pipeline/runtime_check.rs
+++ b/crates/midori-runtime/src/events_pipeline/runtime_check.rs
@@ -12,7 +12,7 @@
 use std::collections::BTreeMap;
 
 use super::decode::{DecodedPayload, FieldValue};
-use crate::events_schema::{EventDef, EventsSchema, FieldSpec, FieldType, RangeBound};
+use crate::events_schema::{yaml_to_f64, EventDef, EventsSchema, FieldSpec, FieldType, RangeBound};
 
 /// schema 照合を通過したイベント。Layer 2 binding の入口に渡す形。
 #[derive(Debug, PartialEq)]
@@ -395,17 +395,6 @@ fn numeric_as_f64(value: &FieldValue) -> f64 {
         FieldValue::UInt(u) => *u as f64,
         FieldValue::Float(f) => *f,
         _ => unreachable!("caller has matched only on numeric variants"),
-    }
-}
-
-#[allow(clippy::cast_precision_loss)]
-fn yaml_to_f64(v: &serde_yml::Value) -> Option<f64> {
-    match v {
-        serde_yml::Value::Number(n) => n
-            .as_f64()
-            .or_else(|| n.as_i64().map(|i| i as f64))
-            .or_else(|| n.as_u64().map(|u| u as f64)),
-        _ => None,
     }
 }
 

--- a/crates/midori-runtime/src/events_pipeline/tests.rs
+++ b/crates/midori-runtime/src/events_pipeline/tests.rs
@@ -1,0 +1,527 @@
+//! `events_pipeline` 全層の統合テスト。
+//!
+//! - `decode` 単独: msgpack バイト列の境界条件
+//! - `runtime_check` 単独: schema 違反検出の網羅
+//! - パイプライン (`process_inline_payload` / `try_process`): stub `EventSink`
+//!   との結合、events.yaml 未ロード時の drop 挙動
+
+use std::collections::BTreeMap;
+
+use rmpv::Value;
+
+use super::decode::{decode_event, DecodeError, FieldValue};
+use super::runtime_check::{check_event, RuntimeCheckError, ValidatedEvent};
+use super::{process_inline_payload, try_process, EventSink, ProcessError};
+use crate::events_schema::EventsSchema;
+
+// ============================================================
+// fixtures
+// ============================================================
+
+/// テストで何度も使う MIDI 風の events.yaml を 1 箇所に固める。
+/// `noteOn` / `realtime`（enum）/ `sysex`（bytes `max_length`）の 3 イベントで
+/// runtime check の主要分岐を踏める。
+fn midi_schema() -> EventsSchema {
+    let yaml = r"
+schema_version: 1
+events:
+  noteOn:
+    fields:
+      channel:  { type: uint8, range: [1, 16] }
+      note:     { type: uint8, range: [0, 127] }
+      velocity: { type: uint8, range: [0, 127] }
+    binding_filter: [type, channel]
+    note_field: note
+  realtime:
+    fields:
+      message: { type: enum, values: [start, stop, continue, clock] }
+    binding_filter: [type, message]
+  sysex:
+    fields:
+      payload: { type: bytes, max_length: 8 }
+    binding_filter: [type]
+";
+    serde_yml::from_str(yaml).expect("fixture parses")
+}
+
+fn encode_map(entries: &[(&str, Value)]) -> Vec<u8> {
+    let value = Value::Map(
+        entries
+            .iter()
+            .map(|(k, v)| (Value::String((*k).into()), v.clone()))
+            .collect(),
+    );
+    let mut buf = Vec::new();
+    rmpv::encode::write_value(&mut buf, &value).expect("encode test fixture");
+    buf
+}
+
+#[derive(Default)]
+struct RecordingSink {
+    events: Vec<ValidatedEvent>,
+}
+
+impl EventSink for RecordingSink {
+    fn dispatch(&mut self, event: ValidatedEvent) {
+        self.events.push(event);
+    }
+}
+
+// ============================================================
+// decode unit tests
+// ============================================================
+
+#[test]
+fn it_should_decode_a_flat_msgpack_map_into_field_values() {
+    let bytes = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("channel", Value::from(1u8)),
+        ("note", Value::from(60u8)),
+        ("velocity", Value::from(100u8)),
+    ]);
+
+    let decoded = decode_event(&bytes).expect("valid map decodes");
+
+    assert_eq!(
+        decoded.get("type"),
+        Some(&FieldValue::String("noteOn".into()))
+    );
+    assert_eq!(decoded.get("channel"), Some(&FieldValue::UInt(1)));
+    assert_eq!(decoded.get("note"), Some(&FieldValue::UInt(60)));
+    assert_eq!(decoded.get("velocity"), Some(&FieldValue::UInt(100)));
+}
+
+#[test]
+fn it_should_decode_negative_integers_as_signed() {
+    let bytes = encode_map(&[
+        ("type", Value::String("pitchBend".into())),
+        ("value", Value::from(-4096i32)),
+    ]);
+
+    let decoded = decode_event(&bytes).expect("decodes");
+    assert_eq!(decoded.get("value"), Some(&FieldValue::Int(-4096)));
+}
+
+#[test]
+fn it_should_reject_non_map_top_level() {
+    let mut buf = Vec::new();
+    rmpv::encode::write_value(&mut buf, &Value::from(42u8)).expect("encode");
+
+    let err = decode_event(&buf).expect_err("non-map must be rejected");
+    assert!(
+        matches!(err, DecodeError::NotAMap),
+        "expected NotAMap, got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_reject_truncated_msgpack() {
+    let bytes = encode_map(&[("type", Value::String("noteOn".into()))]);
+    let truncated = &bytes[..bytes.len() - 1];
+
+    let err = decode_event(truncated).expect_err("truncated must fail to parse");
+    assert!(
+        matches!(err, DecodeError::Parse(_)),
+        "expected Parse, got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_reject_trailing_bytes_after_top_level_map() {
+    let mut bytes = encode_map(&[("type", Value::String("noteOn".into()))]);
+    bytes.push(0xc0); // extra msgpack nil
+
+    let err = decode_event(&bytes).expect_err("trailing bytes must be rejected");
+    assert!(
+        matches!(err, DecodeError::TrailingBytes),
+        "expected TrailingBytes, got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_reject_non_string_map_keys() {
+    // map with integer key 1 → "noteOn"
+    let value = Value::Map(vec![(Value::from(1u8), Value::String("noteOn".into()))]);
+    let mut buf = Vec::new();
+    rmpv::encode::write_value(&mut buf, &value).expect("encode");
+
+    let err = decode_event(&buf).expect_err("non-string key must be rejected");
+    assert!(
+        matches!(err, DecodeError::NonStringKey),
+        "expected NonStringKey, got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_reject_nil_field_values() {
+    let bytes = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("channel", Value::Nil),
+    ]);
+
+    let err = decode_event(&bytes).expect_err("nil must be rejected");
+    assert!(
+        matches!(err, DecodeError::UnsupportedValue { kind: "nil", .. }),
+        "expected UnsupportedValue(nil), got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_reject_nested_maps_inside_a_field() {
+    let nested = Value::Map(vec![(Value::String("x".into()), Value::from(1u8))]);
+    let bytes = encode_map(&[("type", Value::String("noteOn".into())), ("inner", nested)]);
+
+    let err = decode_event(&bytes).expect_err("nested map must be rejected");
+    assert!(
+        matches!(err, DecodeError::NestedMap { .. }),
+        "expected NestedMap, got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_reject_arrays_whose_elements_are_arrays() {
+    let inner = Value::Array(vec![Value::from(1u8)]);
+    let bytes = encode_map(&[
+        ("type", Value::String("nested".into())),
+        ("nums", Value::Array(vec![inner])),
+    ]);
+
+    let err = decode_event(&bytes).expect_err("array<array> must be rejected");
+    assert!(
+        matches!(err, DecodeError::NonScalarArrayElement { .. }),
+        "expected NonScalarArrayElement, got {err:?}"
+    );
+}
+
+// ============================================================
+// runtime_check unit tests
+// ============================================================
+
+fn payload(entries: &[(&str, FieldValue)]) -> BTreeMap<String, FieldValue> {
+    entries
+        .iter()
+        .map(|(k, v)| ((*k).to_owned(), v.clone()))
+        .collect()
+}
+
+#[test]
+fn it_should_accept_a_valid_noteon_event_and_strip_the_type_discriminator() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("noteOn".into())),
+        ("channel", FieldValue::UInt(1)),
+        ("note", FieldValue::UInt(60)),
+        ("velocity", FieldValue::UInt(100)),
+    ]);
+
+    let event = check_event("midi", &schema, p).expect("valid event passes");
+
+    assert_eq!(event.driver_name, "midi");
+    assert_eq!(event.event_type, "noteOn");
+    // `type` discriminator は ValidatedEvent.fields からは外れている
+    assert!(!event.fields.contains_key("type"));
+    assert_eq!(event.fields.len(), 3);
+}
+
+#[test]
+fn it_should_reject_payloads_without_a_type_field() {
+    let schema = midi_schema();
+    let p = payload(&[("channel", FieldValue::UInt(1))]);
+
+    let err = check_event("midi", &schema, p).expect_err("type missing");
+    assert_eq!(err, RuntimeCheckError::MissingTypeField);
+}
+
+#[test]
+fn it_should_reject_payloads_whose_type_is_not_a_string() {
+    let schema = midi_schema();
+    let p = payload(&[("type", FieldValue::UInt(42))]);
+
+    let err = check_event("midi", &schema, p).expect_err("type must be string");
+    assert_eq!(err, RuntimeCheckError::NonStringType);
+}
+
+#[test]
+fn it_should_reject_unknown_event_types() {
+    let schema = midi_schema();
+    let p = payload(&[("type", FieldValue::String("unknownEvent".into()))]);
+
+    let err = check_event("midi", &schema, p).expect_err("unknown type");
+    assert_eq!(
+        err,
+        RuntimeCheckError::UnknownEventType {
+            event_type: "unknownEvent".into()
+        }
+    );
+}
+
+#[test]
+fn it_should_reject_when_a_required_field_is_missing() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("noteOn".into())),
+        ("channel", FieldValue::UInt(1)),
+        ("note", FieldValue::UInt(60)),
+        // velocity 抜け
+    ]);
+
+    let err = check_event("midi", &schema, p).expect_err("missing required");
+    assert_eq!(
+        err,
+        RuntimeCheckError::RequiredFieldMissing {
+            event_type: "noteOn".into(),
+            field: "velocity".into(),
+        }
+    );
+}
+
+#[test]
+fn it_should_reject_unexpected_fields() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("noteOn".into())),
+        ("channel", FieldValue::UInt(1)),
+        ("note", FieldValue::UInt(60)),
+        ("velocity", FieldValue::UInt(100)),
+        ("ghost", FieldValue::UInt(0)),
+    ]);
+
+    let err = check_event("midi", &schema, p).expect_err("unexpected field");
+    assert_eq!(
+        err,
+        RuntimeCheckError::UnexpectedField {
+            event_type: "noteOn".into(),
+            field: "ghost".into(),
+        }
+    );
+}
+
+#[test]
+fn it_should_reject_values_outside_the_declared_range() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("noteOn".into())),
+        ("channel", FieldValue::UInt(0)), // range [1, 16] の外
+        ("note", FieldValue::UInt(60)),
+        ("velocity", FieldValue::UInt(100)),
+    ]);
+
+    let err = check_event("midi", &schema, p).expect_err("range violation");
+    let RuntimeCheckError::OutOfRange {
+        event_type, field, ..
+    } = err
+    else {
+        panic!("expected OutOfRange, got {err:?}");
+    };
+    assert_eq!(event_type, "noteOn");
+    assert_eq!(field, "channel");
+}
+
+#[test]
+fn it_should_reject_values_outside_the_types_default_range_when_no_explicit_range() {
+    // `range:` 宣言が無いケースでも型のデフォルト値域に収まらない値は弾く必要がある。
+    let yaml = r"
+schema_version: 1
+events:
+  raw:
+    fields:
+      v: { type: uint8 }
+    binding_filter: [type]
+";
+    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+    let p = payload(&[
+        ("type", FieldValue::String("raw".into())),
+        ("v", FieldValue::UInt(300)), // uint8 default は 0..=255
+    ]);
+
+    let err = check_event("drv", &schema, p).expect_err("uint8 default range");
+    assert!(matches!(err, RuntimeCheckError::OutOfRange { .. }));
+}
+
+#[test]
+fn it_should_reject_signed_negative_for_unsigned_field() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("noteOn".into())),
+        ("channel", FieldValue::Int(-1)),
+        ("note", FieldValue::UInt(60)),
+        ("velocity", FieldValue::UInt(100)),
+    ]);
+
+    let err = check_event("midi", &schema, p).expect_err("negative for uint");
+    assert!(
+        matches!(err, RuntimeCheckError::TypeMismatch { .. }),
+        "expected TypeMismatch, got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_reject_enum_values_not_in_the_declared_list() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("realtime".into())),
+        ("message", FieldValue::String("rewind".into())),
+    ]);
+
+    let err = check_event("midi", &schema, p).expect_err("bad enum value");
+    let RuntimeCheckError::EnumValueNotAllowed { value, .. } = err else {
+        panic!("expected EnumValueNotAllowed, got {err:?}");
+    };
+    assert_eq!(value, "rewind");
+}
+
+#[test]
+fn it_should_reject_bytes_payloads_that_exceed_max_length() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("sysex".into())),
+        ("payload", FieldValue::Bytes(vec![0u8; 9])), // max_length: 8
+    ]);
+
+    let err = check_event("midi", &schema, p).expect_err("max_length");
+    assert_eq!(
+        err,
+        RuntimeCheckError::MaxLengthExceeded {
+            event_type: "sysex".into(),
+            field: "payload".into(),
+            len: 9,
+            max: 8,
+        }
+    );
+}
+
+#[test]
+fn it_should_reject_field_with_wrong_kind() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("realtime".into())),
+        ("message", FieldValue::UInt(0)), // enum 期待で UInt
+    ]);
+
+    let err = check_event("midi", &schema, p).expect_err("type mismatch");
+    let RuntimeCheckError::TypeMismatch {
+        expected, actual, ..
+    } = err
+    else {
+        panic!("expected TypeMismatch, got {err:?}");
+    };
+    assert_eq!(expected, "enum");
+    assert_eq!(actual, "uint");
+}
+
+#[test]
+fn it_should_apply_defaults_block_required_check_to_every_event() {
+    // defaults 宣言の required field は全 event で required 扱い。
+    let yaml = r"
+schema_version: 1
+defaults:
+  ts: { type: uint64 }
+events:
+  ping:
+    fields:
+      payload: { type: uint8 }
+    binding_filter: [type]
+";
+    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+
+    // ts 抜けは required missing
+    let missing = payload(&[
+        ("type", FieldValue::String("ping".into())),
+        ("payload", FieldValue::UInt(7)),
+    ]);
+    let err = check_event("drv", &schema, missing).expect_err("ts required");
+    assert_eq!(
+        err,
+        RuntimeCheckError::RequiredFieldMissing {
+            event_type: "ping".into(),
+            field: "ts".into(),
+        }
+    );
+
+    // ts 同梱なら通る
+    let ok = payload(&[
+        ("type", FieldValue::String("ping".into())),
+        ("payload", FieldValue::UInt(7)),
+        ("ts", FieldValue::UInt(123_456)),
+    ]);
+    check_event("drv", &schema, ok).expect("with ts passes");
+}
+
+// ============================================================
+// pipeline glue tests (integration)
+// ============================================================
+
+#[test]
+fn it_should_route_a_valid_event_all_the_way_to_the_layer2_stub() {
+    let schema = midi_schema();
+    let bytes = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("channel", Value::from(1u8)),
+        ("note", Value::from(60u8)),
+        ("velocity", Value::from(100u8)),
+    ]);
+
+    let mut sink = RecordingSink::default();
+    process_inline_payload("midi", Some(&schema), &bytes, &mut sink);
+
+    assert_eq!(sink.events.len(), 1);
+    assert_eq!(sink.events[0].event_type, "noteOn");
+    assert_eq!(sink.events[0].driver_name, "midi");
+}
+
+#[test]
+fn it_should_drop_malformed_msgpack_without_invoking_the_sink() {
+    let schema = midi_schema();
+    let bogus = vec![0xc1u8]; // msgpack reserved tag → parse error
+
+    let mut sink = RecordingSink::default();
+    process_inline_payload("midi", Some(&schema), &bogus, &mut sink);
+
+    assert!(sink.events.is_empty(), "decode failure must drop the event");
+
+    let err = try_process("midi", Some(&schema), &bogus).expect_err("decode fails");
+    assert!(matches!(err, ProcessError::Decode(_)));
+}
+
+#[test]
+fn it_should_drop_schema_violating_events_without_invoking_the_sink() {
+    let schema = midi_schema();
+    let bytes = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("channel", Value::from(1u8)),
+        ("note", Value::from(60u8)),
+        ("velocity", Value::from(200u8)), // range 外
+    ]);
+
+    let mut sink = RecordingSink::default();
+    process_inline_payload("midi", Some(&schema), &bytes, &mut sink);
+
+    assert!(sink.events.is_empty());
+
+    let err = try_process("midi", Some(&schema), &bytes).expect_err("schema fails");
+    let ProcessError::Check(check_err) = err else {
+        panic!("expected ProcessError::Check, got {err:?}");
+    };
+    assert!(matches!(check_err, RuntimeCheckError::OutOfRange { .. }));
+}
+
+#[test]
+fn it_should_drop_events_when_the_drivers_schema_is_unavailable() {
+    let bytes = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("channel", Value::from(1u8)),
+        ("note", Value::from(60u8)),
+        ("velocity", Value::from(100u8)),
+    ]);
+
+    let mut sink = RecordingSink::default();
+    process_inline_payload("midi", None, &bytes, &mut sink);
+
+    assert!(
+        sink.events.is_empty(),
+        "events.yaml が無い driver の event は全件 drop される"
+    );
+
+    let err = try_process("midi", None, &bytes).expect_err("schema missing");
+    assert!(matches!(err, ProcessError::SchemaMissing));
+}

--- a/crates/midori-runtime/src/events_pipeline/tests.rs
+++ b/crates/midori-runtime/src/events_pipeline/tests.rs
@@ -167,6 +167,22 @@ fn it_should_reject_nil_field_values() {
 }
 
 #[test]
+fn it_should_reject_msgpack_ext_field_values() {
+    // ext type は events.yaml 語彙外。`Value::Ext(type_id, payload)` を 1 件
+    // でも含む payload は decode 時点で reject されることを担保する。
+    let bytes = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("custom", Value::Ext(42, vec![0xde, 0xad, 0xbe, 0xef])),
+    ]);
+
+    let err = decode_event(&bytes).expect_err("ext must be rejected");
+    assert!(
+        matches!(err, DecodeError::UnsupportedValue { kind: "ext", .. }),
+        "expected UnsupportedValue(ext), got {err:?}"
+    );
+}
+
+#[test]
 fn it_should_reject_nested_maps_inside_a_field() {
     let nested = Value::Map(vec![(Value::String("x".into()), Value::from(1u8))]);
     let bytes = encode_map(&[("type", Value::String("noteOn".into())), ("inner", nested)]);
@@ -597,6 +613,45 @@ fn it_should_drop_schema_violating_events_without_invoking_the_sink() {
         panic!("expected ProcessError::Check, got {err:?}");
     };
     assert!(matches!(check_err, RuntimeCheckError::OutOfRange { .. }));
+}
+
+#[test]
+fn it_should_continue_processing_after_dropping_an_invalid_event() {
+    // 不正イベントを drop した後でも次の有効イベントが sink に届く（=
+    // pipeline は止まらない）ことを連続呼び出しで担保する。同じ sink を
+    // 共有することで「process_inline_payload が内部状態を持たず、失敗が
+    // 後続呼び出しを汚染しない」契約を回帰として固定する。
+    let schema = midi_schema();
+    let mut sink = RecordingSink::default();
+
+    // 1 件目: schema 違反（velocity が range 外）
+    let invalid = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("channel", Value::from(1u8)),
+        ("note", Value::from(60u8)),
+        ("velocity", Value::from(200u8)),
+    ]);
+    process_inline_payload("midi", Some(&schema), &invalid, &mut sink);
+    assert!(
+        sink.events.is_empty(),
+        "schema 違反は sink に届かない（drop）"
+    );
+
+    // 2 件目: 正常イベント
+    let valid = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("channel", Value::from(1u8)),
+        ("note", Value::from(60u8)),
+        ("velocity", Value::from(100u8)),
+    ]);
+    process_inline_payload("midi", Some(&schema), &valid, &mut sink);
+
+    assert_eq!(
+        sink.events.len(),
+        1,
+        "drop 後も後続イベントは dispatch される"
+    );
+    assert_eq!(sink.events[0].event_type, "noteOn");
 }
 
 #[test]

--- a/crates/midori-runtime/src/events_pipeline/tests.rs
+++ b/crates/midori-runtime/src/events_pipeline/tests.rs
@@ -410,6 +410,100 @@ fn it_should_reject_field_with_wrong_kind() {
 }
 
 #[test]
+fn it_should_reject_uint_value_above_i64_max_for_int64_field() {
+    // f64 経由の比較だと `i64::MAX` と `i64::MAX as u64 + 1` が同じ値に丸まり、
+    // out-of-range が誤って通過する。整数比較で確実に reject されることを担保する。
+    let yaml = r"
+schema_version: 1
+events:
+  ping:
+    fields:
+      v: { type: int64 }
+    binding_filter: [type]
+";
+    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+
+    #[allow(clippy::cast_sign_loss)]
+    let just_above_i64_max: u64 = i64::MAX as u64 + 1;
+    let p = payload(&[
+        ("type", FieldValue::String("ping".into())),
+        ("v", FieldValue::UInt(just_above_i64_max)),
+    ]);
+
+    let err = check_event("drv", &schema, p).expect_err("UInt > i64::MAX must be rejected");
+    assert!(
+        matches!(err, RuntimeCheckError::OutOfRange { .. }),
+        "expected OutOfRange, got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_accept_i64_max_as_int64_field() {
+    let yaml = r"
+schema_version: 1
+events:
+  ping:
+    fields:
+      v: { type: int64 }
+    binding_filter: [type]
+";
+    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+
+    #[allow(clippy::cast_sign_loss)]
+    let i64_max_as_u: u64 = i64::MAX as u64;
+    let p = payload(&[
+        ("type", FieldValue::String("ping".into())),
+        ("v", FieldValue::UInt(i64_max_as_u)),
+    ]);
+
+    check_event("drv", &schema, p).expect("i64::MAX exact must pass");
+}
+
+#[test]
+fn it_should_reject_uint64_value_above_explicit_range_with_integer_precision() {
+    // `range: [0, 9000000000000000000]` の境界 +1 は f64 では同一に丸まるが、
+    // 整数比較なら確実に弾ける。
+    let yaml = r"
+schema_version: 1
+events:
+  ping:
+    fields:
+      v: { type: uint64, range: [0, 9000000000000000000] }
+    binding_filter: [type]
+";
+    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+
+    let p = payload(&[
+        ("type", FieldValue::String("ping".into())),
+        ("v", FieldValue::UInt(9_000_000_000_000_000_001)),
+    ]);
+
+    let err = check_event("drv", &schema, p).expect_err("just-above range must be rejected");
+    assert!(matches!(err, RuntimeCheckError::OutOfRange { .. }));
+}
+
+#[test]
+fn it_should_reject_negative_signed_for_uint64_field() {
+    let yaml = r"
+schema_version: 1
+events:
+  ping:
+    fields:
+      v: { type: uint64 }
+    binding_filter: [type]
+";
+    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+
+    let p = payload(&[
+        ("type", FieldValue::String("ping".into())),
+        ("v", FieldValue::Int(-1)),
+    ]);
+
+    let err = check_event("drv", &schema, p).expect_err("negative for uint64");
+    assert!(matches!(err, RuntimeCheckError::TypeMismatch { .. }));
+}
+
+#[test]
 fn it_should_apply_defaults_block_required_check_to_every_event() {
     // defaults 宣言の required field は全 event で required 扱い。
     let yaml = r"

--- a/crates/midori-runtime/src/events_pipeline/tests.rs
+++ b/crates/midori-runtime/src/events_pipeline/tests.rs
@@ -506,6 +506,75 @@ fn it_should_drop_schema_violating_events_without_invoking_the_sink() {
 }
 
 #[test]
+fn it_should_render_decode_error_display_with_specific_diagnostic_text() {
+    let bytes = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        (
+            "inner",
+            Value::Map(vec![(Value::String("x".into()), Value::from(1u8))]),
+        ),
+    ]);
+    let err = decode_event(&bytes).expect_err("nested map");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("nested maps"),
+        "DecodeError display should describe the violation, got: {rendered}"
+    );
+}
+
+#[test]
+fn it_should_render_runtime_check_error_display_with_field_and_event_context() {
+    let schema = midi_schema();
+    let p = payload(&[
+        ("type", FieldValue::String("noteOn".into())),
+        ("channel", FieldValue::UInt(99)), // out of [1, 16]
+        ("note", FieldValue::UInt(60)),
+        ("velocity", FieldValue::UInt(100)),
+    ]);
+    let err = check_event("midi", &schema, p).expect_err("range");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("noteOn"),
+        "RuntimeCheckError display should mention the event type, got: {rendered}"
+    );
+    assert!(
+        rendered.contains("channel"),
+        "RuntimeCheckError display should mention the offending field, got: {rendered}"
+    );
+}
+
+#[test]
+fn it_should_render_process_error_display_distinguishing_each_pipeline_stage() {
+    let schema = midi_schema();
+    let bogus_msgpack = vec![0xc1u8];
+    let decode_err = try_process("midi", Some(&schema), &bogus_msgpack).expect_err("decode");
+    assert!(
+        decode_err.to_string().contains("msgpack decode failed"),
+        "ProcessError::Decode display, got: {decode_err}"
+    );
+
+    let missing_err = try_process("midi", None, &[0x80u8]).expect_err("missing");
+    assert!(
+        missing_err
+            .to_string()
+            .contains("driver has no events.yaml schema loaded"),
+        "ProcessError::SchemaMissing display, got: {missing_err}"
+    );
+
+    let bytes = encode_map(&[
+        ("type", Value::String("noteOn".into())),
+        ("channel", Value::from(1u8)),
+        ("note", Value::from(60u8)),
+        ("velocity", Value::from(200u8)), // out of range
+    ]);
+    let check_err = try_process("midi", Some(&schema), &bytes).expect_err("check");
+    assert!(
+        check_err.to_string().contains("schema check failed"),
+        "ProcessError::Check display, got: {check_err}"
+    );
+}
+
+#[test]
 fn it_should_drop_events_when_the_drivers_schema_is_unavailable() {
     let bytes = encode_map(&[
         ("type", Value::String("noteOn".into())),

--- a/crates/midori-runtime/src/events_schema/mod.rs
+++ b/crates/midori-runtime/src/events_schema/mod.rs
@@ -29,6 +29,9 @@ mod validator;
 pub use feature_check::{check_runtime_features, FeatureUnavailable};
 pub use loader::{load_from_path, resolve_events_yaml_path, LoadError, LoadOutcome};
 pub use types::{EventDef, EventsSchema, FieldSpec, FieldType, RangeBound, Tier};
+// 同 crate 内の `events_pipeline::runtime_check` も範囲比較で使うため
+// crate スコープで再エクスポートする（外部 API には出さない）。
+pub(crate) use types::yaml_to_f64;
 pub use validator::{validate, ValidationError};
 
 #[cfg(test)]

--- a/crates/midori-runtime/src/events_schema/types.rs
+++ b/crates/midori-runtime/src/events_schema/types.rs
@@ -190,11 +190,11 @@ impl FieldType {
     }
 
     /// Default integer/float bounds (inclusive). `None` for non-numeric types.
-    /// 整数の `f64` 化は schema validator の境界比較用なので、`i64::MAX`
-    /// 付近で 1 ulp ずれても実害がない（events.yaml で `int64` ぴったり
-    /// 境界の `range` を書く driver は事実上いない）と判断して許容する。
+    /// 整数の `f64` 化は境界比較用なので、`i64::MAX` 付近で 1 ulp ずれても
+    /// 実害がない（events.yaml で `int64` ぴったり境界の `range` を書く driver
+    /// は事実上いない）と判断して許容する。
     #[allow(clippy::cast_precision_loss)]
-    pub(super) fn default_range(&self) -> Option<(f64, f64)> {
+    pub(crate) fn default_range(&self) -> Option<(f64, f64)> {
         Some(match self {
             Self::Int8 => (f64::from(i8::MIN), f64::from(i8::MAX)),
             Self::Uint8 => (0.0, f64::from(u8::MAX)),

--- a/crates/midori-runtime/src/events_schema/types.rs
+++ b/crates/midori-runtime/src/events_schema/types.rs
@@ -190,9 +190,12 @@ impl FieldType {
     }
 
     /// Default integer/float bounds (inclusive). `None` for non-numeric types.
-    /// 整数の `f64` 化は境界比較用なので、`i64::MAX` 付近で 1 ulp ずれても
-    /// 実害がない（events.yaml で `int64` ぴったり境界の `range` を書く driver
-    /// は事実上いない）と判断して許容する。
+    ///
+    /// 起動時 schema validator（`events_schema::validator`）と runtime 照合層
+    /// （`events_pipeline::runtime_check`）の両方が `range:` 省略時の境界比較
+    /// に用いる。整数の `f64` 化は `i64::MAX` 付近で 1 ulp ずれても実害がない
+    /// （events.yaml で `int64` ぴったり境界の `range` を書く driver は事実上
+    /// いない）と判断して許容する。
     #[allow(clippy::cast_precision_loss)]
     pub(crate) fn default_range(&self) -> Option<(f64, f64)> {
         Some(match self {
@@ -281,4 +284,22 @@ where
         "a map of field names to field specs",
         "field name",
     )
+}
+
+/// `serde_yml::Value` の数値を `f64` に変換する。
+///
+/// `as_f64()` 単独では実装によって整数リテラル（`range: [0, 127]` 等）が
+/// `None` を返す可能性があるため、`as_i64()` / `as_u64()` への fallback を
+/// 順に試す。`Value::Number` 以外は `None`。validator（schema 起動時検査）と
+/// `events_pipeline::runtime_check`（イベントごとの runtime 検査）の両方が
+/// 範囲比較で使うため、ここに共通定義を置く。
+#[allow(clippy::cast_precision_loss)]
+pub(crate) fn yaml_to_f64(v: &serde_yml::Value) -> Option<f64> {
+    match v {
+        serde_yml::Value::Number(n) => n
+            .as_f64()
+            .or_else(|| n.as_i64().map(|i| i as f64))
+            .or_else(|| n.as_u64().map(|u| u as f64)),
+        _ => None,
+    }
 }

--- a/crates/midori-runtime/src/events_schema/validator.rs
+++ b/crates/midori-runtime/src/events_schema/validator.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use super::types::{EventDef, EventsSchema, FieldSpec, FieldType, RangeBound};
+use super::types::{yaml_to_f64, EventDef, EventsSchema, FieldSpec, FieldType, RangeBound};
 
 /// Single schema violation. Path identifies the offending location.
 #[derive(Debug, PartialEq, Eq)]
@@ -311,21 +311,5 @@ fn validate_default(
                 );
             }
         }
-    }
-}
-
-/// `serde_yml::Value` の数値を f64 に変換する。
-///
-/// `as_f64()` 単独では実装によって整数リテラル (`range: [0, 127]` 等) が
-/// `None` 返却となる可能性があるため、`as_i64()` / `as_u64()` への fallback
-/// を順に試す。`Value::Number` 以外は `None`。
-#[allow(clippy::cast_precision_loss)]
-fn yaml_to_f64(v: &serde_yml::Value) -> Option<f64> {
-    match v {
-        serde_yml::Value::Number(n) => n
-            .as_f64()
-            .or_else(|| n.as_i64().map(|i| i as f64))
-            .or_else(|| n.as_u64().map(|u| u as f64)),
-        _ => None,
     }
 }

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -1,4 +1,5 @@
 mod error;
+mod events_pipeline;
 mod events_schema;
 
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary

- `events_pipeline` モジュールを新設し、SPSC ring slot の inline payload を **msgpack decode → events.yaml schema 照合 → Layer 2 stub I/F dispatch** する 3 段経路を実装した。
- 不正イベント（msgpack 破損 / schema 違反 / events.yaml 未ロード）は Error ログを出して drop。パイプラインは継続する。
- Layer 2 binding 本体は本 Issue のスコープ外。`EventSink` trait + `LoggingSink` stub で trace まで配線し、後続 Issue で差し替え予定。

## 主な変更

- `crates/midori-runtime/src/events_pipeline/decode.rs` — `rmpv` で msgpack を `BTreeMap<String, FieldValue>` へ decode。nil / ext / 非文字列キー / 入れ子 map / array<array> は語彙外として reject。
- `crates/midori-runtime/src/events_pipeline/runtime_check.rs` — `type` discriminator 抽出 → schema lookup → defaults と event.fields をマージ → 必須欠落 / 余剰 / 型不一致 / 値域外 / enum 違反 / `max_length` 超過を網羅判定。
- `crates/midori-runtime/src/events_pipeline/mod.rs` — `EventSink` trait、`LoggingSink`、`process_inline_payload`、テスト用 `try_process` (`Result` 版) を提供。
- `crates/midori-runtime/src/events_pipeline/tests.rs` — decode 9 件 / runtime_check 13 件 / pipeline glue 4 件 (`RecordingSink` で stub 受領を確認) の単体・統合テスト。
- `crates/midori-runtime/Cargo.toml` — `rmpv = "1"` 追加。
- `crates/midori-runtime/src/events_schema/types.rs` — `FieldType::default_range()` の可視性を `pub(super)` → `pub(crate)` に拡張（`events_pipeline` から参照可能にするため）。

## AC マッピング

- [x] `rmp-serde`（or 同等の `rmpv`）を runtime に導入
- [x] inline payload を msgpack decode、失敗時は Error ログ + drop
- [x] schema 照合（type / 必須 / 値域 / enum / max_length）、違反は Error ログ + drop
- [x] Layer 2 binding stub I/F (`EventSink` trait) に妥当 event を渡す。受信 trace に最小 log を出す `LoggingSink`
- [x] 統合テスト: 正常 / msgpack 不正 / schema 違反 / events.yaml 無し の 4 経路

## Out of Scope

- 実 SPSC ring 経由の連携（mock パイプラインに閉じる、後続 subtask）
- Layer 2 binding 本実装
- `tier: streamed` の runtime feature check（MEW-51 で先行済み）
- side channel 経由の payload 復元（MEW-43）

## Test plan

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --workspace --all-targets -- -D warnings` 通過
- [x] `cargo test --workspace` 通過（既存 30 → 75、events_pipeline 26 件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * インラインペイロード向けのイベント処理パイプラインを追加（msgpackデコード→ランタイムのスキーマ検証→送信）
  * 検証済イベントのロギング送信先を追加

* **テスト**
  * デコードからスキーマ検証、パイプライン実行までのエンドツーエンドテストを追加

* **雑多**
  * ランタイムで利用する新しい依存ライブラリを追加
* **内部改善**
  * YAML数値変換などの内部ヘルパーの可視性を調整
<!-- end of auto-generated comment: release notes by coderabbit.ai -->