### PR TITLE
feat(runtime): wire events.yaml validation chain into startup CLI (MEW-54)

### DIFF
--- a/crates/midori-runtime/src/error.rs
+++ b/crates/midori-runtime/src/error.rs
@@ -1,11 +1,17 @@
 use std::path::PathBuf;
 
+use crate::events_pipeline::StartupCheckError;
+
 #[derive(Debug)]
 pub enum CliError {
     ReadProfile {
         path: PathBuf,
         source: std::io::Error,
     },
+    /// `--driver-events` 引数の値が `<name>=<path>` の形式に従っていない。
+    InvalidDriverEventsArg { raw: String },
+    /// 起動時の events.yaml チェックで Bridge が継続できない違反を検出した。
+    StartupCheck { source: StartupCheckError },
 }
 
 impl std::fmt::Display for CliError {
@@ -18,6 +24,11 @@ impl std::fmt::Display for CliError {
                     path.display()
                 )
             }
+            Self::InvalidDriverEventsArg { raw } => write!(
+                f,
+                "--driver-events の値が `<name>=<path>` 形式ではありません: `{raw}`"
+            ),
+            Self::StartupCheck { source } => write!(f, "起動時チェックに失敗しました: {source}"),
         }
     }
 }
@@ -26,6 +37,8 @@ impl std::error::Error for CliError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::ReadProfile { source, .. } => Some(source),
+            Self::StartupCheck { source } => Some(source),
+            Self::InvalidDriverEventsArg { .. } => None,
         }
     }
 }

--- a/crates/midori-runtime/src/events_pipeline/mod.rs
+++ b/crates/midori-runtime/src/events_pipeline/mod.rs
@@ -1,14 +1,16 @@
 //! Inline payload を Layer 2 binding 入口まで運ぶ runtime パイプライン層。
 //!
-//! 役割は 3 段:
+//! 役割は 4 つ:
 //!
-//! 1. msgpack バイト列の decode（[`decode`] サブモジュール）
-//! 2. 1 イベント単位の events.yaml schema 照合（[`runtime_check`] サブモジュール）
-//! 3. 照合通過イベントを Layer 2 binding 側へ手渡す（本モジュールの [`EventSink`]）
+//! 1. Bridge 起動時に各 driver の events.yaml を整合性チェック
+//!    （[`startup`] サブモジュール、main から駆動）
+//! 2. msgpack バイト列の decode（[`decode`] サブモジュール）
+//! 3. 1 イベント単位の events.yaml schema 照合（[`runtime_check`] サブモジュール）
+//! 4. 照合通過イベントを Layer 2 binding 側へ手渡す（本モジュールの [`EventSink`]）
 //!
-//! Layer 2 binding 本体は MEW-50 のスコープ外。本層は **stub I/F** として
-//! `EventSink` trait と最小実装 [`LoggingSink`] を提供し、後続の binding 実装
-//! で差し替える前提。
+//! Layer 2 binding 本体はまだ未実装で、本層は **stub I/F** として `EventSink`
+//! trait と最小実装 [`LoggingSink`] を提供する。実 binding 経路の I/F が
+//! 固まり次第差し替える。
 //!
 //! 不正イベント（decode 失敗 / schema 違反 / events.yaml 未宣言 driver）は
 //! [`process_inline_payload`] が Error ログを出して drop する。パイプライン
@@ -16,13 +18,14 @@
 //!
 //! 構成:
 //!
+//! - [`startup`]: events.yaml の起動時整合性チェック（[`check_driver_schema`]）
 //! - [`decode`]: msgpack → [`DecodedPayload`]
 //! - [`runtime_check`]: [`DecodedPayload`] × `EventsSchema` → [`ValidatedEvent`]
 //! - 本ファイル: [`EventSink`] / [`LoggingSink`] / [`process_inline_payload`]
 //! - `tests`: 統合テスト
 
-// `decode` / `runtime_check` 経路は SPSC ring からの実 ingest が MEW-43
-// 完了後に配線される予定。それまで本ファイル直下の SPSC 連携 stub
+// `decode` / `runtime_check` 経路は SPSC ring からの実 ingest 配線後に
+// 実 caller が付く予定。それまで本ファイル直下の SPSC 連携 stub
 // (`LoggingSink` / `process_inline_payload` / `try_process` / `ProcessError`)
 // と sub-module 群はいずれも dead_code 警告を生むので、type 単位で個別に
 // allow する。`startup` は main から駆動済みのため対象外。
@@ -45,8 +48,8 @@ use crate::events_schema::EventsSchema;
 
 /// Layer 2 binding が schema 照合通過後のイベントを受け取る接点。
 ///
-/// 本 trait は MEW-50 段階の **stub**。実 binding 経路の I/F が固まり次第
-/// 差し替える（trait のままにするか、channel ベースへ移すかは後続 Issue で決定）。
+/// 本 trait は **stub**。実 binding 経路の I/F が固まり次第差し替える
+/// （trait のままにするか、channel ベースへ移すかは未定）。
 pub trait EventSink {
     fn dispatch(&mut self, event: ValidatedEvent);
 }

