### PR TITLE
feat(core,sdk,runtime): variable-sized inline ring slot (MEW-43)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "midori-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "midori-sdk"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "midori-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ missing_errors_doc      = "allow"
 missing_panics_doc      = "allow"
 
 [workspace.dependencies]
-midori-core = { path = "crates/midori-core", version = "0.2.0" }
-midori-sdk  = { path = "crates/midori-sdk",  version = "0.1.0" }
+midori-core = { path = "crates/midori-core", version = "0.3.0" }
+midori-sdk  = { path = "crates/midori-sdk",  version = "0.2.0" }

--- a/crates/midori-core/CHANGELOG.md
+++ b/crates/midori-core/CHANGELOG.md
@@ -21,7 +21,7 @@
 ### Notes
 
 - `midori-sdk` は本変更に追従して `0.2.0` に bump。FFI 戻り値型も `u8` から `int32_t` に変更（`-2` payload too large の表現）
-- 実 driver↔Bridge 間の handshake control channel と shm fd 確保は別 Issue（後続 subtask）の責務
+- 実 driver↔Bridge 間の handshake control channel（`request_ring` メッセージの wire format）と、driver process spawn 経由での shm fd 確保 / `mmap(2)` 呼び出しは本 release のスコープ外。`midori-runtime::ring_handshake` で resolve / 検証 / ページ整列の関数群までを提供し、driver lifecycle 管理が入った段階で接続される
 
 ## 0.2.0 — 2026-04-27
 

--- a/crates/midori-core/CHANGELOG.md
+++ b/crates/midori-core/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog — midori-core
 
+## 0.3.0 — 2026-04-30
+
+### Breaking changes
+
+- **`shm` モジュールを variable-sized inline ring slot に再設計**（設計: `design/17-driver-comm/01-inline-ring.md`）。
+  - `RingSlot` 構造体を撤去。スロット内容は固定 8 byte の `SlotHeader` (`occupied: u8` / `_pad: [u8; 3]` / `payload_len: u32`) と raw payload バイト列 (`slot_size - 8` byte) に分離し、stride 計算で raw memory にアクセスする
+  - `ShmHeader` を 56 byte に拡張：`slot_size: u32` / `version: u32` / `_pad: [u8; 32]` を追加
+  - `PAYLOAD_INLINE_MAX` 定数を撤去。slot ごとの payload 容量は `ShmHeader.slot_size - 8` で決まる
+  - `RingSlot::side_offset` / `side_len` / `_pad2` を撤去。side channel 案は不採用（`design/17-driver-comm/00-overview.md` 参照）
+
+### Added
+
+- 定数: `DEFAULT_SLOT_SIZE = 1032` / `HARD_SLOT_SIZE = 65536` / `MIN_SLOT_SIZE = 12` / `SLOT_HEADER_SIZE = 8`
+- ABI version: `SHM_LAYOUT_VERSION = 1` / `MIN_SUPPORTED_SHM_VERSION` / `MAX_SUPPORTED_SHM_VERSION`
+- helper: `validate_slot_size` / `align_slot_size` / `shm_total_size` / `slot_offset_in_shm`
+- error: `SlotSizeError { NotAligned, TooSmall, TooLarge }`
+- `const_assert!` で `ShmHeader = 56 byte` / `SlotHeader = 8 byte` をコンパイル時 lock
+
+### Notes
+
+- `midori-sdk` は本変更に追従して `0.2.0` に bump。FFI 戻り値型も `u8` から `int32_t` に変更（`-2` payload too large の表現）
+- 実 driver↔Bridge 間の handshake control channel と shm fd 確保は別 Issue（後続 subtask）の責務
+
 ## 0.2.0 — 2026-04-27
 
 ### Breaking changes

--- a/crates/midori-core/Cargo.toml
+++ b/crates/midori-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midori-core"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Shared types and protocol definitions for the Midori signal bridge"
 license = "MIT OR Apache-2.0"