--- a/crates/midori-runtime/src/events_pipeline/mod.rs
+++ b/crates/midori-runtime/src/events_pipeline/mod.rs
@@ -21,16 +21,25 @@
 //! - 本ファイル: [`EventSink`] / [`LoggingSink`] / [`process_inline_payload`]
 //! - `tests`: 統合テスト
 
-// 本 module の公開 API は Bridge 起動 pipeline からまだ呼び出されておらず
-// （後続 subtask で接続予定）、binary crate 内の dead_code / unused_imports
-// 検出に引っかかるため module 全体で抑制する。実体は単体テストで網羅している。
-#![allow(dead_code, unused_imports)]
-
+// `decode` / `runtime_check` 経路は SPSC ring からの実 ingest が MEW-43
+// 完了後に配線される予定。それまで本ファイル直下の SPSC 連携 stub
+// (`LoggingSink` / `process_inline_payload` / `try_process` / `ProcessError`)
+// と sub-module 群はいずれも dead_code 警告を生むので、type 単位で個別に
+// allow する。`startup` は main から駆動済みのため対象外。
+#[allow(dead_code, unused_imports)]
 mod decode;
+#[allow(dead_code, unused_imports)]
 mod runtime_check;
+mod startup;
 
+// `decode` / `runtime_check` の type は SPSC ingest 配線で表面に出るが
+// 本 subtask の段階では caller が居ない。再 export 自体は維持して、
+// 個別 import 警告は module 内 allow に委ねる。
+#[allow(unused_imports)]
 pub use decode::{decode_event, DecodeError, DecodedPayload, FieldValue};
+#[allow(unused_imports)]
 pub use runtime_check::{check_event, RuntimeCheckError, ValidatedEvent};
+pub use startup::{check_driver_schema, DriverSchemaOutcome, StartupCheckError};
 
 use crate::events_schema::EventsSchema;
 
@@ -43,6 +52,7 @@ pub trait EventSink {
 }
 
 /// stderr に最小情報だけ書き出す `EventSink` の素朴実装。trace 用途。
+#[allow(dead_code)]
 pub struct LoggingSink;
 
 impl EventSink for LoggingSink {
@@ -63,6 +73,7 @@ impl EventSink for LoggingSink {
 /// 値検証ができないため、wire format が偶然正しくても受理しない）。caller
 /// が `LoadOutcome::Missing` を warning として扱いつつパイプラインを継続
 /// したい場合も、本関数は payload を sink へ流さない。
+#[allow(dead_code)]
 pub fn process_inline_payload(
     driver_name: &str,
     schema: Option<&EventsSchema>,
@@ -77,6 +88,7 @@ pub fn process_inline_payload(
 
 /// `process_inline_payload` の純関数版。テストでログ捕捉に頼らず
 /// 失敗種別をパターンマッチで検査するために露出する。
+#[allow(dead_code)]
 pub(crate) fn try_process(
     driver_name: &str,
     schema: Option<&EventsSchema>,
@@ -89,6 +101,7 @@ pub(crate) fn try_process(
 }
 
 /// パイプラインの 3 段が出すエラーを集約した単一型（テスト・観測用）。
+#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) enum ProcessError {
     Decode(DecodeError),

--- a/crates/midori-runtime/src/events_pipeline/startup.rs
+++ b/crates/midori-runtime/src/events_pipeline/startup.rs
@@ -66,13 +66,13 @@ impl std::fmt::Display for StartupCheckError {
                 path,
                 violations,
             } => {
-                writeln!(
+                write!(
                     f,
                     "driver `{driver_name}` の events.yaml ({}) が schema 違反:",
                     path.display()
                 )?;
                 for v in violations {
-                    writeln!(f, "  - {v}")?;
+                    write!(f, "\n  - {v}")?;
                 }
                 Ok(())
             }
@@ -81,13 +81,13 @@ impl std::fmt::Display for StartupCheckError {
                 path,
                 reasons,
             } => {
-                writeln!(
+                write!(
                     f,
                     "driver `{driver_name}` の events.yaml ({}) が runtime 未対応な機能を宣言:",
                     path.display()
                 )?;
                 for r in reasons {
-                    writeln!(f, "  - {r}")?;
+                    write!(f, "\n  - {r}")?;
                 }
                 Ok(())
             }

--- a/crates/midori-runtime/src/events_pipeline/startup.rs
+++ b/crates/midori-runtime/src/events_pipeline/startup.rs
@@ -1,0 +1,144 @@
+//! Bridge 起動時の events.yaml 整合性チェック経路。
+//!
+//! `load_from_path → validate → check_runtime_features` を 1 関数として束ね、
+//! main.rs などの caller が「driver 名 + events.yaml path」のリストを渡せば
+//! 起動エラー or warning の判定を返す薄いラッパーを提供する。
+//!
+//! 実 driver process の spawn / 実 SPSC ring 経由の ingest は本層のスコープ外。
+//! profile YAML resolver も別 subtask の責務で、本層は path を直接受け取る。
+
+use std::path::{Path, PathBuf};
+
+use crate::events_schema::{
+    check_runtime_features, load_from_path, validate, EventsSchema, FeatureUnavailable, LoadError,
+    LoadOutcome, ValidationError,
+};
+
+/// 1 driver ぶんの起動時整合性チェック結果。
+///
+/// `Loaded` が運ぶ `EventsSchema` は本 subtask の caller では未参照だが、
+/// 後続の Layer 2 binding 配線で必要になる正式な戻り値のため保持しておく。
+#[derive(Debug)]
+pub enum DriverSchemaOutcome {
+    /// events.yaml がロードでき、validator / feature check を通過した。
+    Loaded(#[allow(dead_code)] EventsSchema),
+    /// events.yaml が見つからなかった。caller は warning を出して継続する。
+    Missing,
+}
+
+/// 起動時 events.yaml チェックの失敗種別。
+#[derive(Debug)]
+pub enum StartupCheckError {
+    /// YAML の I/O / parse 失敗。
+    Load {
+        driver_name: String,
+        path: PathBuf,
+        source: LoadError,
+    },
+    /// schema 自身の整合性違反（validator が検出）。
+    Validate {
+        driver_name: String,
+        path: PathBuf,
+        violations: Vec<ValidationError>,
+    },
+    /// runtime が未対応な機能宣言（streamed tier 等）。
+    FeatureUnavailable {
+        driver_name: String,
+        path: PathBuf,
+        reasons: Vec<FeatureUnavailable>,
+    },
+}
+
+impl std::fmt::Display for StartupCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Load {
+                driver_name,
+                path,
+                source,
+            } => write!(
+                f,
+                "driver `{driver_name}` の events.yaml ({}) のロードに失敗しました: {source}",
+                path.display()
+            ),
+            Self::Validate {
+                driver_name,
+                path,
+                violations,
+            } => {
+                writeln!(
+                    f,
+                    "driver `{driver_name}` の events.yaml ({}) が schema 違反:",
+                    path.display()
+                )?;
+                for v in violations {
+                    writeln!(f, "  - {v}")?;
+                }
+                Ok(())
+            }
+            Self::FeatureUnavailable {
+                driver_name,
+                path,
+                reasons,
+            } => {
+                writeln!(
+                    f,
+                    "driver `{driver_name}` の events.yaml ({}) が runtime 未対応な機能を宣言:",
+                    path.display()
+                )?;
+                for r in reasons {
+                    writeln!(f, "  - {r}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for StartupCheckError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Load { source, .. } => Some(source),
+            Self::Validate { .. } | Self::FeatureUnavailable { .. } => None,
+        }
+    }
+}
+
+/// 1 driver ぶんの events.yaml を起動時整合性チェックする。
+///
+/// `path` は events.yaml そのものへの絶対 / 相対 path（`resolve_events_yaml_path`
+/// の責務は caller が持つ）。Missing と検査通過は `Ok` で区別し、それ以外の
+/// 失敗は `StartupCheckError` で返す。
+pub fn check_driver_schema(
+    driver_name: &str,
+    path: &Path,
+) -> Result<DriverSchemaOutcome, StartupCheckError> {
+    let outcome = load_from_path(path).map_err(|source| StartupCheckError::Load {
+        driver_name: driver_name.to_owned(),
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    let schema = match outcome {
+        LoadOutcome::Missing => return Ok(DriverSchemaOutcome::Missing),
+        LoadOutcome::Loaded(schema) => schema,
+    };
+
+    if let Err(violations) = validate(&schema) {
+        return Err(StartupCheckError::Validate {
+            driver_name: driver_name.to_owned(),
+            path: path.to_path_buf(),
+            violations,
+        });
+    }
+
+    if let Err(reasons) = check_runtime_features(driver_name, &schema) {
+        return Err(StartupCheckError::FeatureUnavailable {
+            driver_name: driver_name.to_owned(),
+            path: path.to_path_buf(),
+            reasons,
+        });
+    }
+
+    Ok(DriverSchemaOutcome::Loaded(schema))
+}

--- a/crates/midori-runtime/src/events_schema/mod.rs
+++ b/crates/midori-runtime/src/events_schema/mod.rs
@@ -16,9 +16,11 @@
 //! - [`feature_check`]: Bridge runtime が現状サポートしていない宣言の reject
 //! - `tests`:           sub-module すべての単体テスト
 
-// この module の公開 API は Bridge パイプラインからまだ呼び出されておらず
-// （後続 subtask で接続予定）、binary crate 内の dead_code / unused_imports
-// 検出に引っかかるため module 全体で抑制する。実体は単体テストで網羅している。
+// `events_pipeline::startup` 経由で `load_from_path` / `validate` /
+// `check_runtime_features` は実 caller を持つ。一方で `EventsSchema` /
+// `EventDef` / `FieldSpec` などの内部 field は Layer 2 binding 連携が
+// 完成するまで読み出されない。後続 subtask で本格 caller が付くため、
+// 当面は module 全体で抑制を残す（実体は単体テストで網羅している）。
 #![allow(dead_code, unused_imports)]
 
 mod feature_check;

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -120,12 +120,17 @@ fn run(profile_path: &Path, driver_events_args: &[String]) -> Result<(), CliErro
 }
 
 /// `--driver-events <name>=<path>` 形式の引数を分解する。
+///
+/// shell からの引数渡しで前後に空白が混じるケース（例: `"midi=   "`）を
+/// 防衛するため、`name` / `path` は `trim()` してから空判定する。
 fn parse_driver_events_arg(raw: &str) -> Result<(&str, PathBuf), CliError> {
     let (name, path) = raw
         .split_once('=')
         .ok_or_else(|| CliError::InvalidDriverEventsArg {
             raw: raw.to_owned(),
         })?;
+    let name = name.trim();
+    let path = path.trim();
     if name.is_empty() || path.is_empty() {
         return Err(CliError::InvalidDriverEventsArg {
             raw: raw.to_owned(),
@@ -421,6 +426,44 @@ mod tests {
         .expect("parse");
 
         let err = super::dispatch(&cli).expect_err("empty path must fail");
+        assert!(
+            matches!(err, CliError::InvalidDriverEventsArg { .. }),
+            "expected InvalidDriverEventsArg, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_reject_driver_events_argument_with_whitespace_only_name() {
+        let profile = write_tmp_profile("ws-name");
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            "   =/tmp/events.yaml",
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("whitespace-only name must fail");
+        assert!(
+            matches!(err, CliError::InvalidDriverEventsArg { .. }),
+            "expected InvalidDriverEventsArg, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_reject_driver_events_argument_with_whitespace_only_path() {
+        let profile = write_tmp_profile("ws-path");
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            "midi=   ",
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("whitespace-only path must fail");
         assert!(
             matches!(err, CliError::InvalidDriverEventsArg { .. }),
             "expected InvalidDriverEventsArg, got {err:?}"

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -264,17 +264,35 @@ mod tests {
         file
     }
 
+    /// 正常通過する最小 events.yaml フィクスチャ（noteOn の range が
+    /// `[1, 16]` で validator / feature check を全て通過する）。
+    const EVENTS_YAML_VALID_NOTEON: &str = "schema_version: 1\n\
+         events:\n  \
+           noteOn:\n    \
+             fields:\n      \
+               channel: { type: uint8, range: [1, 16] }\n";
+
+    /// schema validator が違反として検出する events.yaml フィクスチャ。
+    /// `range:` の min > max を含む。
+    const EVENTS_YAML_INVALID_RANGE: &str = "schema_version: 1\n\
+         events:\n  \
+           noteOn:\n    \
+             fields:\n      \
+               channel: { type: uint8, range: [16, 1] }\n";
+
+    /// runtime feature-availability check が reject する events.yaml
+    /// フィクスチャ。`tier: streamed` を 1 件含む。
+    const EVENTS_YAML_STREAMED_OSCBLOB: &str = "schema_version: 1\n\
+         events:\n  \
+           oscBlob:\n    \
+             tier: streamed\n    \
+             fields:\n      \
+               payload: { type: bytes, max_length: 1024 }\n";
+
     #[test]
     fn it_should_pass_startup_when_driver_events_yaml_is_valid() {
         let profile = write_tmp_profile("happy");
-        let events = write_tmp_events_yaml(
-            "happy",
-            "schema_version: 1\n\
-             events:\n  \
-               noteOn:\n    \
-                 fields:\n      \
-                   channel: { type: uint8, range: [1, 16] }\n",
-        );
+        let events = write_tmp_events_yaml("happy", EVENTS_YAML_VALID_NOTEON);
         let cli = Cli::try_parse_from([
             "midori",
             "run",
@@ -293,14 +311,7 @@ mod tests {
     fn it_should_fail_startup_when_driver_events_yaml_violates_schema() {
         // `range:` の min > max は validator が違反として検出する。
         let profile = write_tmp_profile("invalid");
-        let events = write_tmp_events_yaml(
-            "invalid",
-            "schema_version: 1\n\
-             events:\n  \
-               noteOn:\n    \
-                 fields:\n      \
-                   channel: { type: uint8, range: [16, 1] }\n",
-        );
+        let events = write_tmp_events_yaml("invalid", EVENTS_YAML_INVALID_RANGE);
         let cli = Cli::try_parse_from([
             "midori",
             "run",
@@ -345,15 +356,7 @@ mod tests {
     #[test]
     fn it_should_fail_startup_when_driver_declares_streamed_tier() {
         let profile = write_tmp_profile("streamed");
-        let events = write_tmp_events_yaml(
-            "streamed",
-            "schema_version: 1\n\
-             events:\n  \
-               oscBlob:\n    \
-                 tier: streamed\n    \
-                 fields:\n      \
-                   payload: { type: bytes, max_length: 1024 }\n",
-        );
+        let events = write_tmp_events_yaml("streamed", EVENTS_YAML_STREAMED_OSCBLOB);
         let cli = Cli::try_parse_from([
             "midori",
             "run",
@@ -475,14 +478,7 @@ mod tests {
         // schema 違反をわざと作って、Display 文字列に driver 名と違反内容が
         // 両方含まれることを担保する。trailing newline がないことも検査する。
         let profile = write_tmp_profile("display");
-        let events = write_tmp_events_yaml(
-            "display",
-            "schema_version: 1\n\
-             events:\n  \
-               noteOn:\n    \
-                 fields:\n      \
-                   channel: { type: uint8, range: [16, 1] }\n",
-        );
+        let events = write_tmp_events_yaml("display", EVENTS_YAML_INVALID_RANGE);
         let cli = Cli::try_parse_from([
             "midori",
             "run",
@@ -511,15 +507,7 @@ mod tests {
     #[test]
     fn it_should_render_startup_check_error_display_with_streamed_feature_reason() {
         let profile = write_tmp_profile("display-streamed");
-        let events = write_tmp_events_yaml(
-            "display-streamed",
-            "schema_version: 1\n\
-             events:\n  \
-               oscBlob:\n    \
-                 tier: streamed\n    \
-                 fields:\n      \
-                   payload: { type: bytes, max_length: 1024 }\n",
-        );
+        let events = write_tmp_events_yaml("display-streamed", EVENTS_YAML_STREAMED_OSCBLOB);
         let cli = Cli::try_parse_from([
             "midori",
             "run",

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -232,7 +232,7 @@ mod tests {
     }
 
     // --------------------------------------------------------------
-    // --driver-events startup chain (MEW-54)
+    // --driver-events startup chain
     // --------------------------------------------------------------
 
     use crate::error::CliError;
@@ -386,6 +386,119 @@ mod tests {
         assert!(
             matches!(err, CliError::InvalidDriverEventsArg { .. }),
             "expected InvalidDriverEventsArg, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_reject_driver_events_argument_with_empty_name() {
+        let profile = write_tmp_profile("empty-name");
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            "=/tmp/events.yaml",
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("empty name must fail");
+        assert!(
+            matches!(err, CliError::InvalidDriverEventsArg { .. }),
+            "expected InvalidDriverEventsArg, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_reject_driver_events_argument_with_empty_path() {
+        let profile = write_tmp_profile("empty-path");
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            "midi=",
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("empty path must fail");
+        assert!(
+            matches!(err, CliError::InvalidDriverEventsArg { .. }),
+            "expected InvalidDriverEventsArg, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_render_startup_check_error_display_with_driver_and_violation_context() {
+        // schema 違反をわざと作って、Display 文字列に driver 名と違反内容が
+        // 両方含まれることを担保する。trailing newline がないことも検査する。
+        let profile = write_tmp_profile("display");
+        let events = write_tmp_events_yaml(
+            "display",
+            "schema_version: 1\n\
+             events:\n  \
+               noteOn:\n    \
+                 fields:\n      \
+                   channel: { type: uint8, range: [16, 1] }\n",
+        );
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            &format!("midi={}", events.path().display()),
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("schema violation");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("midi"),
+            "Display should mention the driver name, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("schema 違反"),
+            "Display should mention the violation kind, got: {rendered}"
+        );
+        assert!(
+            !rendered.ends_with('\n'),
+            "Display must not end with a trailing newline, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_render_startup_check_error_display_with_streamed_feature_reason() {
+        let profile = write_tmp_profile("display-streamed");
+        let events = write_tmp_events_yaml(
+            "display-streamed",
+            "schema_version: 1\n\
+             events:\n  \
+               oscBlob:\n    \
+                 tier: streamed\n    \
+                 fields:\n      \
+                   payload: { type: bytes, max_length: 1024 }\n",
+        );
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            &format!("osc={}", events.path().display()),
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("streamed");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("osc"),
+            "Display should mention the driver name, got: {rendered}"
+        );
+        assert!(
+            rendered.contains("streamed"),
+            "Display should mention the unsupported feature, got: {rendered}"
+        );
+        assert!(
+            !rendered.ends_with('\n'),
+            "Display must not end with a trailing newline, got: {rendered:?}"
         );
     }
 }

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -85,17 +85,26 @@ fn dispatch(cli: &Cli) -> Result<(), CliError> {
 }
 
 // プロファイル本体のパイプラインは後続の subtask で実装する。
-// 本関数では (a) プロファイル YAML が読めること、(b) 暫定経路で渡された
-// `--driver-events` の events.yaml が起動時チェックを通過することのみ確認する。
+// 本関数では (a) `--driver-events` の引数形式が正しいこと、(b) プロファイル
+// YAML が読めること、(c) 各 events.yaml が起動時チェックを通過すること、を
+// この順に確認する。
+//
+// 引数形式違反は I/O より先に弾き、CLI 入力ミスを root cause として安定して
+// 報告できるようにする（profile が無い + arg 不正のとき `ReadProfile` で
+// マスクされないようにするため）。
 fn run(profile_path: &Path, driver_events_args: &[String]) -> Result<(), CliError> {
+    let driver_events: Vec<(&str, PathBuf)> = driver_events_args
+        .iter()
+        .map(|raw| parse_driver_events_arg(raw))
+        .collect::<Result<_, _>>()?;
+
     let _profile_yaml =
         std::fs::read_to_string(profile_path).map_err(|source| CliError::ReadProfile {
             path: profile_path.to_path_buf(),
             source,
         })?;
 
-    for raw in driver_events_args {
-        let (name, path) = parse_driver_events_arg(raw)?;
+    for (name, path) in driver_events {
         match check_driver_schema(name, &path)
             .map_err(|source| CliError::StartupCheck { source })?
         {
@@ -501,6 +510,82 @@ mod tests {
         assert!(
             !rendered.ends_with('\n'),
             "Display must not end with a trailing newline, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_iterate_through_multiple_driver_events_and_fail_on_the_violating_entry() {
+        // 1 件目は通過、2 件目で schema 違反 → fail。複数 `--driver-events`
+        // を全件走査し、後続エントリの違反でも CliError::StartupCheck が
+        // 返ることを担保する。
+        let profile = write_tmp_profile("multi-fail");
+        let valid = write_tmp_events_yaml("multi-fail-ok", EVENTS_YAML_VALID_NOTEON);
+        let invalid = write_tmp_events_yaml("multi-fail-bad", EVENTS_YAML_INVALID_RANGE);
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            &format!("ok={}", valid.path().display()),
+            "--driver-events",
+            &format!("bad={}", invalid.path().display()),
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("second entry violates schema");
+        assert!(
+            matches!(
+                err,
+                CliError::StartupCheck {
+                    source: crate::events_pipeline::StartupCheckError::Validate { .. }
+                }
+            ),
+            "expected StartupCheck::Validate, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_continue_through_missing_entry_when_other_driver_events_are_valid() {
+        // Missing entry を挟んでも warning + 継続し、後続の正常 entry まで
+        // 全件走査することを担保する。
+        let profile = write_tmp_profile("multi-mixed");
+        let valid = write_tmp_events_yaml("multi-mixed-ok", EVENTS_YAML_VALID_NOTEON);
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            "absent=/nonexistent/midori-mew54-multi/events.yaml",
+            "--driver-events",
+            &format!("ok={}", valid.path().display()),
+        ])
+        .expect("parse");
+
+        let result = super::dispatch(&cli);
+        assert!(
+            result.is_ok(),
+            "missing entry should warn + continue: {result:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_reject_malformed_driver_events_argument_before_reading_profile() {
+        // profile path が存在しない + arg が不正なケース。引数検証が profile
+        // I/O より先に走るので、root cause の InvalidDriverEventsArg が返り
+        // ReadProfile でマスクされないことを担保する。
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            "/nonexistent/midori-mew54/profile.yaml",
+            "--driver-events",
+            "no-equals-sign",
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("arg validation must fail first");
+        assert!(
+            matches!(err, CliError::InvalidDriverEventsArg { .. }),
+            "expected InvalidDriverEventsArg (arg validated before profile I/O), got {err:?}"
         );
     }
 

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -298,6 +298,10 @@ mod tests {
              fields:\n      \
                payload: { type: bytes, max_length: 1024 }\n";
 
+    /// loader 段階の YAML パースで失敗する events.yaml フィクスチャ。
+    /// 末尾の `[` が閉じておらず `serde_yml::from_str` が Parse error を返す。
+    const EVENTS_YAML_MALFORMED: &str = "schema_version: [\n";
+
     #[test]
     fn it_should_pass_startup_when_driver_events_yaml_is_valid() {
         let profile = write_tmp_profile("happy");
@@ -510,6 +514,35 @@ mod tests {
         assert!(
             !rendered.ends_with('\n'),
             "Display must not end with a trailing newline, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_fail_startup_when_driver_events_yaml_cannot_be_loaded() {
+        // YAML 構文エラーは loader 段階で検出され、StartupCheckError::Load が
+        // CliError::StartupCheck に包まれて返る。3 variant のうち Validate /
+        // FeatureUnavailable は別テストで担保しているので、Load 分岐の回帰
+        // 経路を本テストで埋める。
+        let profile = write_tmp_profile("load-error");
+        let events = write_tmp_events_yaml("load-error", EVENTS_YAML_MALFORMED);
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            &format!("midi={}", events.path().display()),
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("malformed YAML must fail");
+        assert!(
+            matches!(
+                err,
+                CliError::StartupCheck {
+                    source: crate::events_pipeline::StartupCheckError::Load { .. }
+                }
+            ),
+            "expected StartupCheck::Load, got {err:?}"
         );
     }
 

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -8,6 +8,7 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::error::CliError;
+use crate::events_pipeline::{check_driver_schema, DriverSchemaOutcome};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -40,6 +41,12 @@ enum Command {
         /// プロファイル YAML へのパス
         #[arg(value_name = "PROFILE")]
         profile: PathBuf,
+
+        /// driver の events.yaml を `<name>=<path>` 形式で直接指定する。
+        /// profile YAML resolver 完成までの暫定経路で、CLI help では非露出。
+        /// 複数回指定可。
+        #[arg(long = "driver-events", value_name = "NAME=PATH", hide = true)]
+        driver_events: Vec<String>,
     },
 }
 
@@ -70,19 +77,61 @@ fn main() -> ExitCode {
 
 fn dispatch(cli: &Cli) -> Result<(), CliError> {
     match &cli.command {
-        Command::Run { profile } => run(profile),
+        Command::Run {
+            profile,
+            driver_events,
+        } => run(profile, driver_events),
     }
 }
 
-// パイプライン本体は MEW-23 以降で実装する。
-// ここではプロファイルが読み込めることだけを確認する骨格を置く。
-fn run(profile_path: &Path) -> Result<(), CliError> {
+// プロファイル本体のパイプラインは後続の subtask で実装する。
+// 本関数では (a) プロファイル YAML が読めること、(b) 暫定経路で渡された
+// `--driver-events` の events.yaml が起動時チェックを通過することのみ確認する。
+fn run(profile_path: &Path, driver_events_args: &[String]) -> Result<(), CliError> {
     let _profile_yaml =
         std::fs::read_to_string(profile_path).map_err(|source| CliError::ReadProfile {
             path: profile_path.to_path_buf(),
             source,
         })?;
+
+    for raw in driver_events_args {
+        let (name, path) = parse_driver_events_arg(raw)?;
+        match check_driver_schema(name, &path)
+            .map_err(|source| CliError::StartupCheck { source })?
+        {
+            DriverSchemaOutcome::Loaded(_) => {
+                eprintln!(
+                    "midori: driver `{name}` の events.yaml ({}) のチェックが完了しました",
+                    path.display()
+                );
+            }
+            DriverSchemaOutcome::Missing => {
+                // events.yaml が無い driver は spec 上「明示的な schema 未宣言モード」
+                // として warning に留めて起動を継続する。
+                eprintln!(
+                    "midori: warning: driver `{name}` の events.yaml ({}) が見つかりませんでした。schema 未宣言モードで起動します",
+                    path.display()
+                );
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// `--driver-events <name>=<path>` 形式の引数を分解する。
+fn parse_driver_events_arg(raw: &str) -> Result<(&str, PathBuf), CliError> {
+    let (name, path) = raw
+        .split_once('=')
+        .ok_or_else(|| CliError::InvalidDriverEventsArg {
+            raw: raw.to_owned(),
+        })?;
+    if name.is_empty() || path.is_empty() {
+        return Err(CliError::InvalidDriverEventsArg {
+            raw: raw.to_owned(),
+        });
+    }
+    Ok((name, PathBuf::from(path)))
 }
 
 #[cfg(test)]
@@ -113,8 +162,12 @@ mod tests {
             .expect("run subcommand with positional profile must parse");
 
         match cli.command {
-            Command::Run { profile } => {
+            Command::Run {
+                profile,
+                driver_events,
+            } => {
                 assert_eq!(profile, PathBuf::from("/tmp/profile.yaml"));
+                assert!(driver_events.is_empty());
             }
         }
     }
@@ -176,5 +229,163 @@ mod tests {
         .expect("parse");
         let result = super::dispatch(&cli);
         assert!(result.is_err(), "missing profile should fail");
+    }
+
+    // --------------------------------------------------------------
+    // --driver-events startup chain (MEW-54)
+    // --------------------------------------------------------------
+
+    use crate::error::CliError;
+
+    /// 必要最小の profile YAML をテンポラリ生成し、その path を返す。
+    fn write_tmp_profile(tag: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::Builder::new()
+            .prefix(&format!("midori-mew54-{tag}-"))
+            .suffix(".yaml")
+            .tempfile()
+            .expect("tempfile");
+        std::io::Write::write_all(&mut file, b"name: test\n").expect("write profile");
+        file
+    }
+
+    /// 任意の events.yaml 文字列を temp ファイルに書き出す。
+    fn write_tmp_events_yaml(tag: &str, body: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::Builder::new()
+            .prefix(&format!("midori-mew54-events-{tag}-"))
+            .suffix(".yaml")
+            .tempfile()
+            .expect("tempfile");
+        std::io::Write::write_all(&mut file, body.as_bytes()).expect("write events.yaml");
+        file
+    }
+
+    #[test]
+    fn it_should_pass_startup_when_driver_events_yaml_is_valid() {
+        let profile = write_tmp_profile("happy");
+        let events = write_tmp_events_yaml(
+            "happy",
+            "schema_version: 1\n\
+             events:\n  \
+               noteOn:\n    \
+                 fields:\n      \
+                   channel: { type: uint8, range: [1, 16] }\n",
+        );
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            &format!("midi={}", events.path().display()),
+        ])
+        .expect("parse");
+
+        let result = super::dispatch(&cli);
+
+        assert!(result.is_ok(), "valid events.yaml should pass: {result:?}");
+    }
+
+    #[test]
+    fn it_should_fail_startup_when_driver_events_yaml_violates_schema() {
+        // `range:` の min > max は validator が違反として検出する。
+        let profile = write_tmp_profile("invalid");
+        let events = write_tmp_events_yaml(
+            "invalid",
+            "schema_version: 1\n\
+             events:\n  \
+               noteOn:\n    \
+                 fields:\n      \
+                   channel: { type: uint8, range: [16, 1] }\n",
+        );
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            &format!("midi={}", events.path().display()),
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("schema violation must fail");
+        assert!(
+            matches!(
+                err,
+                CliError::StartupCheck {
+                    source: crate::events_pipeline::StartupCheckError::Validate { .. }
+                }
+            ),
+            "expected StartupCheck::Validate, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_warn_and_continue_when_driver_events_yaml_is_missing() {
+        let profile = write_tmp_profile("missing");
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            "midi=/nonexistent/midori-mew54/events.yaml",
+        ])
+        .expect("parse");
+
+        let result = super::dispatch(&cli);
+
+        assert!(
+            result.is_ok(),
+            "missing events.yaml should be a warning, not a startup failure: {result:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_fail_startup_when_driver_declares_streamed_tier() {
+        let profile = write_tmp_profile("streamed");
+        let events = write_tmp_events_yaml(
+            "streamed",
+            "schema_version: 1\n\
+             events:\n  \
+               oscBlob:\n    \
+                 tier: streamed\n    \
+                 fields:\n      \
+                   payload: { type: bytes, max_length: 1024 }\n",
+        );
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            &format!("osc={}", events.path().display()),
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("streamed must be rejected at startup");
+        assert!(
+            matches!(
+                err,
+                CliError::StartupCheck {
+                    source: crate::events_pipeline::StartupCheckError::FeatureUnavailable { .. }
+                }
+            ),
+            "expected StartupCheck::FeatureUnavailable, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn it_should_reject_malformed_driver_events_argument() {
+        let profile = write_tmp_profile("malformed");
+        let cli = Cli::try_parse_from([
+            "midori",
+            "run",
+            profile.path().to_str().expect("profile utf-8"),
+            "--driver-events",
+            "no-equals-sign",
+        ])
+        .expect("parse");
+
+        let err = super::dispatch(&cli).expect_err("malformed arg must fail");
+        assert!(
+            matches!(err, CliError::InvalidDriverEventsArg { .. }),
+            "expected InvalidDriverEventsArg, got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `midori run` に hidden な `--driver-events <name>=<path>` (複数可) を追加し、MEW-49/50/51 で温まっていた events.yaml の `load → validate → check_runtime_features` 連鎖を Bridge CLI 起動時に駆動する。
- profile YAML resolver / driver spawn / 実 SPSC 連携とは独立した暫定経路。後続 subtask で profile resolver に置き換える。
- `LoadOutcome::Missing` は warn 継続、schema 違反 / streamed 宣言は `CliError::StartupCheck` で起動失敗。
- `events_schema` / `events_pipeline` の `dead_code allow` をスコープ限定的に縮小。

## 主な変更

- `crates/midori-runtime/src/events_pipeline/startup.rs` (新規) — 1 driver ぶんの起動時整合性チェックを束ねる `check_driver_schema`。`DriverSchemaOutcome::{Loaded, Missing}` と `StartupCheckError::{Load, Validate, FeatureUnavailable}` を提供。
- `crates/midori-runtime/src/error.rs` — `CliError` に `StartupCheck { source }` / `InvalidDriverEventsArg { raw }` を追加。
- `crates/midori-runtime/src/main.rs` — `Run` subcommand に hidden `--driver-events <NAME=PATH>` を追加。`run()` 内で各 events.yaml を `check_driver_schema` に通す。Missing は warning ログで継続、それ以外は CliError で起動失敗。
- `crates/midori-runtime/src/events_pipeline/mod.rs` / `events_schema/mod.rs` — `dead_code allow` を `decode` / `runtime_check` / SPSC ingest stub に絞り、`startup` は実 caller あり扱い。

## AC マッピング

- [x] `midori run` に `--driver-events <name=path>` (hidden, 複数可) を追加
- [x] `load_from_path → validate → check_runtime_features` を束ねる pub 関数を `events_pipeline` 配下に追加
- [x] `LoadOutcome::Missing` は warning ログで継続
- [x] schema 違反 / streamed tier 宣言は `CliError` で起動失敗
- [x] dead_code allow を最小限まで縮小（実 caller を持つ `startup` 経由関数群の allow を外し、SPSC 連携待ちの stub にスコープ限定）
- [x] 統合テスト 4 ケース + 1 (malformed arg)

## Out of Scope

- profile YAML loader（別 subtask）
- driver.yaml / plugin.yaml の path resolver
- 実 driver process の spawn
- 実 SPSC ring 経由の event ingest（MEW-43 待ち）
- Layer 2 binding 本実装

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`（既存 84 → 89、`tests::it_should_*_startup_*` 5 件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * run コマンドに隠しの --driver-events NAME=PATH フラグを追加（複数指定可）。
  * 起動時に各ドライバーの events.yaml 一貫性チェックを実行。読み込めたスキーマは完了表示、未検出は警告で継続。

* **改善**
  * フラグ形式不備と起動チェックの各種失敗を区別して分かりやすく報告（検出原因の伝達を改善）。
  * 複数ドライバー指定時の順次検査と失敗時の適切な停止挙動を導入。

* **テスト**
  * 引数解析、起動チェック挙動、表示要件を含む包括的なユニットテストを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->