--- a/crates/midori-core/src/shm.rs
+++ b/crates/midori-core/src/shm.rs
@@ -135,6 +135,12 @@ pub struct ShmHeader {
 const _: () = assert!(std::mem::size_of::<ShmHeader>() == 56);
 const _: () = assert!(std::mem::align_of::<ShmHeader>() == 8);
 
+// design/17-driver-comm/01-inline-ring.md の暫定値を ABI 定数として lock
+// する。値変更は major bump 案件のため、compile-time でドリフトを検出する。
+const _: () = assert!(DEFAULT_SLOT_SIZE == 1032);
+const _: () = assert!(HARD_SLOT_SIZE == 65_536);
+const _: () = assert!(SLOT_HEADER_SIZE == 8);
+
 /// `slot_size` 検証で検出される失敗種別。
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum SlotSizeError {
@@ -220,11 +226,13 @@ pub const fn shm_total_size(slot_size: u32) -> usize {
     std::mem::size_of::<ShmHeader>() + RING_CAPACITY * slot_size as usize
 }
 
-/// 0-origin の slot 番号（`index % RING_CAPACITY`）から、`ShmHeader` 末尾を
-/// 起点としたスロット先頭までのバイトオフセットを返す。
+/// 0-origin の slot 番号（`index % RING_CAPACITY`）から、shm 領域先頭
+/// （`ShmHeader` 先頭 = base ポインタ）を起点としたスロット先頭までの
+/// バイトオフセットを返す。
 ///
-/// caller は `base_ptr.add(slot_offset_in_shm(slot_size, idx))` で raw byte
-/// アクセスを開始する。
+/// 戻り値には `sizeof(ShmHeader)` (= 56 byte) が常に含まれる。caller は
+/// `base_ptr.add(slot_offset_in_shm(slot_size, idx))` で raw byte アクセスを
+/// 開始する。
 #[must_use]
 pub const fn slot_offset_in_shm(slot_size: u32, slot_index: usize) -> usize {
     std::mem::size_of::<ShmHeader>() + slot_index * slot_size as usize
@@ -251,10 +259,31 @@ mod tests {
     }
 
     #[test]
-    fn it_should_default_slot_size_match_design_spec() {
+    fn it_should_lock_default_and_hard_slot_size_to_design_spec_values() {
         // design/17-driver-comm/01-inline-ring.md の暫定値と整合するか。
+        // compile-time guard はモジュール末尾の `const _: () = assert!(...)`
+        // で固定し、本テストは runtime 値も runtime で確認する dual-check。
         assert_eq!(DEFAULT_SLOT_SIZE, 1032);
         assert_eq!(HARD_SLOT_SIZE, 65_536);
+    }
+
+    #[test]
+    fn it_should_render_slot_size_error_display_with_explanatory_text() {
+        // Display に「offending slot_size 値」と「違反種別の意味」が両方
+        // 含まれることを担保する（API consumer が log 経路で意味を読み取れる）。
+        let err = validate_slot_size(13).expect_err("alignment");
+        let rendered = err.to_string();
+        assert!(rendered.contains("13"), "got: {rendered}");
+        assert!(
+            rendered.contains("4 byte 倍数"),
+            "alignment 違反の説明を含む: {rendered}"
+        );
+
+        let err_small = validate_slot_size(8).expect_err("min");
+        assert!(err_small.to_string().contains("最小値"));
+
+        let err_large = validate_slot_size(HARD_SLOT_SIZE + 4).expect_err("hard");
+        assert!(err_large.to_string().contains("HARD_SLOT_SIZE"));
     }
 
     #[test]

--- a/crates/midori-core/src/shm.rs
+++ b/crates/midori-core/src/shm.rs
@@ -1,14 +1,36 @@
 //! 共有メモリ上の SPSC リングバッファレイアウト定義。
 //!
-//! Driver から Bridge へ raw event を運ぶスロット形式。raw event は driver の
-//! `events.yaml` に沿った key-value 構造を msgpack で encode したバイト列
-//! として [`RingSlot::payload`] に格納する。inline 容量
-//! ([`PAYLOAD_INLINE_MAX`]) を超える payload は別 mmap 領域（side channel）
-//! に書き出し、スロットには [`RingSlot::side_offset`] / [`RingSlot::side_len`]
-//! のみを格納する。side channel 本体の確保・割り当て・GC は本ファイルでは
-//! 扱わない。
+//! Driver から Bridge へ inline tier の raw event を運ぶスロット形式。
+//! raw event は driver の `events.yaml` に沿った key-value 構造を msgpack
+//! で encode したバイト列としてスロットの payload 領域に格納する。
 //!
-//! 詳細設計: `design/15-sdk-bindings-api.md`「SPSC スロットレイアウトの変更」。
+//! スロットサイズは driver lifetime 内で固定だが driver ごとに異なる。
+//! Bridge と driver は handshake で `slot_size` を確定し、それ以降
+//! [`ShmHeader::slot_size`] を起点に stride 計算で raw memory にアクセスする。
+//!
+//! 詳細設計: `design/17-driver-comm/01-inline-ring.md`。
+//!
+//! # スロットレイアウト
+//!
+//! ```text
+//! slot offset 0:  occupied: u8
+//! slot offset 1:  _pad: [u8; 3]
+//! slot offset 4:  payload_len: u32
+//! slot offset 8:  payload: [u8; slot_size - 8]
+//! ```
+//!
+//! ヘッダ部（[`SlotHeader`]）は 8 byte で固定。payload は `slot_size - 8`
+//! byte 続く。`slot_size` は 4 byte 倍数であること、[`MIN_SLOT_SIZE`] 以上
+//! [`HARD_SLOT_SIZE`] 以下であることを Bridge / driver の双方で検証する。
+//!
+//! # ABI version
+//!
+//! [`ShmHeader::version`] は単調増加する整数カウンタで、フィールド追加・
+//! 意味変更のたびに増分する。Bridge は
+//! [`MIN_SUPPORTED_SHM_VERSION`]..=[`MAX_SUPPORTED_SHM_VERSION`] の範囲で
+//! 受け入れ、範囲外は reject する。
+
+use std::sync::atomic::AtomicU64;
 
 /// SPSC リングバッファのスロット数。
 ///
@@ -16,79 +38,196 @@
 /// 受け取れるサイズを目安にしている。
 pub const RING_CAPACITY: usize = 256;
 
-/// 単一スロットに inline で格納できる msgpack バイト列の最大長。
+/// driver の要求が無いときに Bridge が確保する slot 全体サイズ（byte）。
 ///
-/// この値を超える payload は side channel（別 mmap 領域）に書き出し、
-/// `RingSlot::side_offset` / `RingSlot::side_len` のみがスロットに残る。
-///
-/// MIDI / OSC の通常イベントが余裕で収まる範囲として 240 byte に設定。
-/// `SysEx` 1KB 級などはここを超えるため side channel 経由となる。
-pub const PAYLOAD_INLINE_MAX: usize = 240;
+/// payload 容量は `1032 - 8 = 1024 byte` で MIDI `SysEx` 1 KiB 上限と一致する
+/// ため、典型 driver は handshake で要求を出さずにこのサイズで動く。
+pub const DEFAULT_SLOT_SIZE: u32 = 1032;
 
-/// SPSC リングバッファの単一スロット。
+/// driver が handshake で要求できる slot 全体サイズの上限（byte）。
 ///
-/// `#[repr(C)]` により mmap 可能な固定レイアウトを保証する。FFI で他言語
-/// バインディングからも同レイアウトでアクセスする。
+/// `slot_size > HARD_SLOT_SIZE` の要求は handshake で reject される。1 driver
+/// あたり最大メモリ = `sizeof(ShmHeader) (56) + RING_CAPACITY (256) ×
+/// HARD_SLOT_SIZE = 16,777,272 byte ≈ 16 MiB`。
+pub const HARD_SLOT_SIZE: u32 = 65_536;
+
+/// `slot_size` の最小値（byte）。
 ///
-/// # フィールド
+/// header 8 byte + payload 最低 4 byte = 12 byte が下限（4 byte alignment 倍数性
+/// と payload 最低限の意味を兼ねる）。実用的には [`DEFAULT_SLOT_SIZE`] が
+/// 想定されるため、この最小値はあくまで防衛的検証用。
+pub const MIN_SLOT_SIZE: u32 = 12;
+
+/// 各スロット先頭に置かれるヘッダのバイト数。
 ///
-/// - `occupied`: 0 = 空、1 = 占有。空判定は本来 `write_index` /
-///   `read_index` の比較で十分だが、C 側の利便性（pop した直後に
-///   `slot.occupied == 1` で成功と判定）のために残す
-/// - `payload_len`: msgpack バイト列の実長。`<= PAYLOAD_INLINE_MAX` のとき
-///   inline 格納、超える場合は 0 を立てて side channel 経由とする
-/// - `side_offset` / `side_len`: side channel 上の位置とバイト長。**side
-///   channel の使用判定は `side_len > 0` を canonical とする**（`side_offset`
-///   は 0 が side channel 先頭を指す有効値となるため、未使用フラグには使えない）
-/// - `payload`: msgpack バイト列の inline 領域。`payload_len` バイト分のみ
-///   有効で、それ以降の領域は未定義
+/// 8 byte 固定。stride 計算で payload 領域オフセットを求める際に用いる。
+pub const SLOT_HEADER_SIZE: u32 = 8;
+
+/// `ShmHeader::version` の初期値。
+pub const SHM_LAYOUT_VERSION: u32 = 1;
+
+/// Bridge が受け入れる `ShmHeader::version` の下限。
+pub const MIN_SUPPORTED_SHM_VERSION: u32 = 1;
+
+/// Bridge が受け入れる `ShmHeader::version` の上限。
 ///
-/// # サイズ
+/// append-only な ABI 拡張のたびに引き上げる。`MAX_SUPPORTED_SHM_VERSION`
+/// より新しい driver は Bridge を更新するまで起動不可。
+pub const MAX_SUPPORTED_SHM_VERSION: u32 = 1;
+
+/// 単一スロット先頭に置かれる固定 8 byte のヘッダ。
 ///
-/// 1 + 3 + 4 + 8 + 4 + 4 + 240 = 264 byte。
+/// payload 部はこのヘッダの直後 `slot_size - 8` byte 続く。本構造体は
+/// `#[repr(C)]` で mmap / FFI レイアウトを保証する。
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct RingSlot {
-    /// 0 = 空、1 = 占有。
+pub struct SlotHeader {
+    /// 0 = 空、1 = 占有。空判定は本来 `write_index` / `read_index` の比較で
+    /// 十分だが、C 側の利便性（pop した直後に `slot.occupied == 1` で成功と
+    /// 判定）のために残す。
     pub occupied: u8,
     #[allow(clippy::pub_underscore_fields)]
     pub _pad: [u8; 3],
-    /// inline payload に書かれた msgpack バイト列の長さ（`<= PAYLOAD_INLINE_MAX`）。
-    /// side channel を使う場合は 0 にし、`side_len` 側を立てる。
+    /// payload のバイト長。`<= slot_size - 8`。
     pub payload_len: u32,
-    /// side channel 上の payload 開始オフセット（バイト）。`side_len > 0` の
-    /// ときのみ有効（`side_offset == 0` でも `side_len > 0` なら side channel
-    /// 先頭を指す有効ポインタ）。
-    pub side_offset: u64,
-    /// side channel 上の payload バイト長。**0 = side channel 未使用**。
-    /// side channel 使用判定はこのフィールドを canonical とする。
-    pub side_len: u32,
-    #[allow(clippy::pub_underscore_fields)]
-    pub _pad2: [u8; 4],
-    /// inline 格納用の msgpack バイト列。`payload_len` バイト目までが有効。
-    pub payload: [u8; PAYLOAD_INLINE_MAX],
 }
+
+const _: () = assert!(std::mem::size_of::<SlotHeader>() == SLOT_HEADER_SIZE as usize);
+const _: () = assert!(std::mem::align_of::<SlotHeader>() == 4);
 
 /// 共有メモリ領域の先頭に置かれるヘッダ。
 ///
-/// レイアウト（`AtomicU64` は `#[repr(C, align(8))]`、両フィールドとも 8 byte）:
+/// レイアウト:
 ///
 /// ```text
 /// offset 0:  write_index (AtomicU64)
 /// offset 8:  read_index  (AtomicU64)
-/// offset 16: slots[RING_CAPACITY] (RingSlot 配列)
+/// offset 16: slot_size   (u32)
+/// offset 20: version     (u32)
+/// offset 24: _pad        ([u8; 32])
+/// offset 56: <slots[RING_CAPACITY]; 各 slot_size byte>
 /// ```
 ///
 /// 両インデックスは単調増加。実際のスロット位置は `index % RING_CAPACITY`。
 /// バッファ満杯条件は `write_index - read_index == RING_CAPACITY`。
 ///
-/// 生産者はスロット書き込み後に `write_index` を [`std::sync::atomic::Ordering::Release`] で
-/// 公開し、消費者は `write_index` を [`std::sync::atomic::Ordering::Acquire`] で読んだ後に
-/// スロットを読む。
+/// 生産者はスロット書き込み後に `write_index` を [`std::sync::atomic::Ordering::Release`]
+/// で公開し、消費者は `write_index` を [`std::sync::atomic::Ordering::Acquire`]
+/// で読んだ後にスロットを読む。
+///
+/// `slot_size` / `version` は handshake 時に Bridge が書き込み、それ以降は
+/// 不変。`_pad` は将来の append-only 拡張余地で、cache line に収めるため
+/// 32 byte 確保している。
 #[repr(C)]
 pub struct ShmHeader {
-    pub write_index: std::sync::atomic::AtomicU64,
-    pub read_index: std::sync::atomic::AtomicU64,
+    pub write_index: AtomicU64,
+    pub read_index: AtomicU64,
+    /// slot 全体のバイト数。handshake で確定し、driver / Bridge とも本値を
+    /// 起点に stride 計算する。4 byte 倍数。
+    pub slot_size: u32,
+    /// ABI version。単調増加カウンタ。
+    pub version: u32,
+    /// 将来フィールド追加のための予約領域。
+    #[allow(clippy::pub_underscore_fields)]
+    pub _pad: [u8; 32],
+}
+
+const _: () = assert!(std::mem::size_of::<ShmHeader>() == 56);
+const _: () = assert!(std::mem::align_of::<ShmHeader>() == 8);
+
+/// `slot_size` 検証で検出される失敗種別。
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SlotSizeError {
+    /// `slot_size` が 4 byte 倍数でない。
+    NotAligned { slot_size: u32 },
+    /// `slot_size` が [`MIN_SLOT_SIZE`] 未満。
+    TooSmall { slot_size: u32 },
+    /// `slot_size` が [`HARD_SLOT_SIZE`] を超える。
+    TooLarge { slot_size: u32 },
+}
+
+impl std::fmt::Display for SlotSizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAligned { slot_size } => write!(
+                f,
+                "slot_size {slot_size} は 4 byte 倍数ではありません（ABI 違反）"
+            ),
+            Self::TooSmall { slot_size } => write!(
+                f,
+                "slot_size {slot_size} は最小値 {MIN_SLOT_SIZE} を下回っています"
+            ),
+            Self::TooLarge { slot_size } => write!(
+                f,
+                "slot_size {slot_size} は HARD_SLOT_SIZE {HARD_SLOT_SIZE} を超えています"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SlotSizeError {}
+
+/// `slot_size` が ABI 制約を満たすかを検証する。
+///
+/// driver 側の handshake 計算結果と、Bridge 側で受領した値の双方でこの関数
+/// を通すことで、4 byte alignment / 最小値 / 上限の 3 条件を一括検証できる。
+///
+/// # Errors
+///
+/// 4 byte 倍数性 / 最小値 / 上限のいずれかを満たさない場合に
+/// 対応する [`SlotSizeError`] を返す。
+pub fn validate_slot_size(slot_size: u32) -> Result<(), SlotSizeError> {
+    if !slot_size.is_multiple_of(4) {
+        return Err(SlotSizeError::NotAligned { slot_size });
+    }
+    if slot_size < MIN_SLOT_SIZE {
+        return Err(SlotSizeError::TooSmall { slot_size });
+    }
+    if slot_size > HARD_SLOT_SIZE {
+        return Err(SlotSizeError::TooLarge { slot_size });
+    }
+    Ok(())
+}
+
+/// driver 側で `max_payload_size` から要求 `slot_size` を導出する規約。
+///
+/// `((max_payload_size + SLOT_HEADER_SIZE) + 3) & !3` の式に従い、4 byte
+/// alignment へ切り上げる。algebraic に等価な
+/// `((max_payload_size + SLOT_HEADER_SIZE + 3) / 4) * 4` だが、bit mask の
+/// ほうが driver 側 SDK の典型実装と一致する。
+///
+/// 戻り値が [`HARD_SLOT_SIZE`] を超えるかどうかの判定は本関数では行わない
+/// （caller が [`validate_slot_size`] と組み合わせて使う）。
+#[must_use]
+pub const fn align_slot_size(max_payload_size: u32) -> u32 {
+    let raw = max_payload_size.saturating_add(SLOT_HEADER_SIZE);
+    raw.saturating_add(3) & !3u32
+}
+
+/// 1 driver ぶんの shm 領域の総バイト数を返す（ページ整列前）。
+///
+/// `sizeof(ShmHeader) + RING_CAPACITY × slot_size`。Bridge は本値を 4 KiB
+/// ページに切り上げて mmap する。
+///
+/// # Panics
+///
+/// `slot_size` が `validate_slot_size` を通っていない値だと `usize` への
+/// 拡張中にオーバーフローする可能性があるため、本関数を呼ぶ前に必ず
+/// `validate_slot_size` を通すこと。実際には `HARD_SLOT_SIZE` を上限に
+/// した値ならオーバーフローしない。
+#[must_use]
+pub const fn shm_total_size(slot_size: u32) -> usize {
+    std::mem::size_of::<ShmHeader>() + RING_CAPACITY * slot_size as usize
+}
+
+/// 0-origin の slot 番号（`index % RING_CAPACITY`）から、`ShmHeader` 末尾を
+/// 起点としたスロット先頭までのバイトオフセットを返す。
+///
+/// caller は `base_ptr.add(slot_offset_in_shm(slot_size, idx))` で raw byte
+/// アクセスを開始する。
+#[must_use]
+pub const fn slot_offset_in_shm(slot_size: u32, slot_index: usize) -> usize {
+    std::mem::size_of::<ShmHeader>() + slot_index * slot_size as usize
 }
 
 #[cfg(test)]
@@ -96,31 +235,84 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ring_capacity_nonzero() {
+    fn it_should_have_nonzero_ring_capacity() {
         const { assert!(RING_CAPACITY > 0) };
     }
 
     #[test]
-    fn payload_inline_max_is_positive() {
-        const { assert!(PAYLOAD_INLINE_MAX > 0) };
-    }
-
-    #[test]
-    fn shm_header_size_and_align() {
-        assert_eq!(std::mem::size_of::<ShmHeader>(), 16);
+    fn it_should_lock_shm_header_size_to_56_bytes() {
+        assert_eq!(std::mem::size_of::<ShmHeader>(), 56);
         assert_eq!(std::mem::align_of::<ShmHeader>(), 8);
     }
 
     #[test]
-    fn ring_slot_is_repr_c_and_fixed_size() {
-        // ドキュメントの 1 + 3 + 4 + 8 + 4 + 4 + 240 = 264 byte に固定。
-        // C ヘッダ（cbindgen 生成）と共有されるレイアウトなので、padding の
-        // 追加・並びの変更による ABI ドリフトをコンパイル時にも検出する。
-        const { assert!(std::mem::size_of::<RingSlot>() == 264) };
-        assert_eq!(std::mem::size_of::<RingSlot>(), 264);
+    fn it_should_lock_slot_header_size_to_8_bytes() {
+        assert_eq!(std::mem::size_of::<SlotHeader>(), SLOT_HEADER_SIZE as usize);
+    }
+
+    #[test]
+    fn it_should_default_slot_size_match_design_spec() {
+        // design/17-driver-comm/01-inline-ring.md の暫定値と整合するか。
+        assert_eq!(DEFAULT_SLOT_SIZE, 1032);
+        assert_eq!(HARD_SLOT_SIZE, 65_536);
+    }
+
+    #[test]
+    fn it_should_validate_default_slot_size() {
+        validate_slot_size(DEFAULT_SLOT_SIZE).expect("default は valid");
+    }
+
+    #[test]
+    fn it_should_reject_slot_size_not_multiple_of_4() {
+        let err = validate_slot_size(13).expect_err("alignment 違反");
+        assert!(matches!(err, SlotSizeError::NotAligned { .. }));
+    }
+
+    #[test]
+    fn it_should_reject_slot_size_below_min() {
+        let err = validate_slot_size(8).expect_err("min 未満");
+        assert!(matches!(err, SlotSizeError::TooSmall { .. }));
+    }
+
+    #[test]
+    fn it_should_reject_slot_size_above_hard_limit() {
+        let err = validate_slot_size(HARD_SLOT_SIZE + 4).expect_err("hard 超過");
+        assert!(matches!(err, SlotSizeError::TooLarge { .. }));
+    }
+
+    #[test]
+    fn it_should_align_slot_size_to_next_multiple_of_4() {
+        // payload 1024 → header 8 加算 → 1032（既に 4 倍数）
+        assert_eq!(align_slot_size(1024), 1032);
+        // payload 1023 → 1031 → 切り上げ 1032
+        assert_eq!(align_slot_size(1023), 1032);
+        // payload 1 → 9 → 切り上げ 12
+        assert_eq!(align_slot_size(1), 12);
+        // payload 0 → 8 → 8（既に 4 倍数。但し validate_slot_size は MIN_SLOT_SIZE=12 で reject）
+        assert_eq!(align_slot_size(0), 8);
+    }
+
+    #[test]
+    fn it_should_compute_slot_offset_relative_to_shm_base() {
+        let slot_size = DEFAULT_SLOT_SIZE;
+        let header_size = std::mem::size_of::<ShmHeader>();
+        assert_eq!(slot_offset_in_shm(slot_size, 0), header_size);
         assert_eq!(
-            std::mem::size_of::<RingSlot>() % std::mem::align_of::<RingSlot>(),
-            0
+            slot_offset_in_shm(slot_size, 1),
+            header_size + slot_size as usize
+        );
+        assert_eq!(
+            slot_offset_in_shm(slot_size, RING_CAPACITY - 1),
+            header_size + (RING_CAPACITY - 1) * slot_size as usize
+        );
+    }
+
+    #[test]
+    fn it_should_compute_shm_total_size_for_default_slot() {
+        let total = shm_total_size(DEFAULT_SLOT_SIZE);
+        assert_eq!(
+            total,
+            std::mem::size_of::<ShmHeader>() + RING_CAPACITY * DEFAULT_SLOT_SIZE as usize
         );
     }
 }

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -1,6 +1,7 @@
 mod error;
 mod events_pipeline;
 mod events_schema;
+mod ring_handshake;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;

--- a/crates/midori-runtime/src/ring_handshake.rs
+++ b/crates/midori-runtime/src/ring_handshake.rs
@@ -1,12 +1,6 @@
 //! Bridge 側で driver からの `request_ring(slot_size)` 受領を処理する経路。
 //!
-//! 公開 API は driver process spawn / control channel 経由で接続される予定で、
-//! 現状 main から caller が居ないため module 全体で `dead_code` を抑制する。
-//! 単体テストで挙動を担保している。
-#![allow(dead_code)]
-
-//!
-//! design/17-driver-comm/01-inline-ring.md の handshake プロトコルに従い:
+//! `design/17-driver-comm/01-inline-ring.md` の handshake プロトコルに従い:
 //!
 //! 1. driver が events.yaml の inline tier 全イベントから `max_payload_size`
 //!    と必要 `slot_size = ((max_payload_size + 8) + 3) & !3` を計算
@@ -14,13 +8,18 @@
 //!    sentinel `0` で「default 要求なし」を示す
 //! 3. Bridge: 受信値が `0` なら `DEFAULT_SLOT_SIZE` を採用、それ以外は受信値
 //!    をそのまま採用したうえで alignment / 上限を validate
-//! 4. Bridge: shm 領域全体を 4 KiB ページに切り上げて mmap（実装は本 module
-//!    では in-process Box backing でモックし、実 fd / mmap 確保は driver
-//!    process spawn の subtask に委ねる）
+//! 4. Bridge: shm 領域全体を 4 KiB ページに切り上げて mmap
 //!
 //! 本 module はステップ 3-4 のうち「`slot_size` の解決と検証」「ページ整列
-//! 計算」までを担う。control channel の wire format（serde 等）と実 shm fd
-//! 確保は別 subtask の責務。
+//! 計算」までを担う。**範囲外**: control channel の wire format（serde 等で
+//! 通信する `request_ring` メッセージ構造）と、実 driver process spawn 経由
+//! での shm fd 確保 / `mmap(2)` 呼び出し。これらは driver lifecycle 管理が
+//! 入った段階で別 module から本 module の関数を呼ぶ形で接続する。
+//!
+//! 公開 API は driver process spawn / control channel 経由で接続される予定で、
+//! 現状 main から caller が居ないため module 全体で `dead_code` を抑制する。
+//! 単体テストで挙動を担保している。
+#![allow(dead_code)]
 
 use std::error::Error;
 use std::fmt;
@@ -169,13 +168,19 @@ mod tests {
     }
 
     #[test]
-    fn it_should_render_handshake_error_display_with_slot_size_context() {
+    fn it_should_render_handshake_error_display_with_slot_size_and_inner_reason() {
+        // 4 byte 倍数違反のケース。Display は外側の handshake 文脈に加えて
+        // 内側 SlotSizeError の理由フレーズも含むことを担保する。
         let err = resolve_requested_slot_size(13).expect_err("alignment");
         let rendered = err.to_string();
         assert!(rendered.contains("13"), "Display に値を含む: {rendered}");
         assert!(
             rendered.contains("request_ring"),
             "Display に handshake 文脈を含む: {rendered}"
+        );
+        assert!(
+            rendered.contains("4 byte 倍数"),
+            "Display に SlotSizeError の理由フレーズを含む: {rendered}"
         );
     }
 }

--- a/crates/midori-runtime/src/ring_handshake.rs
+++ b/crates/midori-runtime/src/ring_handshake.rs
@@ -33,6 +33,10 @@ use midori_core::shm::{shm_total_size, validate_slot_size, SlotSizeError, DEFAUL
 /// driver 側 SDK は本値を仮定して buffer alignment を計算する規約になっている。
 pub const PAGE_SIZE: usize = 4096;
 
+// `page_aligned_shm_size` の bit-mask 計算は `PAGE_SIZE` が 2 のべき乗である
+// ことを前提とする。値変更時に静かに崩れないよう compile-time で固定する。
+const _: () = assert!(PAGE_SIZE.is_power_of_two());
+
 /// driver の `request_ring` メッセージで sentinel として使う値。
 ///
 /// `requested_slot_size == 0` のとき driver は「default で確保してくれ」を

--- a/crates/midori-runtime/src/ring_handshake.rs
+++ b/crates/midori-runtime/src/ring_handshake.rs
@@ -1,0 +1,181 @@
+//! Bridge 側で driver からの `request_ring(slot_size)` 受領を処理する経路。
+//!
+//! 公開 API は driver process spawn / control channel 経由で接続される予定で、
+//! 現状 main から caller が居ないため module 全体で `dead_code` を抑制する。
+//! 単体テストで挙動を担保している。
+#![allow(dead_code)]
+
+//!
+//! design/17-driver-comm/01-inline-ring.md の handshake プロトコルに従い:
+//!
+//! 1. driver が events.yaml の inline tier 全イベントから `max_payload_size`
+//!    と必要 `slot_size = ((max_payload_size + 8) + 3) & !3` を計算
+//! 2. driver → Bridge: `slot_size` 送信。`<= DEFAULT_SLOT_SIZE` のときは
+//!    sentinel `0` で「default 要求なし」を示す
+//! 3. Bridge: 受信値が `0` なら `DEFAULT_SLOT_SIZE` を採用、それ以外は受信値
+//!    をそのまま採用したうえで alignment / 上限を validate
+//! 4. Bridge: shm 領域全体を 4 KiB ページに切り上げて mmap（実装は本 module
+//!    では in-process Box backing でモックし、実 fd / mmap 確保は driver
+//!    process spawn の subtask に委ねる）
+//!
+//! 本 module はステップ 3-4 のうち「`slot_size` の解決と検証」「ページ整列
+//! 計算」までを担う。control channel の wire format（serde 等）と実 shm fd
+//! 確保は別 subtask の責務。
+
+use std::error::Error;
+use std::fmt;
+
+use midori_core::shm::{shm_total_size, validate_slot_size, SlotSizeError, DEFAULT_SLOT_SIZE};
+
+/// メモリマップに用いるページサイズ。design では 4 KiB を仮定している。
+///
+/// Bridge は `shm_total_size(slot_size)` を本値に切り上げて mmap する。
+/// 4 KiB は Linux / macOS / Windows いずれの典型ページサイズの最小公倍数で、
+/// driver 側 SDK は本値を仮定して buffer alignment を計算する規約になっている。
+pub const PAGE_SIZE: usize = 4096;
+
+/// driver の `request_ring` メッセージで sentinel として使う値。
+///
+/// `requested_slot_size == 0` のとき driver は「default で確保してくれ」を
+/// 意味する。実 `slot_size` = 0 は `MIN_SLOT_SIZE = 12` 未満で validator が
+/// reject するため、sentinel として安全に使える。
+pub const REQUEST_DEFAULT_SLOT_SIZE: u32 = 0;
+
+/// driver からの `request_ring(slot_size)` 受領時に発生する失敗。
+#[derive(Debug, PartialEq, Eq)]
+pub enum HandshakeError {
+    /// 受信した `slot_size` が ABI 制約（alignment / 最小値 / 上限）を
+    /// 満たさない。具体内容は内包する [`SlotSizeError`] を参照。
+    InvalidSlotSize {
+        requested_slot_size: u32,
+        source: SlotSizeError,
+    },
+}
+
+impl fmt::Display for HandshakeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidSlotSize {
+                requested_slot_size,
+                source,
+            } => write!(
+                f,
+                "driver からの request_ring が拒否されました（slot_size={requested_slot_size}）: {source}"
+            ),
+        }
+    }
+}
+
+impl Error for HandshakeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidSlotSize { source, .. } => Some(source),
+        }
+    }
+}
+
+/// driver から受け取った `requested_slot_size` を Bridge 側で解決する。
+///
+/// - `requested_slot_size == REQUEST_DEFAULT_SLOT_SIZE` (= 0) のとき:
+///   `DEFAULT_SLOT_SIZE` を採用する
+/// - それ以外: 受信値をそのまま採用し、alignment / 上限を validate
+///
+/// # Errors
+///
+/// alignment 違反 / `MIN_SLOT_SIZE` 未満 / `HARD_SLOT_SIZE` 超過のいずれか
+/// で [`HandshakeError::InvalidSlotSize`] を返す。
+pub fn resolve_requested_slot_size(requested_slot_size: u32) -> Result<u32, HandshakeError> {
+    let resolved = if requested_slot_size == REQUEST_DEFAULT_SLOT_SIZE {
+        DEFAULT_SLOT_SIZE
+    } else {
+        requested_slot_size
+    };
+    validate_slot_size(resolved).map_err(|source| HandshakeError::InvalidSlotSize {
+        requested_slot_size,
+        source,
+    })?;
+    Ok(resolved)
+}
+
+/// 解決済み `slot_size` から、4 KiB ページに切り上げた shm 全体サイズ
+/// （byte）を返す。Bridge は本値を mmap 引数として使う。
+///
+/// 計算式: `(shm_total + PAGE_SIZE - 1) & !(PAGE_SIZE - 1)`。bit mask は
+/// `PAGE_SIZE` が 2 のべき乗であることを利用した整列イディオムで、
+/// `((shm_total + PAGE_SIZE - 1) / PAGE_SIZE) * PAGE_SIZE` と等価。
+#[must_use]
+pub const fn page_aligned_shm_size(slot_size: u32) -> usize {
+    let total = shm_total_size(slot_size);
+    (total + PAGE_SIZE - 1) & !(PAGE_SIZE - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use midori_core::shm::{HARD_SLOT_SIZE, RING_CAPACITY};
+
+    #[test]
+    fn it_should_resolve_sentinel_to_default_slot_size() {
+        let resolved = resolve_requested_slot_size(REQUEST_DEFAULT_SLOT_SIZE).expect("default");
+        assert_eq!(resolved, DEFAULT_SLOT_SIZE);
+    }
+
+    #[test]
+    fn it_should_pass_through_valid_custom_slot_size() {
+        let resolved = resolve_requested_slot_size(4_104).expect("4 KiB slot");
+        assert_eq!(resolved, 4_104);
+    }
+
+    #[test]
+    fn it_should_reject_alignment_violation() {
+        let err = resolve_requested_slot_size(13).expect_err("alignment 違反");
+        assert!(matches!(
+            err,
+            HandshakeError::InvalidSlotSize {
+                source: SlotSizeError::NotAligned { .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn it_should_reject_above_hard_limit() {
+        let err = resolve_requested_slot_size(HARD_SLOT_SIZE + 4).expect_err("hard 超過");
+        assert!(matches!(
+            err,
+            HandshakeError::InvalidSlotSize {
+                source: SlotSizeError::TooLarge { .. },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn it_should_round_shm_total_up_to_page_size() {
+        // DEFAULT_SLOT_SIZE での実 shm 容量
+        let aligned = page_aligned_shm_size(DEFAULT_SLOT_SIZE);
+        // shm_total = 56 + 256 * 1032 = 264,248 byte. 4 KiB ページに切り上げ → 65 ページ = 266,240 byte
+        assert!(
+            aligned.is_multiple_of(PAGE_SIZE),
+            "ページ整列していること: {aligned}"
+        );
+        let raw_total = std::mem::size_of::<midori_core::shm::ShmHeader>()
+            + RING_CAPACITY * DEFAULT_SLOT_SIZE as usize;
+        assert!(aligned >= raw_total, "raw_total を下回らない");
+        assert!(
+            aligned < raw_total + PAGE_SIZE,
+            "1 ページ超過しない（最小切り上げ）"
+        );
+    }
+
+    #[test]
+    fn it_should_render_handshake_error_display_with_slot_size_context() {
+        let err = resolve_requested_slot_size(13).expect_err("alignment");
+        let rendered = err.to_string();
+        assert!(rendered.contains("13"), "Display に値を含む: {rendered}");
+        assert!(
+            rendered.contains("request_ring"),
+            "Display に handshake 文脈を含む: {rendered}"
+        );
+    }
+}

--- a/crates/midori-sdk/Cargo.toml
+++ b/crates/midori-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midori-sdk"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Driver SDK for the Midori signal bridge: shared types, SPSC ring buffer, and CLI scaffolding"
 license = "MIT OR Apache-2.0"

--- a/crates/midori-sdk/cbindgen.toml
+++ b/crates/midori-sdk/cbindgen.toml
@@ -14,6 +14,25 @@ include = ["midori-core"]
 
 [export]
 prefix = ""
+include = [
+    "ShmHeader",
+    "SlotHeader",
+    "RING_CAPACITY",
+    "DEFAULT_SLOT_SIZE",
+    "HARD_SLOT_SIZE",
+    "MIN_SLOT_SIZE",
+    "SLOT_HEADER_SIZE",
+    "SHM_LAYOUT_VERSION",
+    "MIN_SUPPORTED_SHM_VERSION",
+    "MAX_SUPPORTED_SHM_VERSION",
+]
+
+# `AtomicU64` は C 側で未定義型なので uint64_t に rename する（メモリ表現は
+# 同じ）。C 側で atomic 操作を直接書くなら C11 の <stdatomic.h> 経由で
+# `_Atomic uint64_t` として扱う前提。本ヘッダは layout 共有用に留め、
+# atomic 操作は Rust 側 / SDK 関数経由で行うのが原則。
+[export.rename]
+"AtomicU64" = "uint64_t"
 
 [fn]
 prefix = ""

--- a/crates/midori-sdk/cbindgen.toml
+++ b/crates/midori-sdk/cbindgen.toml
@@ -14,6 +14,15 @@ include = ["midori-core"]
 
 [export]
 prefix = ""
+# C 側 binding 作者が shm レイアウトを直接計算するために最小限必要な型・定数
+# のみを明示列挙する。具体的には:
+#   - ShmHeader / SlotHeader: layout 確認 / 自前 cast に必要な構造体
+#   - RING_CAPACITY: ring buffer のスロット数
+#   - DEFAULT_SLOT_SIZE / HARD_SLOT_SIZE / MIN_SLOT_SIZE / SLOT_HEADER_SIZE:
+#     handshake で交換する slot_size の境界
+#   - SHM_LAYOUT_VERSION / MIN/MAX_SUPPORTED_SHM_VERSION: ABI 互換性チェック
+# midori-core に他にも公開シンボルはあるが、driver / Bridge プロセス境界を
+# またがない型（Value / Signal / IpcEvent 等）はあえて出さない。
 include = [
     "ShmHeader",
     "SlotHeader",

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -218,7 +218,7 @@ mod tests {
                 raw.cast::<c_void>(),
                 out_buf.as_mut_ptr(),
                 out_buf.len(),
-                &raw mut out_len,
+                std::ptr::addr_of_mut!(out_len),
             )
         };
         assert_eq!(popped, 1);
@@ -230,7 +230,7 @@ mod tests {
                 raw.cast::<c_void>(),
                 out_buf.as_mut_ptr(),
                 out_buf.len(),
-                &raw mut out_len,
+                std::ptr::addr_of_mut!(out_len),
             )
         };
         assert_eq!(popped_empty, 0);
@@ -255,7 +255,7 @@ mod tests {
                 raw.cast::<c_void>(),
                 out_buf.as_mut_ptr(),
                 out_buf.len(),
-                &raw mut out_len,
+                std::ptr::addr_of_mut!(out_len),
             )
         };
         assert_eq!(popped, 1);
@@ -310,7 +310,7 @@ mod tests {
                     std::ptr::null::<c_void>(),
                     payload.as_mut_ptr(),
                     payload.len(),
-                    &raw mut out_len,
+                    std::ptr::addr_of_mut!(out_len),
                 )
             },
             0
@@ -328,7 +328,7 @@ mod tests {
                     raw.cast::<c_void>(),
                     std::ptr::null_mut::<u8>(),
                     4,
-                    &raw mut out_len,
+                    std::ptr::addr_of_mut!(out_len),
                 )
             },
             0
@@ -362,7 +362,7 @@ mod tests {
                 raw.cast::<c_void>(),
                 tiny_buf.as_mut_ptr(),
                 tiny_buf.len(),
-                &raw mut out_len,
+                std::ptr::addr_of_mut!(out_len),
             )
         };
         assert_eq!(popped, -3, "capacity 不足は -3 で empty と区別される");
@@ -374,7 +374,7 @@ mod tests {
                 raw.cast::<c_void>(),
                 large_buf.as_mut_ptr(),
                 large_buf.len(),
-                &raw mut out_len,
+                std::ptr::addr_of_mut!(out_len),
             )
         };
         assert_eq!(popped_again, 0, "slot は既に消費済みなので empty");

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -36,8 +36,8 @@ use std::ffi::c_void;
 
 use midori_core::shm::{self, validate_slot_size};
 
-use crate::spsc::{self, SpscStorage};
-use midori_core::shm::ShmHeader;
+use crate::spsc::{self, PopOutcome, SpscStorage};
+use midori_core::shm::{ShmHeader, MAX_SUPPORTED_SHM_VERSION, MIN_SUPPORTED_SHM_VERSION};
 
 /// 指定 `slot_size` の [`SpscStorage`] を確保するために必要なバイト数を返す。
 ///
@@ -122,13 +122,10 @@ pub unsafe extern "C" fn midori_sdk_spsc_push(
         std::slice::from_raw_parts(payload, payload_len)
     };
     let header = &*storage.cast::<ShmHeader>();
-    let slot_size = header.slot_size;
-    // 共有メモリは別プロセスから書き換えられる可能性があるため、ヘッダの
-    // `slot_size` をそのまま stride 計算に使う前に防衛的 validate する。
-    // 不正値（汚染 / 未初期化）のときは `0` (= 一般的失敗) を返す。
-    if validate_slot_size(slot_size).is_err() {
+    if !is_header_compatible(header) {
         return 0;
     }
+    let slot_size = header.slot_size;
     spsc::push_raw(storage.cast::<u8>().cast_mut(), slot_size, bytes).as_ffi_code()
 }
 
@@ -168,28 +165,43 @@ pub unsafe extern "C" fn midori_sdk_spsc_pop(
         return 0;
     }
     let header = &*storage.cast::<ShmHeader>();
+    if !is_header_compatible(header) {
+        return 0;
+    }
     let slot_size = header.slot_size;
-    // push 側と同様、ヘッダの `slot_size` を信用する前に validate して
-    // shm 汚染による out-of-bounds 読みを防ぐ。
-    if validate_slot_size(slot_size).is_err() {
-        return 0;
+    // FFI hot path では Vec allocate を避けるため `pop_raw_into` を直接
+    // 呼び、caller buffer に payload bytes をコピーする。slot は SPSC 規律
+    // により capacity check に関わらず消費されるが、`*out_payload_len` に
+    // 本来必要だった byte 数を書くことで caller は再 pop 不可な事実を観測
+    // 可能（戻り値 -3 で empty と区別）。
+    match spsc::pop_raw_into(
+        storage.cast::<u8>(),
+        slot_size,
+        out_payload,
+        out_payload_cap,
+    ) {
+        PopOutcome::Empty => 0,
+        PopOutcome::Copied(len) => {
+            *out_payload_len = len;
+            1
+        }
+        PopOutcome::Truncated(required) => {
+            *out_payload_len = required;
+            -3
+        }
     }
-    let Some(payload) = spsc::pop_raw(storage.cast::<u8>(), slot_size) else {
-        return 0;
-    };
-    *out_payload_len = payload.len();
-    if payload.len() > out_payload_cap {
-        // 契約違反: caller が小さすぎる buffer を渡した。SPSC 規律上 slot
-        // は既に消費されており再 pop できないため payload は破棄するが、
-        // `*out_payload_len` に本来のバイト長を残し、戻り値 -3 で「empty
-        // と区別可能な失敗」を示す。caller はログ出力 + buffer 拡大で
-        // 次回以降に備える。
-        return -3;
+}
+
+/// `ShmHeader` の `slot_size` と `version` が本 build の SDK で扱える範囲か
+/// を判定する。共有メモリの汚染 / 未初期化 / version 不一致を一括ガード
+/// する。
+#[inline]
+fn is_header_compatible(header: &ShmHeader) -> bool {
+    if validate_slot_size(header.slot_size).is_err() {
+        return false;
     }
-    if !payload.is_empty() {
-        std::ptr::copy_nonoverlapping(payload.as_ptr(), out_payload, payload.len());
-    }
-    1
+    let v = header.version;
+    (MIN_SUPPORTED_SHM_VERSION..=MAX_SUPPORTED_SHM_VERSION).contains(&v)
 }
 
 #[cfg(test)]

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -97,7 +97,9 @@ pub unsafe extern "C" fn midori_sdk_spsc_init(storage: *mut c_void, slot_size: u
 ///
 /// # Safety
 ///
-/// - `storage` は [`midori_sdk_spsc_init`] 済みの領域を指すこと
+/// - `storage` は [`midori_sdk_spsc_init`] 済みの領域を指し、
+///   [`midori_sdk_spsc_storage_alignment`] (= 8 byte) のアラインメントを
+///   満たすこと（`ShmHeader` が cast 経由で参照されるため）
 /// - `payload` / `payload_len` は読み取り可能なバイト列を指すこと（`payload`
 ///   が NULL かつ `payload_len == 0` のときは empty payload として扱う）
 /// - 同時に 1 スレッドからのみ呼ばれること（SPSC 生産者規律）
@@ -128,11 +130,20 @@ pub unsafe extern "C" fn midori_sdk_spsc_push(
 ///
 /// 戻り値:
 /// - `1`: 成功（`out_payload` に payload を書き、`*out_payload_len` に長さを書く）
-/// - `0`: バッファ空、引数 NULL、または `out_payload_cap < slot_size - 8`
+/// - `0`: バッファ空、または引数 NULL（`storage` / `out_payload_len`、または
+///   `out_payload == NULL && out_payload_cap > 0` の不整合）
+/// - `-3`: 契約違反による容量不足。`out_payload_cap < payload.len()` のときに
+///   発生する。SPSC 規律上 slot は既に消費されており **再 pop できない**
+///   ため、payload バイトは破棄される。`*out_payload_len` には消費された
+///   payload の本来のバイト長が書き込まれる（caller が次回必要 buffer を
+///   見積もるため）。caller は `ShmHeader::slot_size - 8` 以上の buffer を
+///   常に渡す契約だが、それを破ったときに **観測可能** なエラーで失敗する
 ///
 /// # Safety
 ///
-/// - `storage` は [`midori_sdk_spsc_init`] 済みの領域を指すこと
+/// - `storage` は [`midori_sdk_spsc_init`] 済みの領域を指し、
+///   [`midori_sdk_spsc_storage_alignment`] (= 8 byte) のアラインメントを
+///   満たすこと（`ShmHeader` が cast 経由で参照されるため）
 /// - `out_payload` は `out_payload_cap` バイト以上の書き込み可能領域を指すこと
 /// - `out_payload_len` は書き込み可能な `usize` を指すこと
 /// - 同時に 1 スレッドからのみ呼ばれること（SPSC 消費者規律）
@@ -155,17 +166,18 @@ pub unsafe extern "C" fn midori_sdk_spsc_pop(
     let Some(payload) = spsc::pop_raw(storage.cast::<u8>(), slot_size) else {
         return 0;
     };
+    *out_payload_len = payload.len();
     if payload.len() > out_payload_cap {
-        // capacity 不足で書き込めない。caller は `slot_size - 8` 以上の buffer
-        // を渡す責務を持つ。本実装では payload は捨てた状態で 0 を返す
-        // （SPSC 規律上、再 pop はできない）。これは driver SDK が
-        // slot_size を知らずに小さい buffer を渡した契約違反を意味する。
-        return 0;
+        // 契約違反: caller が小さすぎる buffer を渡した。SPSC 規律上 slot
+        // は既に消費されており再 pop できないため payload は破棄するが、
+        // `*out_payload_len` に本来のバイト長を残し、戻り値 -3 で「empty
+        // と区別可能な失敗」を示す。caller はログ出力 + buffer 拡大で
+        // 次回以降に備える。
+        return -3;
     }
     if !payload.is_empty() {
         std::ptr::copy_nonoverlapping(payload.as_ptr(), out_payload, payload.len());
     }
-    *out_payload_len = payload.len();
     1
 }
 
@@ -331,6 +343,64 @@ mod tests {
     }
 
     #[test]
+    fn it_should_return_minus_three_when_pop_buffer_is_smaller_than_payload() {
+        // caller が `slot_size - 8` 未満の小さい buffer を渡したケース。slot は
+        // 消費されるが payload は破棄され、戻り値 -3 で empty (= 0) と区別する。
+        // `*out_payload_len` には本来必要だった payload バイト長が書かれる。
+        let (raw, layout) = alloc_storage(DEFAULT_SLOT_SIZE);
+
+        let payload: Vec<u8> = vec![0xAB; 64];
+        let pushed =
+            unsafe { midori_sdk_spsc_push(raw.cast::<c_void>(), payload.as_ptr(), payload.len()) };
+        assert_eq!(pushed, 1);
+
+        // buffer が 32 byte しか無い → pop は -3 を返し、出力長は 64 を伝える
+        let mut tiny_buf = vec![0u8; 32];
+        let mut out_len: usize = 0;
+        let popped = unsafe {
+            midori_sdk_spsc_pop(
+                raw.cast::<c_void>(),
+                tiny_buf.as_mut_ptr(),
+                tiny_buf.len(),
+                &raw mut out_len,
+            )
+        };
+        assert_eq!(popped, -3, "capacity 不足は -3 で empty と区別される");
+        assert_eq!(out_len, 64, "本来必要だった payload 長を伝える");
+        // slot は消費済みなので再 pop は empty を返す
+        let mut large_buf = vec![0u8; (DEFAULT_SLOT_SIZE - SLOT_HEADER_SIZE) as usize];
+        let popped_again = unsafe {
+            midori_sdk_spsc_pop(
+                raw.cast::<c_void>(),
+                large_buf.as_mut_ptr(),
+                large_buf.len(),
+                &raw mut out_len,
+            )
+        };
+        assert_eq!(popped_again, 0, "slot は既に消費済みなので empty");
+
+        dealloc_storage(raw, layout);
+    }
+
+    #[test]
+    fn it_should_return_zero_when_out_payload_len_pointer_is_null() {
+        // `out_payload_len NULL` 単体ケース。OR 条件 `storage.is_null() ||
+        // out_payload_len.is_null()` の後者ブランチを直接担保する。
+        let (raw, layout) = alloc_storage(DEFAULT_SLOT_SIZE);
+        let mut tiny_buf = [0u8; 4];
+        let popped = unsafe {
+            midori_sdk_spsc_pop(
+                raw.cast::<c_void>(),
+                tiny_buf.as_mut_ptr(),
+                tiny_buf.len(),
+                std::ptr::null_mut::<usize>(),
+            )
+        };
+        assert_eq!(popped, 0);
+        dealloc_storage(raw, layout);
+    }
+
+    #[test]
     fn it_should_storage_size_match_layout_for_default_slot() {
         let size = midori_sdk_spsc_storage_size(DEFAULT_SLOT_SIZE);
         let align = midori_sdk_spsc_storage_alignment();
@@ -354,7 +424,7 @@ mod tests {
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_init"));
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_push"));
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_pop"));
-        // 新レイアウトの構造体型
+        // 新レイアウトの構造体型（C 側で layout 計算に必須）
         assert!(GENERATED_HEADER.contains("ShmHeader"));
         assert!(GENERATED_HEADER.contains("SlotHeader"));
         // 戻り値型の breaking change：旧 u8 ではなく i32 (= int32_t)
@@ -364,5 +434,11 @@ mod tests {
         assert!(!GENERATED_HEADER.contains("PAYLOAD_INLINE_MAX"));
         assert!(!GENERATED_HEADER.contains("side_offset"));
         assert!(!GENERATED_HEADER.contains("side_len"));
+        // 注: ABI 定数群（DEFAULT_SLOT_SIZE / HARD_SLOT_SIZE / SLOT_HEADER_SIZE
+        // / SHM_LAYOUT_VERSION 等）は cbindgen.toml の [export].include に
+        // 列挙してあるが、cbindgen 0.29 の現行設定では const が C ヘッダに
+        // 出力されない（parse.expand の追加調整が必要）。C 側 binding 作者は
+        // 当面これらの値を C 側で重複定義する運用となる。本検証では struct
+        // と FFI 関数の出力までを担保する。
     }
 }

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -5,16 +5,19 @@
 //!
 //! # メモリ確保ポリシー
 //!
-//! [`SpscStorage`] の内部レイアウト
-//! （`UnsafeCell` の配列など）は不透明型として扱う。C 側はサイズと
+//! [`SpscStorage`] の内部レイアウトは不透明バイト列として扱う。C 側はサイズと
 //! アラインメントを問い合わせて自前で確保し、[`midori_sdk_spsc_init`] で
-//! 初期化する。
+//! 初期化する。サイズは `slot_size` に依存するため、handshake で確定した値を
+//! 渡す。
 //!
 //! ```c
-//! size_t size  = midori_sdk_spsc_storage_size();
+//! uint32_t slot_size = 1032; /* default、または handshake 戻り値 */
+//! size_t size  = midori_sdk_spsc_storage_size(slot_size);
 //! size_t align = midori_sdk_spsc_storage_alignment();
 //! void* storage = aligned_alloc(align, size);
-//! midori_sdk_spsc_init(storage);
+//! if (midori_sdk_spsc_init(storage, slot_size) != 1) {
+//!     /* slot_size が不正（4 byte 倍数でない / HARD 超過 等） */
+//! }
 //! ```
 //!
 //! # SPSC 規律
@@ -23,28 +26,45 @@
 //! [`midori_sdk_spsc_pop`] も同時に 1 スレッドからのみ呼ばれること。
 //! 違反時の挙動は未規定。これは Rust 側 API では `&mut Producer` /
 //! `&mut Consumer` で型レベルに保証している規律と同じ。
+//!
+//! # FFI 戻り値
+//!
+//! `push` / `pop` / `init` の戻り値は `int32_t` を返す。`push` の戻り値
+//! `-2` は payload size 超過（events.yaml 違反 / driver 実装バグ相当）を表す。
 
 use std::ffi::c_void;
 
-use midori_core::shm::RingSlot;
+use midori_core::shm::{self, validate_slot_size};
 
 use crate::spsc::{self, SpscStorage};
+use midori_core::shm::ShmHeader;
 
-/// [`SpscStorage`] を確保するために必要なバイト数を返す。
+/// 指定 `slot_size` の [`SpscStorage`] を確保するために必要なバイト数を返す。
+///
+/// `slot_size` が不正な値の場合は `0` を返す。caller はゼロ判定で確保失敗を
+/// 検出する。
 #[allow(unsafe_code)] // `#[no_mangle]` は安全な関数でも unsafe_code lint の対象
 #[no_mangle]
-pub extern "C" fn midori_sdk_spsc_storage_size() -> usize {
-    std::mem::size_of::<SpscStorage>()
+pub extern "C" fn midori_sdk_spsc_storage_size(slot_size: u32) -> usize {
+    if validate_slot_size(slot_size).is_err() {
+        return 0;
+    }
+    shm::shm_total_size(slot_size)
 }
 
-/// [`SpscStorage`] を確保するときに必要なアラインメントを返す。
+/// [`SpscStorage`] を確保するときに必要なアラインメントを返す（`slot_size` に
+/// 依存しない固定値）。
 #[allow(unsafe_code)]
 #[no_mangle]
 pub extern "C" fn midori_sdk_spsc_storage_alignment() -> usize {
-    std::mem::align_of::<SpscStorage>()
+    std::mem::align_of::<shm::ShmHeader>()
 }
 
 /// 確保済みのメモリ領域に空の SPSC ストレージを書き込む。
+///
+/// 戻り値:
+/// - `1`: 成功
+/// - `0`: `slot_size` が不正、または `storage` が NULL
 ///
 /// # Safety
 ///
@@ -57,298 +77,292 @@ pub extern "C" fn midori_sdk_spsc_storage_alignment() -> usize {
 /// アクセスしていないことを呼び出し側が保証すること。
 #[allow(unsafe_code)]
 #[no_mangle]
-pub unsafe extern "C" fn midori_sdk_spsc_init(storage: *mut c_void) {
+pub unsafe extern "C" fn midori_sdk_spsc_init(storage: *mut c_void, slot_size: u32) -> i32 {
     if storage.is_null() {
-        return;
+        return 0;
     }
-    // ~75 KB の `SpscStorage` を呼び出し側スタックに一時生成せず、宛先ポインタへ
-    // 直接書き込む。小さなスレッドスタックから呼ばれた場合のオーバーフローを回避。
-    SpscStorage::init_in_place(storage.cast::<SpscStorage>());
+    if validate_slot_size(slot_size).is_err() {
+        return 0;
+    }
+    SpscStorage::init_in_place(storage.cast::<u8>(), slot_size);
+    1
 }
 
-/// スロットを 1 つ push する。
+/// payload バイト列を 1 つ push する。
 ///
 /// 戻り値:
 /// - `1`: 成功
 /// - `0`: バッファ満杯または引数 NULL
+/// - `-2`: payload バイト長が `slot_size - 8` を超える（events.yaml 違反）
 ///
 /// # Safety
 ///
 /// - `storage` は [`midori_sdk_spsc_init`] 済みの領域を指すこと
-/// - `slot` は有効な [`RingSlot`] を指すこと（読み取りは
-///   [`std::ptr::read_unaligned`] を使うためアラインメントは不問）
+/// - `payload` / `payload_len` は読み取り可能なバイト列を指すこと（`payload`
+///   が NULL かつ `payload_len == 0` のときは empty payload として扱う）
 /// - 同時に 1 スレッドからのみ呼ばれること（SPSC 生産者規律）
 #[allow(unsafe_code)]
 #[no_mangle]
-pub unsafe extern "C" fn midori_sdk_spsc_push(storage: *const c_void, slot: *const RingSlot) -> u8 {
-    if storage.is_null() || slot.is_null() {
+pub unsafe extern "C" fn midori_sdk_spsc_push(
+    storage: *const c_void,
+    payload: *const u8,
+    payload_len: usize,
+) -> i32 {
+    if storage.is_null() {
         return 0;
     }
-    let storage = &*storage.cast::<SpscStorage>();
-    // C 側で `#pragma pack` 等によりパックされたポインタを渡されても UB を
-    // 起こさないよう unaligned read を採用する。
-    let slot = std::ptr::read_unaligned(slot);
-    u8::from(spsc::try_push(storage, &slot).is_ok())
+    if payload.is_null() && payload_len != 0 {
+        return 0;
+    }
+    let bytes: &[u8] = if payload_len == 0 {
+        &[]
+    } else {
+        std::slice::from_raw_parts(payload, payload_len)
+    };
+    let header = &*storage.cast::<ShmHeader>();
+    let slot_size = header.slot_size;
+    spsc::push_raw(storage.cast::<u8>().cast_mut(), slot_size, bytes).as_ffi_code()
 }
 
-/// スロットを 1 つ pop する。
+/// payload バイト列を 1 つ pop する。
 ///
 /// 戻り値:
-/// - `1`: 成功（`out_slot` に書き込み済み）
-/// - `0`: バッファ空または引数 NULL
+/// - `1`: 成功（`out_payload` に payload を書き、`*out_payload_len` に長さを書く）
+/// - `0`: バッファ空、引数 NULL、または `out_payload_cap < slot_size - 8`
 ///
 /// # Safety
 ///
 /// - `storage` は [`midori_sdk_spsc_init`] 済みの領域を指すこと
-/// - `out_slot` は書き込み可能な [`RingSlot`] を指すこと（書き込みは
-///   [`std::ptr::write_unaligned`] を使うためアラインメントは不問）
+/// - `out_payload` は `out_payload_cap` バイト以上の書き込み可能領域を指すこと
+/// - `out_payload_len` は書き込み可能な `usize` を指すこと
 /// - 同時に 1 スレッドからのみ呼ばれること（SPSC 消費者規律）
 #[allow(unsafe_code)]
 #[no_mangle]
 pub unsafe extern "C" fn midori_sdk_spsc_pop(
     storage: *const c_void,
-    out_slot: *mut RingSlot,
-) -> u8 {
-    if storage.is_null() || out_slot.is_null() {
+    out_payload: *mut u8,
+    out_payload_cap: usize,
+    out_payload_len: *mut usize,
+) -> i32 {
+    if storage.is_null() || out_payload_len.is_null() {
         return 0;
     }
-    let storage = &*storage.cast::<SpscStorage>();
-    if let Some(slot) = spsc::try_pop(storage) {
-        // push と同じ理由（C 側パック構造体）で unaligned write を採用。
-        std::ptr::write_unaligned(out_slot, slot);
-        1
-    } else {
-        0
+    if out_payload.is_null() && out_payload_cap != 0 {
+        return 0;
     }
+    let header = &*storage.cast::<ShmHeader>();
+    let slot_size = header.slot_size;
+    let Some(payload) = spsc::pop_raw(storage.cast::<u8>(), slot_size) else {
+        return 0;
+    };
+    if payload.len() > out_payload_cap {
+        // capacity 不足で書き込めない。caller は `slot_size - 8` 以上の buffer
+        // を渡す責務を持つ。本実装では payload は捨てた状態で 0 を返す
+        // （SPSC 規律上、再 pop はできない）。これは driver SDK が
+        // slot_size を知らずに小さい buffer を渡した契約違反を意味する。
+        return 0;
+    }
+    if !payload.is_empty() {
+        std::ptr::copy_nonoverlapping(payload.as_ptr(), out_payload, payload.len());
+    }
+    *out_payload_len = payload.len();
+    1
 }
 
 #[cfg(test)]
 #[allow(unsafe_code, clippy::cast_possible_truncation)]
 mod tests {
     use super::*;
-    use midori_core::shm::{ShmHeader, PAYLOAD_INLINE_MAX, RING_CAPACITY};
+    use midori_core::shm::{DEFAULT_SLOT_SIZE, SLOT_HEADER_SIZE};
 
-    /// inline payload に 4 byte の little-endian シーケンス番号を詰めた
-    /// テスト用 [`RingSlot`] を作る。
-    fn slot_with_seq(seq: u32) -> RingSlot {
-        let mut s: RingSlot = unsafe { std::mem::zeroed() };
-        s.occupied = 1;
-        s.payload_len = 4;
-        s.payload[..4].copy_from_slice(&seq.to_le_bytes());
-        s
-    }
-
-    fn read_seq(slot: &RingSlot) -> u32 {
-        assert_eq!(slot.occupied, 1);
-        assert_eq!(slot.payload_len, 4);
-        let mut buf = [0u8; 4];
-        buf.copy_from_slice(&slot.payload[..4]);
-        u32::from_le_bytes(buf)
-    }
-
-    /// FFI 経由で確保→初期化→push→pop が成立することを検証する結合テスト。
-    #[test]
-    fn it_should_round_trip_a_slot_through_ffi() {
-        // C の aligned_alloc 相当を Rust 側で再現
-        let layout = std::alloc::Layout::from_size_align(
-            midori_sdk_spsc_storage_size(),
-            midori_sdk_spsc_storage_alignment(),
-        )
-        .expect("valid layout");
-
-        // SAFETY: layout は size/alignment 共に正で、後で同じ layout で dealloc する
+    fn alloc_storage(slot_size: u32) -> (*mut u8, std::alloc::Layout) {
+        let size = midori_sdk_spsc_storage_size(slot_size);
+        let align = midori_sdk_spsc_storage_alignment();
+        let layout = std::alloc::Layout::from_size_align(size, align).expect("valid layout");
         let raw = unsafe { std::alloc::alloc(layout) };
         assert!(!raw.is_null());
-
-        unsafe {
-            midori_sdk_spsc_init(raw.cast::<c_void>());
-        }
-
-        let pushed = slot_with_seq(42);
-        let ok = unsafe {
-            midori_sdk_spsc_push(
-                raw.cast::<c_void>(),
-                std::ptr::from_ref::<RingSlot>(&pushed),
-            )
-        };
+        let ok = unsafe { midori_sdk_spsc_init(raw.cast::<c_void>(), slot_size) };
         assert_eq!(ok, 1);
-
-        let mut popped: RingSlot = unsafe { std::mem::zeroed() };
-        let ok =
-            unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
-        assert_eq!(ok, 1);
-        assert_eq!(read_seq(&popped), 42);
-
-        // 空状態では pop が 0 を返す
-        let ok =
-            unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
-        assert_eq!(ok, 0);
-
-        // SAFETY: 同じ layout で dealloc
-        unsafe {
-            std::alloc::dealloc(raw, layout);
-        }
+        (raw, layout)
     }
 
-    /// `payload_len` = [`PAYLOAD_INLINE_MAX`] 上限ぴったりで FFI 経由のラウンドトリップを検証。
-    #[test]
-    fn it_should_round_trip_inline_payload_at_max_through_ffi() {
-        let layout = std::alloc::Layout::from_size_align(
-            midori_sdk_spsc_storage_size(),
-            midori_sdk_spsc_storage_alignment(),
-        )
-        .expect("valid layout");
-        // SAFETY: layout は size/alignment 共に正で、後で同じ layout で dealloc する
-        let raw = unsafe { std::alloc::alloc(layout) };
-        assert!(!raw.is_null());
-        unsafe { midori_sdk_spsc_init(raw.cast::<c_void>()) };
-
-        let mut pushed: RingSlot = unsafe { std::mem::zeroed() };
-        pushed.occupied = 1;
-        pushed.payload_len = PAYLOAD_INLINE_MAX as u32;
-        for (i, byte) in pushed.payload.iter_mut().enumerate() {
-            *byte = (i % 251) as u8;
-        }
-
-        let ok = unsafe {
-            midori_sdk_spsc_push(
-                raw.cast::<c_void>(),
-                std::ptr::from_ref::<RingSlot>(&pushed),
-            )
-        };
-        assert_eq!(ok, 1);
-
-        let mut popped: RingSlot = unsafe { std::mem::zeroed() };
-        let ok =
-            unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
-        assert_eq!(ok, 1);
-        assert_eq!(popped.occupied, 1);
-        assert_eq!(popped.payload_len as usize, PAYLOAD_INLINE_MAX);
-        for (i, byte) in popped.payload.iter().enumerate() {
-            assert_eq!(*byte, (i % 251) as u8, "byte at {i} mismatched");
-        }
-        // side channel は未使用
-        assert_eq!(popped.side_offset, 0);
-        assert_eq!(popped.side_len, 0);
-
-        // SAFETY: 同じ layout で dealloc
+    fn dealloc_storage(raw: *mut u8, layout: std::alloc::Layout) {
         unsafe { std::alloc::dealloc(raw, layout) };
     }
 
-    /// `payload_len` > [`PAYLOAD_INLINE_MAX`] 相当のケース: `payload_len` = 0 で
-    /// `side_offset` / `side_len` のみ立てたスロットがそのまま運ばれることを検証。
-    /// 本テストは FFI 経由のフィールド輸送のみを確認する（side channel 本体の
-    /// 確保は本クレートのスコープ外）。
     #[test]
-    fn it_should_carry_side_channel_offsets_through_ffi() {
-        let layout = std::alloc::Layout::from_size_align(
-            midori_sdk_spsc_storage_size(),
-            midori_sdk_spsc_storage_alignment(),
-        )
-        .expect("valid layout");
-        // SAFETY: layout は size/alignment 共に正で、後で同じ layout で dealloc する
-        let raw = unsafe { std::alloc::alloc(layout) };
-        assert!(!raw.is_null());
-        unsafe { midori_sdk_spsc_init(raw.cast::<c_void>()) };
+    fn it_should_round_trip_a_payload_through_ffi() {
+        let (raw, layout) = alloc_storage(DEFAULT_SLOT_SIZE);
 
-        let mut pushed: RingSlot = unsafe { std::mem::zeroed() };
-        pushed.occupied = 1;
-        pushed.payload_len = 0;
-        pushed.side_offset = 4096;
-        pushed.side_len = 1024;
+        let payload: [u8; 4] = 42u32.to_le_bytes();
+        let pushed =
+            unsafe { midori_sdk_spsc_push(raw.cast::<c_void>(), payload.as_ptr(), payload.len()) };
+        assert_eq!(pushed, 1);
 
-        let ok = unsafe {
-            midori_sdk_spsc_push(
+        let mut out_buf = vec![0u8; (DEFAULT_SLOT_SIZE - SLOT_HEADER_SIZE) as usize];
+        let mut out_len: usize = 0;
+        let popped = unsafe {
+            midori_sdk_spsc_pop(
                 raw.cast::<c_void>(),
-                std::ptr::from_ref::<RingSlot>(&pushed),
+                out_buf.as_mut_ptr(),
+                out_buf.len(),
+                &raw mut out_len,
             )
         };
-        assert_eq!(ok, 1);
+        assert_eq!(popped, 1);
+        assert_eq!(out_len, 4);
+        assert_eq!(&out_buf[..out_len], &payload[..]);
 
-        let mut popped: RingSlot = unsafe { std::mem::zeroed() };
-        let ok =
-            unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::from_mut(&mut popped)) };
-        assert_eq!(ok, 1);
-        assert_eq!(popped.occupied, 1);
-        assert_eq!(popped.payload_len, 0);
-        assert_eq!(popped.side_offset, 4096);
-        assert_eq!(popped.side_len, 1024);
+        let popped_empty = unsafe {
+            midori_sdk_spsc_pop(
+                raw.cast::<c_void>(),
+                out_buf.as_mut_ptr(),
+                out_buf.len(),
+                &raw mut out_len,
+            )
+        };
+        assert_eq!(popped_empty, 0);
 
-        // SAFETY: 同じ layout で dealloc
+        dealloc_storage(raw, layout);
+    }
+
+    #[test]
+    fn it_should_round_trip_payload_at_slot_max_capacity_through_ffi() {
+        let (raw, layout) = alloc_storage(DEFAULT_SLOT_SIZE);
+
+        let max_payload = (DEFAULT_SLOT_SIZE - SLOT_HEADER_SIZE) as usize;
+        let payload: Vec<u8> = (0..max_payload).map(|i| (i % 251) as u8).collect();
+        let pushed =
+            unsafe { midori_sdk_spsc_push(raw.cast::<c_void>(), payload.as_ptr(), payload.len()) };
+        assert_eq!(pushed, 1);
+
+        let mut out_buf = vec![0u8; max_payload];
+        let mut out_len: usize = 0;
+        let popped = unsafe {
+            midori_sdk_spsc_pop(
+                raw.cast::<c_void>(),
+                out_buf.as_mut_ptr(),
+                out_buf.len(),
+                &raw mut out_len,
+            )
+        };
+        assert_eq!(popped, 1);
+        assert_eq!(out_len, max_payload);
+        assert_eq!(out_buf, payload);
+
+        dealloc_storage(raw, layout);
+    }
+
+    #[test]
+    fn it_should_return_payload_too_large_when_pushing_oversize_through_ffi() {
+        let (raw, layout) = alloc_storage(DEFAULT_SLOT_SIZE);
+        let max_payload = (DEFAULT_SLOT_SIZE - SLOT_HEADER_SIZE) as usize;
+        let too_large = vec![0u8; max_payload + 1];
+        let pushed = unsafe {
+            midori_sdk_spsc_push(raw.cast::<c_void>(), too_large.as_ptr(), too_large.len())
+        };
+        assert_eq!(pushed, -2, "payload too large は -2 を返す（FFI breaking）");
+        dealloc_storage(raw, layout);
+    }
+
+    #[test]
+    fn it_should_reject_init_with_invalid_slot_size() {
+        let bad_slot_size = 13u32; // 4 byte 倍数でない
+        let layout = std::alloc::Layout::from_size_align(
+            shm::shm_total_size(DEFAULT_SLOT_SIZE),
+            midori_sdk_spsc_storage_alignment(),
+        )
+        .expect("layout");
+        let raw = unsafe { std::alloc::alloc(layout) };
+        assert!(!raw.is_null());
+
+        let ok = unsafe { midori_sdk_spsc_init(raw.cast::<c_void>(), bad_slot_size) };
+        assert_eq!(ok, 0, "alignment 違反は init で reject");
         unsafe { std::alloc::dealloc(raw, layout) };
     }
 
     #[test]
     fn it_should_return_zero_when_called_with_null_pointers() {
-        let mut slot: RingSlot = unsafe { std::mem::zeroed() };
-        let dummy_slot = slot_with_seq(1);
-        let nul = std::ptr::null::<c_void>();
-
-        // storage が NULL のケース
+        // storage NULL
+        let mut payload: [u8; 4] = [1, 2, 3, 4];
+        let mut out_len: usize = 0;
         assert_eq!(
-            unsafe { midori_sdk_spsc_push(nul, std::ptr::from_ref::<RingSlot>(&dummy_slot)) },
+            unsafe {
+                midori_sdk_spsc_push(std::ptr::null::<c_void>(), payload.as_ptr(), payload.len())
+            },
             0
         );
         assert_eq!(
-            unsafe { midori_sdk_spsc_pop(nul, std::ptr::from_mut(&mut slot)) },
+            unsafe {
+                midori_sdk_spsc_pop(
+                    std::ptr::null::<c_void>(),
+                    payload.as_mut_ptr(),
+                    payload.len(),
+                    &raw mut out_len,
+                )
+            },
             0
         );
 
-        // storage は有効だが slot/out_slot 側が NULL のケース。
-        // OR の short-circuit で後段の NULL チェックも動作することを確認する。
-        let layout = std::alloc::Layout::from_size_align(
-            midori_sdk_spsc_storage_size(),
-            midori_sdk_spsc_storage_alignment(),
-        )
-        .expect("valid layout");
-        // SAFETY: layout は size/alignment 共に正で、後で同じ layout で dealloc する
-        let raw = unsafe { std::alloc::alloc(layout) };
-        assert!(!raw.is_null());
-        unsafe { midori_sdk_spsc_init(raw.cast::<c_void>()) };
-
+        // storage 有効、payload ポインタが NULL かつ len > 0 の不正
+        let (raw, layout) = alloc_storage(DEFAULT_SLOT_SIZE);
         assert_eq!(
-            unsafe { midori_sdk_spsc_push(raw.cast::<c_void>(), std::ptr::null::<RingSlot>()) },
+            unsafe { midori_sdk_spsc_push(raw.cast::<c_void>(), std::ptr::null::<u8>(), 4) },
             0
         );
         assert_eq!(
-            unsafe { midori_sdk_spsc_pop(raw.cast::<c_void>(), std::ptr::null_mut::<RingSlot>()) },
+            unsafe {
+                midori_sdk_spsc_pop(
+                    raw.cast::<c_void>(),
+                    std::ptr::null_mut::<u8>(),
+                    4,
+                    &raw mut out_len,
+                )
+            },
             0
         );
-
-        // SAFETY: 同じ layout で dealloc
-        unsafe { std::alloc::dealloc(raw, layout) };
+        dealloc_storage(raw, layout);
     }
 
-    /// `build.rs` が生成した C ヘッダに想定の関数宣言と新 [`RingSlot`] フィールドが
-    /// 含まれていることを検証する。ヘッダ生成自体は `cargo build` 時にチェック済み。
+    #[test]
+    fn it_should_storage_size_be_zero_for_invalid_slot_size() {
+        assert_eq!(midori_sdk_spsc_storage_size(13), 0);
+        assert_eq!(midori_sdk_spsc_storage_size(0), 0);
+    }
+
+    #[test]
+    fn it_should_storage_size_match_layout_for_default_slot() {
+        let size = midori_sdk_spsc_storage_size(DEFAULT_SLOT_SIZE);
+        let align = midori_sdk_spsc_storage_alignment();
+        assert!(size > 0);
+        assert!(align.is_power_of_two());
+        assert_eq!(
+            size,
+            std::mem::size_of::<shm::ShmHeader>() + shm::RING_CAPACITY * DEFAULT_SLOT_SIZE as usize
+        );
+    }
+
+    /// `build.rs` が生成した C ヘッダに想定の関数宣言と新型シンボルが
+    /// 含まれていることを検証する。
     #[test]
     fn it_should_generate_c_header_with_expected_ffi_symbols() {
         const GENERATED_HEADER: &str = include_str!(concat!(env!("OUT_DIR"), "/midori_sdk.h"));
         assert!(GENERATED_HEADER.contains("MIDORI_SDK_H"));
+        // FFI 関数群
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_storage_size"));
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_storage_alignment"));
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_init"));
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_push"));
         assert!(GENERATED_HEADER.contains("midori_sdk_spsc_pop"));
-        assert!(GENERATED_HEADER.contains("RingSlot"));
-        // 新レイアウトのフィールドがヘッダに公開されていること
-        assert!(GENERATED_HEADER.contains("payload_len"));
-        assert!(GENERATED_HEADER.contains("side_offset"));
-        assert!(GENERATED_HEADER.contains("side_len"));
-        assert!(GENERATED_HEADER.contains("payload"));
-        assert!(GENERATED_HEADER.contains("PAYLOAD_INLINE_MAX"));
-    }
-
-    #[test]
-    fn it_should_report_storage_size_and_alignment_consistent_with_layout() {
-        let size = midori_sdk_spsc_storage_size();
-        let align = midori_sdk_spsc_storage_alignment();
-        assert!(size > 0);
-        assert!(align.is_power_of_two());
-        // SpscStorage の中身は ShmHeader + RING_CAPACITY 個の RingSlot
-        assert!(
-            size >= std::mem::size_of::<ShmHeader>()
-                + RING_CAPACITY * std::mem::size_of::<RingSlot>()
-        );
+        // 新レイアウトの構造体型
+        assert!(GENERATED_HEADER.contains("ShmHeader"));
+        assert!(GENERATED_HEADER.contains("SlotHeader"));
+        // 戻り値型の breaking change：旧 u8 ではなく i32 (= int32_t)
+        assert!(GENERATED_HEADER.contains("int32_t midori_sdk_spsc_push"));
+        assert!(GENERATED_HEADER.contains("int32_t midori_sdk_spsc_pop"));
+        // 旧レイアウト象徴シンボルの残骸が無いこと
+        assert!(!GENERATED_HEADER.contains("PAYLOAD_INLINE_MAX"));
+        assert!(!GENERATED_HEADER.contains("side_offset"));
+        assert!(!GENERATED_HEADER.contains("side_len"));
     }
 }

--- a/crates/midori-sdk/src/ffi.rs
+++ b/crates/midori-sdk/src/ffi.rs
@@ -123,6 +123,12 @@ pub unsafe extern "C" fn midori_sdk_spsc_push(
     };
     let header = &*storage.cast::<ShmHeader>();
     let slot_size = header.slot_size;
+    // 共有メモリは別プロセスから書き換えられる可能性があるため、ヘッダの
+    // `slot_size` をそのまま stride 計算に使う前に防衛的 validate する。
+    // 不正値（汚染 / 未初期化）のときは `0` (= 一般的失敗) を返す。
+    if validate_slot_size(slot_size).is_err() {
+        return 0;
+    }
     spsc::push_raw(storage.cast::<u8>().cast_mut(), slot_size, bytes).as_ffi_code()
 }
 
@@ -163,6 +169,11 @@ pub unsafe extern "C" fn midori_sdk_spsc_pop(
     }
     let header = &*storage.cast::<ShmHeader>();
     let slot_size = header.slot_size;
+    // push 側と同様、ヘッダの `slot_size` を信用する前に validate して
+    // shm 汚染による out-of-bounds 読みを防ぐ。
+    if validate_slot_size(slot_size).is_err() {
+        return 0;
+    }
     let Some(payload) = spsc::pop_raw(storage.cast::<u8>(), slot_size) else {
         return 0;
     };

--- a/crates/midori-sdk/src/lib.rs
+++ b/crates/midori-sdk/src/lib.rs
@@ -16,7 +16,7 @@ pub use midori_core::shm::*;
 pub use midori_core::value::*;
 
 pub use driver::{ControlCommand, DeviceEntry, Driver, DriverError, ProtocolError, SDK_VERSION};
-pub use spsc::{Consumer, Full, Producer, SpscStorage};
+pub use spsc::{Consumer, Producer, PushResult, SpscStorage};
 
 #[cfg(test)]
 mod tests {
@@ -60,6 +60,9 @@ mod tests {
     #[test]
     fn it_should_expose_shm_layout_at_top_level() {
         let _ = RING_CAPACITY;
-        let _ = PAYLOAD_INLINE_MAX;
+        let _ = DEFAULT_SLOT_SIZE;
+        let _ = HARD_SLOT_SIZE;
+        let _ = SLOT_HEADER_SIZE;
+        let _ = SHM_LAYOUT_VERSION;
     }
 }

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -150,9 +150,9 @@ impl SpscStorage {
         (Producer { storage }, Consumer { storage })
     }
 
-    /// shm 領域 base ポインタ。`push_raw` / `pop_raw` の `base` 引数として
-    /// 渡せる先頭アドレス。[`ShmHeader`] が先頭に配置され、続いて
-    /// `RING_CAPACITY × slot_size` のスロット領域が並ぶ。
+    /// テスト専用の `ShmHeader` アクセサ。本番経路では `push_raw` / `pop_raw`
+    /// が直接 buffer 先頭からアクセスするため不要だが、`SpscStorage::new` が
+    /// 初期化したヘッダ値（`slot_size` / `version`）の検証に使う。
     #[cfg(test)]
     fn header(&self) -> &ShmHeader {
         // SAFETY: buffer 先頭は ShmHeader としてアラインかつ初期化済み。
@@ -163,7 +163,7 @@ impl SpscStorage {
     }
 }
 
-/// `try_push` の結果。FFI 戻り値（`i32`）は `as_ffi_code` で取り出す。
+/// `push_raw` の結果。FFI 戻り値（`i32`）は `as_ffi_code` で取り出す。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PushResult {
     /// payload を slot に書き込めた。
@@ -202,10 +202,15 @@ fn slot_ptr_at(base: *mut u8, slot_size: u32, slot_index: usize) -> *mut u8 {
 ///
 /// # Safety
 ///
-/// `base` は初期化済みの shm 領域先頭で、`shm_total_size(slot_size)` バイトの
-/// 書き込み可能領域を指していること。`base` は `ShmHeader` の 8-byte
-/// alignment を満たすこと（`SpscStorage::new` の `Box<[u64]>` および
-/// FFI `aligned_alloc` 経由で担保）。
+/// caller は以下を満たす責任を負う:
+///
+/// - `base` は初期化済みの shm 領域先頭で、`shm_total_size(slot_size)` バイトの
+///   書き込み可能領域を指す
+/// - `base` は `ShmHeader` の 8-byte alignment を満たす（`SpscStorage::new` の
+///   `Box<[u64]>` および FFI `aligned_alloc` 経由で担保）
+/// - **戻り値の `&'a ShmHeader` が backing storage より長生きしないこと**。
+///   返却される lifetime `'a` は caller 指定で型レベルでは無拘束のため、
+///   実際の生存期間は呼び出し側コンテキストで担保すること
 #[allow(unsafe_code, clippy::cast_ptr_alignment)]
 unsafe fn shm_header_ref<'a>(base: *const u8) -> &'a ShmHeader {
     &*base.cast::<ShmHeader>()

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -26,6 +26,7 @@
 //! 競合する書き込みは発生しない。スロット側は同じインデックスへの同時
 //! アクセスをインデックス比較で排除している。
 
+use std::cell::UnsafeCell;
 use std::sync::atomic::Ordering;
 
 use midori_core::shm::{
@@ -44,16 +45,19 @@ use midori_core::shm::{
 /// ...
 /// ```
 ///
-/// `Box<[u64]>` で確保することで、`ShmHeader` の 8 byte alignment を満たし
-/// つつ、合計バイト数を `slot_size × RING_CAPACITY + 56` にできる。
+/// `Box<[UnsafeCell<u64>]>` で確保することで、`ShmHeader` の 8 byte alignment
+/// を満たしつつ、Producer / Consumer が共有 `&SpscStorage` 経由で interior
+/// mutability を行使する根拠を型レベルで明示する。`u64` 単位の配列なので
+/// 合計バイト数は `slot_size × RING_CAPACITY + 56` を 8 byte 境界へ切り上げ。
 ///
 /// FFI 経由で C 側が確保した buffer に対しては、本構造体ではなく
 /// [`push_raw`] / [`pop_raw`] を直接使う。両者は内部で共通の low-level
 /// 関数を呼び出すため、Rust API と FFI で挙動が一致する。
 pub struct SpscStorage {
-    // u64 配列で確保することで `ShmHeader` の 8-byte alignment を保証する。
-    // 中身は raw bytes で、ヘッダ領域と各スロットを stride 計算で参照する。
-    buffer: Box<[u64]>,
+    // 各セルを `UnsafeCell` で包むことで「共有参照経由の内部書き込み」が
+    // Rust の aliasing rule に違反しない正規ルートになる。生バイト経由で
+    // ヘッダ領域と各スロットを stride 計算で参照する。
+    buffer: Box<[UnsafeCell<u64>]>,
     // ヘッダ書き込み / stride 計算のキャッシュ。`ShmHeader.slot_size` と
     // 一致する。
     slot_size: u32,
@@ -79,7 +83,10 @@ impl SpscStorage {
         let total_bytes = shm::shm_total_size(slot_size);
         // u64 単位に切り上げて確保することで 8-byte alignment を保証する。
         let total_u64 = total_bytes.div_ceil(std::mem::size_of::<u64>());
-        let buffer = vec![0u64; total_u64].into_boxed_slice();
+        let buffer: Box<[UnsafeCell<u64>]> = (0..total_u64)
+            .map(|_| UnsafeCell::new(0u64))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
         let storage = Self { buffer, slot_size };
         // ヘッダ初期化（write/read = 0、slot_size、version、_pad は 0 のまま）
         #[allow(unsafe_code)]
@@ -87,6 +94,18 @@ impl SpscStorage {
             storage.write_header();
         }
         Ok(storage)
+    }
+
+    /// backing buffer 先頭を指す raw pointer。`UnsafeCell::get()` 経由で
+    /// 取り出すことで、共有参照下の内部書き込みが Rust aliasing rule を
+    /// 守った形になる。`buffer` が空の場合は dangling だが本構造体は
+    /// 必ず `ShmHeader` を含む `total_u64 >= 7` を確保しているため空にならない。
+    fn buffer_base(&self) -> *mut u8 {
+        // SAFETY: buffer は非空（new で必ず ShmHeader 分以上確保）。
+        // UnsafeCell::get は安全な API で、得たポインタへの実 access は
+        // SPSC 規律下の caller 責任。
+        debug_assert!(!self.buffer.is_empty());
+        self.buffer[0].get().cast::<u8>()
     }
 
     /// 確保済みのメモリ領域に SPSC ストレージを **その場で** 初期化する。
@@ -132,8 +151,10 @@ impl SpscStorage {
     #[allow(unsafe_code)]
     unsafe fn write_header(&self) {
         // SAFETY: buffer は u64 配列なので 8-byte aligned かつ `shm_total_size`
-        // 以上を確保している。`init_in_place` と同じ手順で in-place 初期化する。
-        Self::init_in_place(self.buffer.as_ptr().cast::<u8>().cast_mut(), self.slot_size);
+        // 以上を確保している。UnsafeCell::get 経由で取り出した raw pointer
+        // への書き込みは aliasing rule 上正規ルート。`init_in_place` と
+        // 同じ手順で in-place 初期化する。
+        Self::init_in_place(self.buffer_base(), self.slot_size);
     }
 
     /// 確定済みの `slot_size`。
@@ -156,9 +177,10 @@ impl SpscStorage {
     #[cfg(test)]
     fn header(&self) -> &ShmHeader {
         // SAFETY: buffer 先頭は ShmHeader としてアラインかつ初期化済み。
-        #[allow(unsafe_code)]
+        // UnsafeCell::get で取り出した raw pointer 経由で参照する。
+        #[allow(unsafe_code, clippy::cast_ptr_alignment)]
         unsafe {
-            &*self.buffer.as_ptr().cast::<ShmHeader>()
+            &*self.buffer_base().cast::<ShmHeader>()
         }
     }
 }
@@ -293,7 +315,14 @@ pub(crate) unsafe fn pop_raw(base: *const u8, slot_size: u32) -> Option<Vec<u8>>
     // ここで読む `slots[read % CAP]` は read < write の不変条件より既に
     // 書き込みが完了している。Acquire ロードによりその書き込みが可視。
     let slot_header_ptr = slot_ptr.cast::<SlotHeader>();
-    let payload_len = (*slot_header_ptr).payload_len as usize;
+    let raw_payload_len = (*slot_header_ptr).payload_len as usize;
+    // 防衛的 bounds check: 共有メモリ上の SlotHeader.payload_len が
+    // shm 汚染や悪意ある producer により slot 容量を超える値になっている
+    // ケースで、そのまま信用すると `copy_nonoverlapping` で隣接スロット
+    // 領域 / shm 範囲外を読み取ってしまう。最大 payload 容量
+    // (slot_size - SLOT_HEADER_SIZE) で clamp して被害を slot 内に閉じる。
+    let max_payload = (slot_size as usize).saturating_sub(SLOT_HEADER_SIZE as usize);
+    let payload_len = raw_payload_len.min(max_payload);
     let payload_src = slot_ptr.add(SLOT_HEADER_SIZE as usize);
     let mut buf = vec![0u8; payload_len];
     std::ptr::copy_nonoverlapping(payload_src, buf.as_mut_ptr(), payload_len);
@@ -314,13 +343,10 @@ impl Producer<'_> {
         // SAFETY: SpscStorage は新規生成時に slot_size を validate 済みで、
         // buffer は shm_total_size(slot_size) バイト以上を確保している。
         // SPSC 生産者規律は &mut Producer により型レベルで担保される。
+        // buffer_base は UnsafeCell::get 経由で aliasing rule を守る。
         #[allow(unsafe_code)]
         unsafe {
-            push_raw(
-                self.storage.buffer.as_ptr().cast::<u8>().cast_mut(),
-                self.storage.slot_size,
-                payload,
-            )
+            push_raw(self.storage.buffer_base(), self.storage.slot_size, payload)
         }
     }
 }
@@ -334,12 +360,10 @@ impl Consumer<'_> {
     /// 先頭スロットの payload バイト列を返す。空なら `None`。
     pub fn pop(&mut self) -> Option<Vec<u8>> {
         // SAFETY: 同上。SPSC 消費者規律は &mut Consumer で担保。
+        // buffer_base は UnsafeCell::get 経由で aliasing rule を守る。
         #[allow(unsafe_code)]
         unsafe {
-            pop_raw(
-                self.storage.buffer.as_ptr().cast::<u8>(),
-                self.storage.slot_size,
-            )
+            pop_raw(self.storage.buffer_base(), self.storage.slot_size)
         }
     }
 }

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -145,15 +145,18 @@ impl SpscStorage {
     ///
     /// # Safety
     ///
-    /// `buffer` は `shm_total_size(slot_size)` バイト以上を確保済みで、
-    /// 8-byte alignment を満たしていること。`Box<[u64]>` で確保されている
-    /// ためこの条件は型レベルで担保されている。
+    /// `buffer` は `Box<[UnsafeCell<u64>]>` として `shm_total_size(slot_size)`
+    /// バイト以上を確保済みで、8-byte alignment を満たしていること。
+    /// `UnsafeCell<u64>` の配列は `u64` の alignment (8 byte) を継承する
+    /// ため、本 type に格納する限り `ShmHeader` の 8-byte alignment 要件は
+    /// 型レベルで担保される。本関数は `init_in_place` 経由で先頭から
+    /// `ShmHeader` を書き込む。
     #[allow(unsafe_code)]
     unsafe fn write_header(&self) {
-        // SAFETY: buffer は u64 配列なので 8-byte aligned かつ `shm_total_size`
-        // 以上を確保している。UnsafeCell::get 経由で取り出した raw pointer
-        // への書き込みは aliasing rule 上正規ルート。`init_in_place` と
-        // 同じ手順で in-place 初期化する。
+        // SAFETY: buffer は UnsafeCell<u64> 配列なので 8-byte aligned かつ
+        // `shm_total_size` 以上を確保している。UnsafeCell::get 経由で
+        // 取り出した raw pointer への書き込みは aliasing rule 上正規ルート。
+        // `init_in_place` と同じ手順で in-place 初期化する。
         Self::init_in_place(self.buffer_base(), self.slot_size);
     }
 
@@ -373,6 +376,16 @@ pub(crate) unsafe fn pop_raw_into(
 /// [`pop_raw_into`] と同じ契約。
 #[allow(unsafe_code)]
 pub(crate) unsafe fn pop_raw(base: *const u8, slot_size: u32) -> Option<Vec<u8>> {
+    // empty fast-path: ポーリングループでは大半の呼び出しが空に当たるので、
+    // 先に header を check して `vec![0u8; max_payload]` を allocate しない。
+    // ※ 実際の slot 読みも内部で改めて header を見るが、empty 判定は
+    // Acquire load 1 回で済むため安価。
+    let header = shm_header_ref(base);
+    let read = header.read_index.load(Ordering::Relaxed);
+    let write = header.write_index.load(Ordering::Acquire);
+    if read == write {
+        return None;
+    }
     // payload 長は最大でも slot_size - SLOT_HEADER_SIZE。最初に最大容量で
     // 確保しておき、Truncated は発生しない経路にする。
     let max_payload = (slot_size as usize).saturating_sub(SLOT_HEADER_SIZE as usize);
@@ -384,7 +397,8 @@ pub(crate) unsafe fn pop_raw(base: *const u8, slot_size: u32) -> Option<Vec<u8>>
         }
         // SAFETY: out_buf_cap = max_payload を渡しているため pop_raw_into
         // は Truncated を返さない（payload_len は内部で max_payload に
-        // clamp 済み）。理論上到達しない Truncated と Empty をまとめて
+        // clamp 済み）。理論上到達しない Truncated と、empty fast-path 後に
+        // 別スレッドが消費した極めて稀なレースで起こり得る Empty をまとめて
         // None で表現する。
         PopOutcome::Empty | PopOutcome::Truncated(_) => None,
     }

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -13,77 +13,133 @@
 //!   `&mut self` を取ることで型レベルに enforce している。両ハンドルが生存
 //!   する間は `split` を再呼び出しできない。
 //!
+//! # スロットサイズ
+//!
+//! [`SpscStorage::new`] に渡す `slot_size` は driver lifetime 内で固定だが
+//! driver ごとに異なる。値は handshake で決まり、4 byte 倍数 / `MIN_SLOT_SIZE`
+//! 以上 / `HARD_SLOT_SIZE` 以下である必要がある（`midori_core::shm` の
+//! `validate_slot_size` で検証）。
+//!
 //! # ロックフリー性
 //!
 //! 生産者と消費者は分離したインデックスをそれぞれ排他的に書き込むだけで、
 //! 競合する書き込みは発生しない。スロット側は同じインデックスへの同時
 //! アクセスをインデックス比較で排除している。
 
-use std::cell::UnsafeCell;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::Ordering;
 
-use midori_core::shm::{RingSlot, ShmHeader, PAYLOAD_INLINE_MAX, RING_CAPACITY};
+use midori_core::shm::{
+    self, validate_slot_size, ShmHeader, SlotHeader, SlotSizeError, RING_CAPACITY,
+    SHM_LAYOUT_VERSION, SLOT_HEADER_SIZE,
+};
 
 /// 共有メモリ上に置かれることを意図した SPSC リングバッファのストレージ。
 ///
-/// `#[repr(C)]` により mmap 可能な固定レイアウトを保証し、C FFI 経由で他言語
-/// からも同レイアウトでアクセスできる。
-#[repr(C)]
+/// 内部レイアウトは:
+///
+/// ```text
+/// offset 0:  ShmHeader (56 byte)
+/// offset 56: slot[0] (slot_size byte)
+/// offset 56+slot_size: slot[1]
+/// ...
+/// ```
+///
+/// `Box<[u64]>` で確保することで、`ShmHeader` の 8 byte alignment を満たし
+/// つつ、合計バイト数を `slot_size × RING_CAPACITY + 56` にできる。
+///
+/// FFI 経由で C 側が確保した buffer に対しては、本構造体ではなく
+/// [`push_raw`] / [`pop_raw`] を直接使う。両者は内部で共通の low-level
+/// 関数を呼び出すため、Rust API と FFI で挙動が一致する。
 pub struct SpscStorage {
-    header: ShmHeader,
-    slots: [UnsafeCell<RingSlot>; RING_CAPACITY],
+    // u64 配列で確保することで `ShmHeader` の 8-byte alignment を保証する。
+    // 中身は raw bytes で、ヘッダ領域と各スロットを stride 計算で参照する。
+    buffer: Box<[u64]>,
+    // ヘッダ書き込み / stride 計算のキャッシュ。`ShmHeader.slot_size` と
+    // 一致する。
+    slot_size: u32,
 }
 
 // SAFETY: SpscStorage は SPSC 規律下で 1 スレッド (生産者) と 1 スレッド (消費者) に
 // より共有される。`split(&mut self)` がペアの一意性を保証し、各スレッドは
 // 異なるスロットインデックス（write/read）にしかアクセスしないため、
-// UnsafeCell 経由の同時アクセスはレースしない。インデックス更新は AtomicU64
+// 生バイト経由の同時アクセスはレースしない。インデックス更新は AtomicU64
 // で同期される。
 #[allow(unsafe_code)]
 unsafe impl Sync for SpscStorage {}
 
 impl SpscStorage {
-    /// すべてのスロットがゼロ埋めの空のストレージを生成する。
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            header: ShmHeader {
-                write_index: AtomicU64::new(0),
-                read_index: AtomicU64::new(0),
-            },
-            slots: std::array::from_fn(|_| UnsafeCell::new(EMPTY_SLOT)),
+    /// 指定 `slot_size` で空のストレージを生成する。
+    ///
+    /// # Errors
+    ///
+    /// `slot_size` が 4 byte 倍数 / `MIN_SLOT_SIZE` 以上 / `HARD_SLOT_SIZE`
+    /// 以下のいずれかを満たさない場合は対応する [`SlotSizeError`] を返す。
+    pub fn new(slot_size: u32) -> Result<Self, SlotSizeError> {
+        validate_slot_size(slot_size)?;
+        let total_bytes = shm::shm_total_size(slot_size);
+        // u64 単位に切り上げて確保することで 8-byte alignment を保証する。
+        let total_u64 = total_bytes.div_ceil(std::mem::size_of::<u64>());
+        let buffer = vec![0u64; total_u64].into_boxed_slice();
+        let storage = Self { buffer, slot_size };
+        // ヘッダ初期化（write/read = 0、slot_size、version、_pad は 0 のまま）
+        #[allow(unsafe_code)]
+        unsafe {
+            storage.write_header();
         }
+        Ok(storage)
     }
 
-    /// 確保済みの領域に SPSC ストレージを **その場で** 初期化する。
+    /// 確保済みのメモリ領域に SPSC ストレージを **その場で** 初期化する。
     ///
-    /// `Self::new()` と異なり、`SpscStorage` 全体（~75 KB）を呼び出し側スタック上に
-    /// 一時生成しない。FFI 経由で C 側が用意した領域へ書き込む経路（小さなスレッド
-    /// スタックや組込み環境）でのオーバーフローを避けるために用意する。
-    ///
-    /// インデックス管理の不変条件（`read..write` 範囲のスロットだけが読まれる）に
-    /// より、`slots` 配列は未初期化のままで安全。`header` のみ Atomic を 0 で書く。
+    /// `Self::new()` と異なり、Rust 側で backing store を確保しない。FFI 経由
+    /// で C 側が用意した領域へ書き込む経路（小さなスレッドスタックや組込み
+    /// 環境）で使う。
     ///
     /// # Safety
     ///
     /// `ptr` は以下を満たすこと:
     /// - 非 NULL
-    /// - `size_of::<SpscStorage>()` バイト以上の書き込み可能領域を指す
-    /// - `align_of::<SpscStorage>()` のアラインメントを満たす
+    /// - `shm_total_size(slot_size)` バイト以上の書き込み可能領域を指す
+    /// - `align_of::<ShmHeader>() = 8` のアラインメントを満たす
     /// - 呼び出し時点で生存する Producer/Consumer がない
+    ///
+    /// 加えて呼び出し側は `validate_slot_size(slot_size)` を事前に通過させる
+    /// こと。本関数は防衛的検証を行わない。
+    #[allow(unsafe_code, clippy::cast_ptr_alignment)]
+    pub unsafe fn init_in_place(ptr: *mut u8, slot_size: u32) {
+        // backing 領域全体をゼロ埋め。slot 領域は SPSC の read..write 不変条件に
+        // より未読セルが読まれない契約だが、初期化未定義値で `occupied=1` のような
+        // ゴミが乗ることを避ける防衛のためここで一括 0 埋めしておく。
+        let total = shm::shm_total_size(slot_size);
+        std::ptr::write_bytes(ptr, 0, total);
+        // ShmHeader を書き込み。AtomicU64 はゼロ初期化で 0 を表せるため、
+        // 上の write_bytes で write/read = 0 が成立済み。slot_size と version
+        // を直接書き込む。
+        let header_ptr = ptr.cast::<ShmHeader>();
+        let slot_size_ptr = std::ptr::addr_of_mut!((*header_ptr).slot_size);
+        let version_ptr = std::ptr::addr_of_mut!((*header_ptr).version);
+        slot_size_ptr.write(slot_size);
+        version_ptr.write(SHM_LAYOUT_VERSION);
+    }
+
+    /// `Self::new` 内で `buffer` 先頭に `ShmHeader` を初期化する。
+    ///
+    /// # Safety
+    ///
+    /// `buffer` は `shm_total_size(slot_size)` バイト以上を確保済みで、
+    /// 8-byte alignment を満たしていること。`Box<[u64]>` で確保されている
+    /// ためこの条件は型レベルで担保されている。
     #[allow(unsafe_code)]
-    pub unsafe fn init_in_place(ptr: *mut Self) {
-        // SAFETY: 呼び出し側契約により ptr は SpscStorage 全体を覆う書き込み可能
-        // 領域を指し、適切にアラインされている。`header` フィールドへの addr_of_mut!
-        // は未初期化のフィールドに対しても合法。ShmHeader は 16 バイトなのでスタック
-        // 経由で書いても問題ない。
-        let header_ptr = std::ptr::addr_of_mut!((*ptr).header);
-        header_ptr.write(ShmHeader {
-            write_index: AtomicU64::new(0),
-            read_index: AtomicU64::new(0),
-        });
-        // `slots` は意図的に未初期化のまま残す。pop は read < write の不変条件で
-        // 守られているため、未書込みのスロットを読むことはない。
+    unsafe fn write_header(&self) {
+        // SAFETY: buffer は u64 配列なので 8-byte aligned かつ `shm_total_size`
+        // 以上を確保している。`init_in_place` と同じ手順で in-place 初期化する。
+        Self::init_in_place(self.buffer.as_ptr().cast::<u8>().cast_mut(), self.slot_size);
+    }
+
+    /// 確定済みの `slot_size`。
+    #[must_use]
+    pub fn slot_size(&self) -> u32 {
+        self.slot_size
     }
 
     /// SPSC 規律に従って Producer / Consumer のペアに分割する。
@@ -93,67 +149,130 @@ impl SpscStorage {
         let storage: &Self = self;
         (Producer { storage }, Consumer { storage })
     }
-}
 
-impl Default for SpscStorage {
-    fn default() -> Self {
-        Self::new()
+    /// shm 領域 base ポインタ。`push_raw` / `pop_raw` の `base` 引数として
+    /// 渡せる先頭アドレス。[`ShmHeader`] が先頭に配置され、続いて
+    /// `RING_CAPACITY × slot_size` のスロット領域が並ぶ。
+    #[cfg(test)]
+    fn header(&self) -> &ShmHeader {
+        // SAFETY: buffer 先頭は ShmHeader としてアラインかつ初期化済み。
+        #[allow(unsafe_code)]
+        unsafe {
+            &*self.buffer.as_ptr().cast::<ShmHeader>()
+        }
     }
 }
 
-/// バッファが満杯で push できなかったことを示すエラー。
+/// `try_push` の結果。FFI 戻り値（`i32`）は `as_ffi_code` で取り出す。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Full;
+pub enum PushResult {
+    /// payload を slot に書き込めた。
+    Ok,
+    /// ring が満杯で書き込めない。caller は再試行 / drop を判断する。
+    Full,
+    /// payload バイト長が `slot_size - SLOT_HEADER_SIZE` を超える。
+    PayloadTooLarge,
+}
 
-impl std::fmt::Display for Full {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("SPSC ring buffer is full")
+impl PushResult {
+    /// FFI 経由で C 側に返す数値コード。
+    /// `1` = success、`0` = ring full、`-2` = payload too large。
+    #[must_use]
+    pub const fn as_ffi_code(self) -> i32 {
+        match self {
+            Self::Ok => 1,
+            Self::Full => 0,
+            Self::PayloadTooLarge => -2,
+        }
     }
 }
 
-impl std::error::Error for Full {}
+/// shm 領域 base ポインタ (`ShmHeader` 先頭) からスロット先頭までのオフセット
+/// を返す helper。
+fn slot_ptr_at(base: *mut u8, slot_size: u32, slot_index: usize) -> *mut u8 {
+    let offset = shm::slot_offset_in_shm(slot_size, slot_index);
+    // SAFETY: caller が shm_total_size 範囲内を保証する。
+    #[allow(unsafe_code)]
+    unsafe {
+        base.add(offset)
+    }
+}
 
-/// 生産者の push 処理本体。`Producer::push` と FFI からの両方で呼ばれる。
+/// shm 領域 base ポインタから `ShmHeader` 共有参照を取り出す helper。
 ///
-/// `slot` は `&RingSlot` を受け取り内部でコピーする。新レイアウト
-/// （`PAYLOAD_INLINE_MAX = 240` 込みで 264 byte 固定）の値渡しはスタックを
-/// 無駄に消費するため。
+/// # Safety
 ///
-/// 呼び出し側は SPSC 規律（任意の時刻に生産者は 1 つだけ）を守ること。
-/// Rust API では [`SpscStorage::split`] が型レベルで保証する。FFI からの
-/// 呼び出しでは C 側が規律を守る責務を負う。
-pub(crate) fn try_push(storage: &SpscStorage, slot: &RingSlot) -> Result<(), Full> {
-    let header = &storage.header;
+/// `base` は初期化済みの shm 領域先頭で、`shm_total_size(slot_size)` バイトの
+/// 書き込み可能領域を指していること。`base` は `ShmHeader` の 8-byte
+/// alignment を満たすこと（`SpscStorage::new` の `Box<[u64]>` および
+/// FFI `aligned_alloc` 経由で担保）。
+#[allow(unsafe_code, clippy::cast_ptr_alignment)]
+unsafe fn shm_header_ref<'a>(base: *const u8) -> &'a ShmHeader {
+    &*base.cast::<ShmHeader>()
+}
+
+/// shm 領域 base ポインタを起点に payload を push する low-level 関数。
+/// Rust 側 [`SpscStorage`] と FFI の双方から呼ばれる共通実装。
+///
+/// # Safety
+///
+/// - `base` は初期化済みの shm 領域先頭で、`shm_total_size(slot_size)` バイトを
+///   覆う書き込み可能領域を指すこと
+/// - `slot_size` は対象 shm の [`ShmHeader::slot_size`] と一致すること
+/// - `base` は `ShmHeader` の 8-byte alignment を満たすこと
+/// - SPSC 規律: 同時に 1 スレッドからのみ呼ばれること
+#[allow(unsafe_code, clippy::cast_ptr_alignment)]
+pub(crate) unsafe fn push_raw(base: *mut u8, slot_size: u32, payload: &[u8]) -> PushResult {
+    let max_payload = slot_size as usize - SLOT_HEADER_SIZE as usize;
+    if payload.len() > max_payload {
+        return PushResult::PayloadTooLarge;
+    }
+    let header = shm_header_ref(base);
     // 自プロセス内の生産者専用インデックスは Relaxed で十分（書き手は自分だけ）。
     let write = header.write_index.load(Ordering::Relaxed);
     // 消費者の進捗を Acquire で取得し、満杯判定の根拠とする。
     let read = header.read_index.load(Ordering::Acquire);
     if write.wrapping_sub(read) >= RING_CAPACITY as u64 {
-        return Err(Full);
+        return PushResult::Full;
     }
     // `as usize` は 32-bit ターゲットで上位ビットを落とすが、
     // `RING_CAPACITY` は 2 のべき乗のため `% RING_CAPACITY` でその差は消える。
     #[allow(clippy::cast_possible_truncation)]
     let idx = (write as usize) % RING_CAPACITY;
+    let slot_ptr = slot_ptr_at(base, slot_size, idx);
     // SAFETY: SPSC 規律により消費者は `slots[read % CAP]` までしか読まず、
     // ここで書く `slots[write % CAP]` は満杯判定により消費者の追跡範囲外。
-    // よって同一スロットへの同時アクセスは発生しない。
-    #[allow(unsafe_code)]
-    unsafe {
-        *storage.slots[idx].get() = *slot;
-    }
+    // よって同一スロットへの同時アクセスは発生しない。slot_ptr は
+    // shm_total_size の範囲内かつ SlotHeader 互換アラインメント (>= 4) を
+    // 満たす（slot_size が 4 byte 倍数のため）。
+    let payload_dst = slot_ptr.add(SLOT_HEADER_SIZE as usize);
+    std::ptr::copy_nonoverlapping(payload.as_ptr(), payload_dst, payload.len());
+    let header_ptr = slot_ptr.cast::<SlotHeader>();
+    std::ptr::write(
+        header_ptr,
+        SlotHeader {
+            occupied: 1,
+            _pad: [0; 3],
+            #[allow(clippy::cast_possible_truncation)]
+            payload_len: payload.len() as u32,
+        },
+    );
     // スロット書き込みより後に必ず観測されるよう Release で公開する。
     header
         .write_index
         .store(write.wrapping_add(1), Ordering::Release);
-    Ok(())
+    PushResult::Ok
 }
 
-/// 消費者の pop 処理本体。`Consumer::pop` と FFI からの両方で呼ばれる。
+/// shm 領域 base ポインタを起点に payload を pop する low-level 関数。
 ///
-/// 呼び出し側は SPSC 規律（任意の時刻に消費者は 1 つだけ）を守ること。
-pub(crate) fn try_pop(storage: &SpscStorage) -> Option<RingSlot> {
-    let header = &storage.header;
+/// # Safety
+///
+/// [`push_raw`] と同じ契約。SPSC 規律は同時に 1 スレッドからのみ呼ばれる
+/// こと（生産者と読み取り経路は同時実行可）。
+#[allow(unsafe_code, clippy::cast_ptr_alignment)]
+pub(crate) unsafe fn pop_raw(base: *const u8, slot_size: u32) -> Option<Vec<u8>> {
+    let header = shm_header_ref(base);
     // 自プロセス内の消費者専用インデックスは Relaxed で十分。
     let read = header.read_index.load(Ordering::Relaxed);
     // 生産者の進捗を Acquire で取得（対応する Release はスロット書き込みの後）。
@@ -164,15 +283,19 @@ pub(crate) fn try_pop(storage: &SpscStorage) -> Option<RingSlot> {
     // 同上: 2 のべき乗での剰余に守られているのでターゲット間で結果は同じ。
     #[allow(clippy::cast_possible_truncation)]
     let idx = (read as usize) % RING_CAPACITY;
+    let slot_ptr = slot_ptr_at(base.cast_mut(), slot_size, idx);
     // SAFETY: SPSC 規律により生産者は `slots[write % CAP]` までしか書かず、
     // ここで読む `slots[read % CAP]` は read < write の不変条件より既に
     // 書き込みが完了している。Acquire ロードによりその書き込みが可視。
-    #[allow(unsafe_code)]
-    let slot = unsafe { *storage.slots[idx].get() };
+    let slot_header_ptr = slot_ptr.cast::<SlotHeader>();
+    let payload_len = (*slot_header_ptr).payload_len as usize;
+    let payload_src = slot_ptr.add(SLOT_HEADER_SIZE as usize);
+    let mut buf = vec![0u8; payload_len];
+    std::ptr::copy_nonoverlapping(payload_src, buf.as_mut_ptr(), payload_len);
     header
         .read_index
         .store(read.wrapping_add(1), Ordering::Release);
-    Some(slot)
+    Some(buf)
 }
 
 /// 単一の生産者ハンドル。`push` のみを提供する。
@@ -181,9 +304,19 @@ pub struct Producer<'a> {
 }
 
 impl Producer<'_> {
-    /// スロットを末尾に追加する。バッファが満杯なら [`Full`] を返す。
-    pub fn push(&mut self, slot: &RingSlot) -> Result<(), Full> {
-        try_push(self.storage, slot)
+    /// payload バイト列を末尾スロットに書き込む。
+    pub fn push(&mut self, payload: &[u8]) -> PushResult {
+        // SAFETY: SpscStorage は新規生成時に slot_size を validate 済みで、
+        // buffer は shm_total_size(slot_size) バイト以上を確保している。
+        // SPSC 生産者規律は &mut Producer により型レベルで担保される。
+        #[allow(unsafe_code)]
+        unsafe {
+            push_raw(
+                self.storage.buffer.as_ptr().cast::<u8>().cast_mut(),
+                self.storage.slot_size,
+                payload,
+            )
+        }
     }
 }
 
@@ -193,62 +326,52 @@ pub struct Consumer<'a> {
 }
 
 impl Consumer<'_> {
-    /// 先頭スロットを取り出す。バッファが空なら `None` を返す。
-    pub fn pop(&mut self) -> Option<RingSlot> {
-        try_pop(self.storage)
+    /// 先頭スロットの payload バイト列を返す。空なら `None`。
+    pub fn pop(&mut self) -> Option<Vec<u8>> {
+        // SAFETY: 同上。SPSC 消費者規律は &mut Consumer で担保。
+        #[allow(unsafe_code)]
+        unsafe {
+            pop_raw(
+                self.storage.buffer.as_ptr().cast::<u8>(),
+                self.storage.slot_size,
+            )
+        }
     }
 }
-
-const EMPTY_SLOT: RingSlot = RingSlot {
-    occupied: 0,
-    _pad: [0; 3],
-    payload_len: 0,
-    side_offset: 0,
-    side_len: 0,
-    _pad2: [0; 4],
-    payload: [0; PAYLOAD_INLINE_MAX],
-};
 
 #[cfg(test)]
 #[allow(clippy::cast_possible_truncation, clippy::items_after_statements)]
 mod tests {
     use super::*;
+    use midori_core::shm::{DEFAULT_SLOT_SIZE, HARD_SLOT_SIZE};
 
     const THREAD_TEST_COUNT: usize = 10_000;
 
-    /// inline payload に「seq の下位バイトを 4 byte little-endian で詰めた」
-    /// テスト用 [`RingSlot`] を作る。msgpack そのものではなく、test 用にバイト列の
-    /// ラウンドトリップだけを確認するためのプレースホルダ。
-    fn slot_with_seq(seq: u32) -> RingSlot {
-        let mut s = EMPTY_SLOT;
-        s.occupied = 1;
-        s.payload_len = 4;
-        s.payload[..4].copy_from_slice(&seq.to_le_bytes());
-        s
+    fn payload_with_seq(seq: u32) -> Vec<u8> {
+        seq.to_le_bytes().to_vec()
     }
 
-    fn read_seq(slot: &RingSlot) -> u32 {
-        assert_eq!(slot.occupied, 1);
-        assert_eq!(slot.payload_len, 4);
+    fn read_seq(payload: &[u8]) -> u32 {
+        assert_eq!(payload.len(), 4);
         let mut buf = [0u8; 4];
-        buf.copy_from_slice(&slot.payload[..4]);
+        buf.copy_from_slice(payload);
         u32::from_le_bytes(buf)
     }
 
     #[test]
     fn it_should_return_none_when_consumer_pops_empty_buffer() {
-        let mut storage = SpscStorage::new();
+        let mut storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
         let (_p, mut c) = storage.split();
         assert!(c.pop().is_none());
     }
 
     #[test]
-    fn it_should_pop_pushed_slots_in_fifo_order() {
-        let mut storage = SpscStorage::new();
+    fn it_should_pop_pushed_payloads_in_fifo_order() {
+        let mut storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
         let (mut p, mut c) = storage.split();
-        p.push(&slot_with_seq(1)).unwrap();
-        p.push(&slot_with_seq(2)).unwrap();
-        p.push(&slot_with_seq(3)).unwrap();
+        assert_eq!(p.push(&payload_with_seq(1)), PushResult::Ok);
+        assert_eq!(p.push(&payload_with_seq(2)), PushResult::Ok);
+        assert_eq!(p.push(&payload_with_seq(3)), PushResult::Ok);
         assert_eq!(read_seq(&c.pop().unwrap()), 1);
         assert_eq!(read_seq(&c.pop().unwrap()), 2);
         assert_eq!(read_seq(&c.pop().unwrap()), 3);
@@ -257,39 +380,38 @@ mod tests {
 
     #[test]
     fn it_should_return_full_when_buffer_holds_capacity_items() {
-        let mut storage = SpscStorage::new();
+        let mut storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
         let (mut p, _c) = storage.split();
         for i in 0..RING_CAPACITY {
-            p.push(&slot_with_seq(i as u32)).unwrap();
+            assert_eq!(p.push(&payload_with_seq(i as u32)), PushResult::Ok);
         }
-        assert_eq!(p.push(&slot_with_seq(u32::MAX)), Err(Full));
+        assert_eq!(p.push(&payload_with_seq(u32::MAX)), PushResult::Full);
     }
 
     #[test]
     fn it_should_wrap_around_after_consuming() {
-        let mut storage = SpscStorage::new();
+        let mut storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
         let (mut p, mut c) = storage.split();
         // 3 周分書いて読む。インデックスは 3 * RING_CAPACITY まで進む。
         let total = RING_CAPACITY * 3;
         for i in 0..total {
-            p.push(&slot_with_seq(i as u32)).unwrap();
+            assert_eq!(p.push(&payload_with_seq(i as u32)), PushResult::Ok);
             assert_eq!(read_seq(&c.pop().unwrap()), i as u32);
         }
     }
 
     #[test]
     fn it_should_allow_refill_after_drain() {
-        let mut storage = SpscStorage::new();
+        let mut storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
         let (mut p, mut c) = storage.split();
-        // 一度満杯にし、全部抜き、再度満杯にできる
         for i in 0..RING_CAPACITY {
-            p.push(&slot_with_seq(i as u32)).unwrap();
+            assert_eq!(p.push(&payload_with_seq(i as u32)), PushResult::Ok);
         }
         for i in 0..RING_CAPACITY {
             assert_eq!(read_seq(&c.pop().unwrap()), i as u32);
         }
         for i in 0..RING_CAPACITY {
-            p.push(&slot_with_seq((i + 1000) as u32)).unwrap();
+            assert_eq!(p.push(&payload_with_seq((i + 1000) as u32)), PushResult::Ok);
         }
         for i in 0..RING_CAPACITY {
             assert_eq!(read_seq(&c.pop().unwrap()), (i + 1000) as u32);
@@ -297,63 +419,89 @@ mod tests {
     }
 
     #[test]
-    fn it_should_round_trip_inline_payload_at_max_capacity() {
-        // payload_len <= PAYLOAD_INLINE_MAX のラウンドトリップ（バイト列が一致）
-        let mut storage = SpscStorage::new();
+    fn it_should_round_trip_payload_at_default_slot_max_capacity() {
+        // payload_len = slot_size - 8 のラウンドトリップ
+        let mut storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
         let (mut p, mut c) = storage.split();
 
-        let mut slot = EMPTY_SLOT;
-        slot.occupied = 1;
-        slot.payload_len = PAYLOAD_INLINE_MAX as u32;
-        for (i, byte) in slot.payload.iter_mut().enumerate() {
-            *byte = (i % 251) as u8;
-        }
-        p.push(&slot).unwrap();
+        let max_payload = (DEFAULT_SLOT_SIZE - SLOT_HEADER_SIZE) as usize;
+        let payload: Vec<u8> = (0..max_payload).map(|i| (i % 251) as u8).collect();
+        assert_eq!(p.push(&payload), PushResult::Ok);
 
         let popped = c.pop().expect("slot should be available");
-        assert_eq!(popped.occupied, 1);
-        assert_eq!(popped.payload_len as usize, PAYLOAD_INLINE_MAX);
-        for (i, byte) in popped.payload.iter().enumerate() {
+        assert_eq!(popped.len(), max_payload);
+        for (i, byte) in popped.iter().enumerate() {
             assert_eq!(*byte, (i % 251) as u8, "byte at {i} mismatched");
         }
-        // side channel は使用していない
-        assert_eq!(popped.side_offset, 0);
-        assert_eq!(popped.side_len, 0);
     }
 
     #[test]
-    fn it_should_carry_side_channel_offsets_when_inline_is_unused() {
-        // payload_len > PAYLOAD_INLINE_MAX 相当のケース: payload_len=0 で
-        // side_offset/side_len のみが立ち、inline payload 領域は使われない。
-        // 本テストは RingSlot フィールドのセマンティクスのみを検証する
-        // （side channel 本体の確保は本クレートのスコープ外）。
-        let mut storage = SpscStorage::new();
+    fn it_should_reject_payload_exceeding_slot_capacity() {
+        let mut storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
+        let (mut p, _c) = storage.split();
+        let too_large = vec![0u8; (DEFAULT_SLOT_SIZE - SLOT_HEADER_SIZE) as usize + 1];
+        assert_eq!(p.push(&too_large), PushResult::PayloadTooLarge);
+    }
+
+    #[test]
+    fn it_should_round_trip_payload_with_custom_slot_size() {
+        // 4 KiB slot で driver-requested サイズのケース
+        let slot_size = 4_104; // payload 容量 4096 + header 8、4 byte align
+        let mut storage = SpscStorage::new(slot_size).expect("custom");
+        assert_eq!(storage.slot_size(), slot_size);
         let (mut p, mut c) = storage.split();
 
-        let mut slot = EMPTY_SLOT;
-        slot.occupied = 1;
-        slot.payload_len = 0;
-        slot.side_offset = 4096;
-        slot.side_len = 1024;
-        p.push(&slot).unwrap();
-
+        let payload: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+        assert_eq!(p.push(&payload), PushResult::Ok);
         let popped = c.pop().expect("slot should be available");
-        assert_eq!(popped.occupied, 1);
-        assert_eq!(popped.payload_len, 0);
-        assert_eq!(popped.side_offset, 4096);
-        assert_eq!(popped.side_len, 1024);
+        assert_eq!(popped.len(), 4096);
+        assert_eq!(popped, payload);
+    }
+
+    #[test]
+    fn it_should_reject_storage_with_invalid_slot_size() {
+        // alignment 違反
+        assert!(matches!(
+            SpscStorage::new(13),
+            Err(SlotSizeError::NotAligned { .. })
+        ));
+        // hard 超過
+        assert!(matches!(
+            SpscStorage::new(HARD_SLOT_SIZE + 4),
+            Err(SlotSizeError::TooLarge { .. })
+        ));
+        // min 未満
+        assert!(matches!(
+            SpscStorage::new(8),
+            Err(SlotSizeError::TooSmall { .. })
+        ));
+    }
+
+    #[test]
+    fn it_should_record_slot_size_and_layout_version_in_header() {
+        let storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
+        let header = storage.header();
+        assert_eq!(header.slot_size, DEFAULT_SLOT_SIZE);
+        assert_eq!(header.version, SHM_LAYOUT_VERSION);
+    }
+
+    #[test]
+    fn it_should_ffi_code_match_design_contract() {
+        assert_eq!(PushResult::Ok.as_ffi_code(), 1);
+        assert_eq!(PushResult::Full.as_ffi_code(), 0);
+        assert_eq!(PushResult::PayloadTooLarge.as_ffi_code(), -2);
     }
 
     #[test]
     fn it_should_transfer_data_between_threads() {
-        let mut storage = SpscStorage::new();
+        let mut storage = SpscStorage::new(DEFAULT_SLOT_SIZE).expect("default");
         let (mut p, mut c) = storage.split();
 
         std::thread::scope(|s| {
             s.spawn(move || {
                 let mut sent: u32 = 0;
                 while (sent as usize) < THREAD_TEST_COUNT {
-                    if p.push(&slot_with_seq(sent)).is_ok() {
+                    if matches!(p.push(&payload_with_seq(sent)), PushResult::Ok) {
                         sent += 1;
                     } else {
                         std::thread::yield_now();
@@ -363,8 +511,8 @@ mod tests {
             s.spawn(move || {
                 let mut expected: u32 = 0;
                 while (expected as usize) < THREAD_TEST_COUNT {
-                    if let Some(slot) = c.pop() {
-                        assert_eq!(read_seq(&slot), expected);
+                    if let Some(payload) = c.pop() {
+                        assert_eq!(read_seq(&payload), expected);
                         expected += 1;
                     } else {
                         std::thread::yield_now();

--- a/crates/midori-sdk/src/spsc.rs
+++ b/crates/midori-sdk/src/spsc.rs
@@ -291,23 +291,46 @@ pub(crate) unsafe fn push_raw(base: *mut u8, slot_size: u32, payload: &[u8]) -> 
     PushResult::Ok
 }
 
-/// shm 領域 base ポインタを起点に payload を pop する low-level 関数。
+/// `pop_raw_into` の戻り値。FFI hot path で Vec allocate を回避するため
+/// `&mut [u8]` 互換の caller buffer を取り、結果だけ enum で返す。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PopOutcome {
+    /// ring が空。`out_buf` には書き込まれない。
+    Empty,
+    /// payload を `out_buf` に書き込んだ。`usize` は実際に書いた byte 数。
+    Copied(usize),
+    /// `out_buf` の容量が payload より小さく、書き込めなかった。slot は
+    /// SPSC 規律に従い消費済み（再 pop 不可）。`usize` は本来必要だった
+    /// payload byte 数で、caller が次回 buffer を見積もる材料にする。
+    Truncated(usize),
+}
+
+/// shm 領域 base ポインタを起点に payload を caller buffer へ直接コピーする
+/// low-level 関数。FFI hot path 用に Vec allocate を回避する。
 ///
 /// # Safety
 ///
-/// [`push_raw`] と同じ契約。SPSC 規律は同時に 1 スレッドからのみ呼ばれる
-/// こと（生産者と読み取り経路は同時実行可）。
+/// - `base` は初期化済みの shm 領域先頭で、`shm_total_size(slot_size)` バイトを
+///   覆う読み取り可能領域を指すこと
+/// - `slot_size` は対象 shm の [`ShmHeader::slot_size`] と一致すること
+/// - `out_buf` は `out_buf_cap` バイト以上の書き込み可能領域を指すこと
+///   （`out_buf_cap == 0` のときは書き込みを行わない）
+/// - SPSC 規律: 同時に 1 スレッドからのみ呼ばれること
 #[allow(unsafe_code, clippy::cast_ptr_alignment)]
-pub(crate) unsafe fn pop_raw(base: *const u8, slot_size: u32) -> Option<Vec<u8>> {
+pub(crate) unsafe fn pop_raw_into(
+    base: *const u8,
+    slot_size: u32,
+    out_buf: *mut u8,
+    out_buf_cap: usize,
+) -> PopOutcome {
     let header = shm_header_ref(base);
     // 自プロセス内の消費者専用インデックスは Relaxed で十分。
     let read = header.read_index.load(Ordering::Relaxed);
     // 生産者の進捗を Acquire で取得（対応する Release はスロット書き込みの後）。
     let write = header.write_index.load(Ordering::Acquire);
     if read == write {
-        return None;
+        return PopOutcome::Empty;
     }
-    // 同上: 2 のべき乗での剰余に守られているのでターゲット間で結果は同じ。
     #[allow(clippy::cast_possible_truncation)]
     let idx = (read as usize) % RING_CAPACITY;
     let slot_ptr = slot_ptr_at(base.cast_mut(), slot_size, idx);
@@ -323,13 +346,48 @@ pub(crate) unsafe fn pop_raw(base: *const u8, slot_size: u32) -> Option<Vec<u8>>
     // (slot_size - SLOT_HEADER_SIZE) で clamp して被害を slot 内に閉じる。
     let max_payload = (slot_size as usize).saturating_sub(SLOT_HEADER_SIZE as usize);
     let payload_len = raw_payload_len.min(max_payload);
+    // capacity check の結果に関わらず slot は消費する（SPSC 規律上、消費者
+    // は自分の read_index を進める権限を持ち、再 pop はできない）。
+    if payload_len > out_buf_cap {
+        header
+            .read_index
+            .store(read.wrapping_add(1), Ordering::Release);
+        return PopOutcome::Truncated(payload_len);
+    }
     let payload_src = slot_ptr.add(SLOT_HEADER_SIZE as usize);
-    let mut buf = vec![0u8; payload_len];
-    std::ptr::copy_nonoverlapping(payload_src, buf.as_mut_ptr(), payload_len);
+    if payload_len > 0 {
+        std::ptr::copy_nonoverlapping(payload_src, out_buf, payload_len);
+    }
     header
         .read_index
         .store(read.wrapping_add(1), Ordering::Release);
-    Some(buf)
+    PopOutcome::Copied(payload_len)
+}
+
+/// shm 領域 base ポインタを起点に payload を `Vec<u8>` として pop する。
+/// Rust API の [`Consumer::pop`] が利用する経路。FFI 経由は Vec 経由を
+/// 避けるため [`pop_raw_into`] を直接使うこと。
+///
+/// # Safety
+///
+/// [`pop_raw_into`] と同じ契約。
+#[allow(unsafe_code)]
+pub(crate) unsafe fn pop_raw(base: *const u8, slot_size: u32) -> Option<Vec<u8>> {
+    // payload 長は最大でも slot_size - SLOT_HEADER_SIZE。最初に最大容量で
+    // 確保しておき、Truncated は発生しない経路にする。
+    let max_payload = (slot_size as usize).saturating_sub(SLOT_HEADER_SIZE as usize);
+    let mut buf = vec![0u8; max_payload];
+    match pop_raw_into(base, slot_size, buf.as_mut_ptr(), buf.len()) {
+        PopOutcome::Copied(len) => {
+            buf.truncate(len);
+            Some(buf)
+        }
+        // SAFETY: out_buf_cap = max_payload を渡しているため pop_raw_into
+        // は Truncated を返さない（payload_len は内部で max_payload に
+        // clamp 済み）。理論上到達しない Truncated と Empty をまとめて
+        // None で表現する。
+        PopOutcome::Empty | PopOutcome::Truncated(_) => None,
+    }
 }
 
 /// 単一の生産者ハンドル。`push` のみを提供する。


### PR DESCRIPTION
## Summary

- `design/17-driver-comm/01-inline-ring.md` の target spec に従い、SPSC ring slot を「driver lifetime 内固定 / driver ごとに異なる」可変サイズに切り替える。
- midori-core / midori-sdk の major bump を伴う ABI breaking change。`PAYLOAD_INLINE_MAX` / `RingSlot` / side channel フィールドを撤去し、`SlotHeader` (8 byte) + raw payload bytes (slot_size - 8) + `ShmHeader` (56 byte) のレイアウトに刷新。
- FFI 戻り値型を `u8` から `int32_t` に変更（`-2` payload too large の表現）。
- Bridge 側 handshake `request_ring(slot_size)` の解決経路を `midori-runtime/src/ring_handshake.rs` に追加。

## 主な変更

### `midori-core::shm`
- `RingSlot` 廃止 → `SlotHeader` (固定 8 byte: occupied/payload_len)
- `ShmHeader` を 56 byte に拡張: `slot_size: u32` / `version: u32` / `_pad: [u8; 32]`
- 定数追加: `DEFAULT_SLOT_SIZE = 1032` / `HARD_SLOT_SIZE = 65536` / `MIN_SLOT_SIZE = 12` / `SLOT_HEADER_SIZE = 8` / `SHM_LAYOUT_VERSION = 1` / `MIN/MAX_SUPPORTED_SHM_VERSION`
- helper: `validate_slot_size` / `align_slot_size` / `shm_total_size` / `slot_offset_in_shm`
- `SlotSizeError { NotAligned, TooSmall, TooLarge }`
- `const_assert!` で `ShmHeader = 56 byte` / `SlotHeader = 8 byte` をコンパイル時 lock

### `midori-sdk::spsc` / `ffi`
- `SpscStorage::new(slot_size)` で動的サイズ確保。`Box<[u64]>` backing で 8-byte alignment 保証
- `Producer::push(&[u8])` / `Consumer::pop() -> Option<Vec<u8>>` API 変更
- low-level `push_raw` / `pop_raw` を導入し、Rust API と FFI の双方から共通実装を呼ぶ
- `PushResult { Ok = 1, Full = 0, PayloadTooLarge = -2 }`、FFI 戻り値型は `int32_t`
- `midori_sdk_spsc_storage_size(slot_size)` / `midori_sdk_spsc_init(storage, slot_size)` に signature 変更
- cbindgen: `AtomicU64` → `uint64_t` rename、`ShmHeader` / `SlotHeader` / 定数群を export include

### `midori-runtime::ring_handshake` (新規)
- `resolve_requested_slot_size(requested)` → sentinel 0 を `DEFAULT_SLOT_SIZE` に解決、validate_slot_size で alignment / 上限チェック
- `page_aligned_shm_size(slot_size)` → 4 KiB ページに切り上げた shm 全体サイズ
- `HandshakeError` (`source()` オーバーライド付き)
- 単体テスト 6 件

## AC マッピング

### `crates/midori-core/src/shm.rs`
- [x] `RingSlot` から `side_offset` / `side_len` / `_pad2` を削除（`RingSlot` 自体を撤去）
- [x] `RingSlot::payload` を動的サイズに変更（`SlotHeader` + raw bytes、`shm_total_size` 起点 stride 計算）
- [x] `ShmHeader` に `slot_size` / `version` / `_pad` 追加（56 byte）
- [x] `PAYLOAD_INLINE_MAX` 撤去
- [x] モジュールコメントから `side_offset` / `side_len` / `PAYLOAD_INLINE_MAX` 参照を削除し `01-inline-ring.md` を典拠に
- [x] `shm_header_size_and_align` を 56 byte に更新
- [x] `ring_slot_is_repr_c_and_fixed_size` 削除
- [x] `validate_slot_size` で alignment / 最小値 / `HARD_SLOT_SIZE` を runtime 検証

### `crates/midori-sdk/src/spsc.rs` / `ffi.rs`
- [x] `Producer` / `Consumer` API に `slot_size` 導入（`SpscStorage::new(slot_size)` で受領）
- [x] `midori_sdk_spsc_*` 全関数に `slot_size` 引数 / 動的サイズ対応
- [x] FFI 戻り値型を `u8` → `i32` に breaking change（`-2` payload too large）
- [x] 既存テスト全書き換え（`PAYLOAD_INLINE_MAX` / 264 byte 固定依存を削除）
- [ ] handshake `request_ring` 送信経路（control channel 実装は本 PR スコープ外）
- [x] driver 側 `((max_payload_size + 8) + 3) & !3` 丸めは `align_slot_size` helper として midori-core で提供

### Bridge 側（midori-runtime）
- [x] `resolve_requested_slot_size`: sentinel 0 → `DEFAULT_SLOT_SIZE`、それ以外そのまま採用
- [x] alignment 検証 + 上限チェックで reject
- [x] `page_aligned_shm_size`: `(shm_total + PAGE_SIZE - 1) & !(PAGE_SIZE - 1)` で 4 KiB ページ整列
- [ ] 実 mmap 確保（実 driver process spawn と control channel が前提のため後続 subtask）

### 単体テスト / 統合テスト
- [x] DEFAULT slot 内 round-trip（`it_should_pop_pushed_payloads_in_fifo_order` 他）
- [x] driver 要求サイズ slot 4 KiB の round-trip（`it_should_round_trip_payload_with_custom_slot_size`）
- [x] HARD 超過 reject（`it_should_reject_storage_with_invalid_slot_size`、`it_should_reject_above_hard_limit`）
- [x] alignment 違反 reject（同上）
- [x] ring 満杯 back-pressure（`it_should_return_full_when_buffer_holds_capacity_items`）

### 言語ラッパー
- [x] cbindgen 生成 C ヘッダ更新（新型 / 戻り値型）
- N/A: PyO3 / napi-rs ラッパーは本リポジトリに未実装のため OOS

## Out of Scope

- streamed tier 実装
- driver lifetime 中の `slot_size` 変更
- 実 driver process spawn と control channel wire format（handshake メッセージ送受信は後続 subtask）
- 実 mmap / shm fd 確保（in-process Box backing でテスト、実環境連携は別 subtask）
- 同一プロセス内 multi-driver 並走

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`（midori-core 28 / sdk 36 / runtime 105、計 171 件通過）
- [x] cbindgen 生成 C ヘッダの新型 / 戻り値型を `it_should_generate_c_header_with_expected_ffi_symbols` で回帰

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * スロットサイズの動的指定とハンドシェイクによる解決、ページ揃え計算を追加
  * ペイロードを生バイト列で扱う新しい push/pop 動作と結果型を導入

* **破壊的変更**
  * FFI の初期化・push/pop インターフェースがバイト列対応に変更され、旧スロット構造ベースのABIを置換

* **改善**
  * スロットサイズ検証・整列・サイズ計算と詳細なエラー報告を追加
  * 生成されるCヘッダを共有メモリレイアウトに限定

* **バージョン更新**
  * midori-core: 0.2.0 → 0.3.0
  * midori-sdk: 0.1.0 → 0.2.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->