### PR TITLE
feat(runtime): wire profile YAML to events.yaml startup chain (MEW-55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -141,6 +141,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,7 +174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -167,6 +188,17 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -245,6 +277,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libyml"
 version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +340,7 @@ name = "midori-runtime"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dirs",
  "midori-core",
  "rmpv",
  "serde",
@@ -339,6 +381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +421,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,7 +459,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -526,10 +585,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -596,6 +675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,12 +740,78 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 midori-core = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+dirs = "5"
 rmpv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_yml = "0.0.12"

--- a/crates/midori-runtime/src/error.rs
+++ b/crates/midori-runtime/src/error.rs
@@ -1,15 +1,13 @@
-use std::path::PathBuf;
-
 use crate::events_pipeline::StartupCheckError;
+use crate::profile::ProfileLoadError;
 
 #[derive(Debug)]
 pub enum CliError {
-    ReadProfile {
-        path: PathBuf,
-        source: std::io::Error,
-    },
-    /// `--driver-events` 引数の値が `<name>=<path>` の形式に従っていない。
-    InvalidDriverEventsArg { raw: String },
+    /// プロファイル YAML のロード / パース / 意味論検証で失敗した。
+    LoadProfile { source: ProfileLoadError },
+    /// `--app-data-dir` 省略時に OS 標準のアプリデータディレクトリが
+    /// 解決できなかった（環境変数 `HOME` / `APPDATA` などが未設定）。
+    AppDataDirUnavailable,
     /// 起動時の events.yaml チェックで Bridge が継続できない違反を検出した。
     StartupCheck { source: StartupCheckError },
 }
@@ -17,16 +15,9 @@ pub enum CliError {
 impl std::fmt::Display for CliError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ReadProfile { path, source } => {
-                write!(
-                    f,
-                    "プロファイルの読み込みに失敗しました ({}): {source}",
-                    path.display()
-                )
-            }
-            Self::InvalidDriverEventsArg { raw } => write!(
-                f,
-                "--driver-events の値が `<name>=<path>` 形式ではありません: `{raw}`"
+            Self::LoadProfile { source } => write!(f, "{source}"),
+            Self::AppDataDirUnavailable => f.write_str(
+                "アプリデータディレクトリを自動解決できませんでした。--app-data-dir で明示してください",
             ),
             Self::StartupCheck { source } => write!(f, "起動時チェックに失敗しました: {source}"),
         }
@@ -36,9 +27,9 @@ impl std::fmt::Display for CliError {
 impl std::error::Error for CliError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            Self::ReadProfile { source, .. } => Some(source),
+            Self::LoadProfile { source } => Some(source),
             Self::StartupCheck { source } => Some(source),
-            Self::InvalidDriverEventsArg { .. } => None,
+            Self::AppDataDirUnavailable => None,
         }
     }
 }

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -226,9 +226,11 @@ mod tests {
 
     use crate::error::CliError;
 
-    /// 与えた driver 名のリストを inputs/outputs として持つ profile YAML を
-    /// tempdir に書き出して path を返す。最初の name は input、2 つ目以降は
-    /// output に振り分ける（最低 1 件ずつが必要なため）。
+    /// 与えた `(kind, name)` ペアのリストから profile YAML を組み立てて
+    /// tempfile に書き出す。`kind == "input"` のものを `inputs[]`、
+    /// `kind == "output"` のものを `outputs[]` に振り分ける。spec 上 inputs
+    /// / outputs はそれぞれ最低 1 件必要なので、片方が空のときは dummy
+    /// エントリを補って `ProfileLoadError::Invalid` を回避する。
     fn write_tmp_profile(tag: &str, drivers: &[(&str, &str)]) -> tempfile::NamedTempFile {
         // drivers: (kind, name) where kind は "input" / "output"
         let mut yaml = String::from("inputs:\n");
@@ -270,7 +272,7 @@ mod tests {
             );
         }
         let mut file = tempfile::Builder::new()
-            .prefix(&format!("midori-mew55-{tag}-"))
+            .prefix(&format!("midori-profile-test-{tag}-"))
             .suffix(".yaml")
             .tempfile()
             .expect("tempfile");
@@ -282,7 +284,7 @@ mod tests {
     /// 用意する。`bodies` で `name -> events.yaml 内容` を渡す。
     fn setup_app_data_dir(bodies: &[(&str, &str)]) -> tempfile::TempDir {
         let dir = tempfile::Builder::new()
-            .prefix("midori-mew55-app-")
+            .prefix("midori-profile-test-app-")
             .tempdir()
             .expect("tempdir");
         for (name, body) in bodies {
@@ -321,6 +323,10 @@ mod tests {
     /// loader 段階の YAML パースで失敗する events.yaml フィクスチャ。
     /// 末尾の `[` が閉じておらず `serde_yml::from_str` が Parse error を返す。
     const EVENTS_YAML_MALFORMED: &str = "schema_version: [\n";
+
+    /// `transform` フィールドを欠いた profile YAML フィクスチャ。
+    /// `ProfileLoadError::Parse` 経路の回帰用。
+    const PROFILE_YAML_MISSING_TRANSFORM: &str = "inputs:\n  - adapter: a.yaml\n    connection: { driver: midi }\noutputs:\n  - adapter: b.yaml\n    connection: { driver: osc }\n";
 
     fn run_args(profile_path: &Path, app_data_dir: &Path) -> Vec<String> {
         vec![
@@ -453,19 +459,29 @@ mod tests {
 
     #[test]
     fn it_should_fail_when_profile_yaml_is_invalid() {
-        // 必須フィールド (transform) を欠いた profile YAML
+        // 必須フィールド (transform) を欠いた profile YAML は serde 段階で
+        // 弾かれ、ProfileLoadError::Parse として CliError::LoadProfile に
+        // 包まれる。inner variant も pin して Io / Invalid との取り違えを防ぐ。
         let app = setup_app_data_dir(&[]);
         let mut bad = tempfile::Builder::new()
-            .prefix("midori-mew55-bad-")
+            .prefix("midori-profile-test-bad-")
             .suffix(".yaml")
             .tempfile()
             .expect("tempfile");
-        let yaml = "inputs:\n  - adapter: a.yaml\n    connection: { driver: midi }\noutputs:\n  - adapter: b.yaml\n    connection: { driver: osc }\n";
-        std::io::Write::write_all(&mut bad, yaml.as_bytes()).expect("write");
+        std::io::Write::write_all(&mut bad, PROFILE_YAML_MISSING_TRANSFORM.as_bytes())
+            .expect("write");
 
         let cli = Cli::try_parse_from(run_args(bad.path(), app.path())).expect("parse");
         let err = super::dispatch(&cli).expect_err("missing transform");
-        assert!(matches!(err, CliError::LoadProfile { .. }));
+        assert!(
+            matches!(
+                err,
+                CliError::LoadProfile {
+                    source: crate::profile::ProfileLoadError::Parse { .. }
+                }
+            ),
+            "expected LoadProfile::Parse, got {err:?}"
+        );
     }
 
     #[test]
@@ -489,6 +505,12 @@ mod tests {
         let rendered = err.to_string();
         assert!(rendered.contains("osc"), "got: {rendered}");
         assert!(rendered.contains("streamed"), "got: {rendered}");
+        // 内側 FeatureUnavailable.reason の文言まで chain して観測できることを
+        // 担保する（feature_check.rs::STREAMED_REASON 由来）。
+        assert!(
+            rendered.contains("not implemented"),
+            "Display should include the inner reason phrase, got: {rendered}"
+        );
         assert!(!rendered.ends_with('\n'), "got: {rendered:?}");
     }
 }

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -1,6 +1,7 @@
 mod error;
 mod events_pipeline;
 mod events_schema;
+mod profile;
 mod ring_handshake;
 
 use std::path::{Path, PathBuf};
@@ -10,6 +11,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 use crate::error::CliError;
 use crate::events_pipeline::{check_driver_schema, DriverSchemaOutcome};
+use crate::profile::{collect_driver_names, load_from_path as load_profile};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -42,12 +44,6 @@ enum Command {
         /// プロファイル YAML へのパス
         #[arg(value_name = "PROFILE")]
         profile: PathBuf,
-
-        /// driver の events.yaml を `<name>=<path>` 形式で直接指定する。
-        /// profile YAML resolver 完成までの暫定経路で、CLI help では非露出。
-        /// 複数回指定可。
-        #[arg(long = "driver-events", value_name = "NAME=PATH", hide = true)]
-        driver_events: Vec<String>,
     },
 }
 
@@ -78,41 +74,28 @@ fn main() -> ExitCode {
 
 fn dispatch(cli: &Cli) -> Result<(), CliError> {
     match &cli.command {
-        Command::Run {
-            profile,
-            driver_events,
-        } => run(profile, driver_events),
+        Command::Run { profile } => run(profile, cli.app_data_dir.as_deref()),
     }
 }
 
 // プロファイル本体のパイプラインは後続の subtask で実装する。
-// 本関数では (a) `--driver-events` の引数形式が正しいこと、(b) プロファイル
-// YAML が読めること、(c) 各 events.yaml が起動時チェックを通過すること、を
-// この順に確認する。
-//
-// 引数形式違反は I/O より先に弾き、CLI 入力ミスを root cause として安定して
-// 報告できるようにする（profile が無い + arg 不正のとき `ReadProfile` で
-// マスクされないようにするため）。
-fn run(profile_path: &Path, driver_events_args: &[String]) -> Result<(), CliError> {
-    let driver_events: Vec<(&str, PathBuf)> = driver_events_args
-        .iter()
-        .map(|raw| parse_driver_events_arg(raw))
-        .collect::<Result<_, _>>()?;
+// 本関数では (a) profile YAML を読み、(b) inputs/outputs から driver 名を
+// 抽出して (c) 各 driver の events.yaml を起動時整合性チェックする、まで
+// を担う。実 driver process spawn / SPSC 連携は別 subtask の責務。
+fn run(profile_path: &Path, app_data_dir_override: Option<&Path>) -> Result<(), CliError> {
+    let profile = load_profile(profile_path).map_err(|source| CliError::LoadProfile { source })?;
+    let driver_names = collect_driver_names(&profile);
+    let app_data_dir = resolve_app_data_dir(app_data_dir_override)?;
 
-    let _profile_yaml =
-        std::fs::read_to_string(profile_path).map_err(|source| CliError::ReadProfile {
-            path: profile_path.to_path_buf(),
-            source,
-        })?;
-
-    for (name, path) in driver_events {
-        match check_driver_schema(name, &path)
+    for name in &driver_names {
+        let events_yaml_path = events_yaml_path_for(&app_data_dir, name);
+        match check_driver_schema(name, &events_yaml_path)
             .map_err(|source| CliError::StartupCheck { source })?
         {
             DriverSchemaOutcome::Loaded(_) => {
                 eprintln!(
                     "midori: driver `{name}` の events.yaml ({}) のチェックが完了しました",
-                    path.display()
+                    events_yaml_path.display()
                 );
             }
             DriverSchemaOutcome::Missing => {
@@ -120,40 +103,49 @@ fn run(profile_path: &Path, driver_events_args: &[String]) -> Result<(), CliErro
                 // として warning に留めて起動を継続する。
                 eprintln!(
                     "midori: warning: driver `{name}` の events.yaml ({}) が見つかりませんでした。schema 未宣言モードで起動します",
-                    path.display()
+                    events_yaml_path.display()
                 );
             }
         }
     }
 
+    let _ = profile; // adapter / transform の本格ロードは別 subtask
     Ok(())
 }
 
-/// `--driver-events <name>=<path>` 形式の引数を分解する。
-///
-/// shell からの引数渡しで前後に空白が混じるケース（例: `"midi=   "`）を
-/// 防衛するため、`name` / `path` は `trim()` してから空判定する。
-fn parse_driver_events_arg(raw: &str) -> Result<(&str, PathBuf), CliError> {
-    let (name, path) = raw
-        .split_once('=')
-        .ok_or_else(|| CliError::InvalidDriverEventsArg {
-            raw: raw.to_owned(),
-        })?;
-    let name = name.trim();
-    let path = path.trim();
-    if name.is_empty() || path.is_empty() {
-        return Err(CliError::InvalidDriverEventsArg {
-            raw: raw.to_owned(),
-        });
+/// `<app-data-dir>/plugins/driver-<name>/events.yaml` の規約で events.yaml
+/// path を組み立てる。本格 plugin.yaml resolver は別 subtask で導入予定。
+fn events_yaml_path_for(app_data_dir: &Path, driver_name: &str) -> PathBuf {
+    app_data_dir
+        .join("plugins")
+        .join(format!("driver-{driver_name}"))
+        .join("events.yaml")
+}
+
+/// CLI override が無ければ OS 標準のアプリデータディレクトリを `dirs` 経由
+/// で解決する。`design/04-runtime-cli.md` の表に従い:
+/// - macOS: `~/Library/Application Support/Midori`
+/// - Windows: `%APPDATA%\Midori`
+/// - Linux: `$XDG_DATA_HOME/midori`（未設定時 `~/.local/share/midori`）
+fn resolve_app_data_dir(cli_override: Option<&Path>) -> Result<PathBuf, CliError> {
+    if let Some(path) = cli_override {
+        return Ok(path.to_path_buf());
     }
-    Ok((name, PathBuf::from(path)))
+    let base = dirs::data_dir().ok_or(CliError::AppDataDirUnavailable)?;
+    Ok(
+        base.join(if cfg!(any(target_os = "macos", target_os = "windows")) {
+            "Midori"
+        } else {
+            "midori"
+        }),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::{Cli, Command, LogFormat, LogLevel};
     use clap::{CommandFactory, Parser};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn it_should_render_help_listing_run_subcommand() {
@@ -177,12 +169,8 @@ mod tests {
             .expect("run subcommand with positional profile must parse");
 
         match cli.command {
-            Command::Run {
-                profile,
-                driver_events,
-            } => {
+            Command::Run { profile } => {
                 assert_eq!(profile, PathBuf::from("/tmp/profile.yaml"));
-                assert!(driver_events.is_empty());
             }
         }
     }
@@ -221,20 +209,6 @@ mod tests {
     }
 
     #[test]
-    fn it_should_succeed_when_profile_file_exists() {
-        let dir = std::env::temp_dir();
-        let path = dir.join(format!("midori-runtime-test-{}.yaml", std::process::id()));
-        std::fs::write(&path, "name: test\n").expect("write tmp profile");
-
-        let cli = Cli::try_parse_from(["midori", "run", path.to_str().expect("tmp path is utf-8")])
-            .expect("parse");
-        let result = super::dispatch(&cli);
-
-        let _ = std::fs::remove_file(&path);
-        assert!(result.is_ok(), "existing profile should load");
-    }
-
-    #[test]
     fn it_should_fail_when_profile_file_is_missing() {
         let cli = Cli::try_parse_from([
             "midori",
@@ -247,31 +221,76 @@ mod tests {
     }
 
     // --------------------------------------------------------------
-    // --driver-events startup chain
+    // profile YAML → events.yaml startup chain
     // --------------------------------------------------------------
 
     use crate::error::CliError;
 
-    /// 必要最小の profile YAML をテンポラリ生成し、その path を返す。
-    fn write_tmp_profile(tag: &str) -> tempfile::NamedTempFile {
+    /// 与えた driver 名のリストを inputs/outputs として持つ profile YAML を
+    /// tempdir に書き出して path を返す。最初の name は input、2 つ目以降は
+    /// output に振り分ける（最低 1 件ずつが必要なため）。
+    fn write_tmp_profile(tag: &str, drivers: &[(&str, &str)]) -> tempfile::NamedTempFile {
+        // drivers: (kind, name) where kind は "input" / "output"
+        let mut yaml = String::from("inputs:\n");
+        let mut input_count = 0;
+        for (kind, name) in drivers {
+            if *kind == "input" {
+                use std::fmt::Write as _;
+                writeln!(
+                    yaml,
+                    "  - adapter: adapters/{name}.yaml\n    connection:\n      driver: {name}"
+                )
+                .expect("string write");
+                input_count += 1;
+            }
+        }
+        if input_count == 0 {
+            // input が無いと invalid。テスト都合で空の dummy input を入れる。
+            yaml.push_str(
+                "  - adapter: adapters/dummy-in.yaml\n    connection:\n      driver: dummy-in\n",
+            );
+        }
+        yaml.push_str("transform: mappers/example.yaml\n");
+        yaml.push_str("outputs:\n");
+        let mut output_count = 0;
+        for (kind, name) in drivers {
+            if *kind == "output" {
+                use std::fmt::Write as _;
+                writeln!(
+                    yaml,
+                    "  - adapter: adapters/{name}.yaml\n    connection:\n      driver: {name}"
+                )
+                .expect("string write");
+                output_count += 1;
+            }
+        }
+        if output_count == 0 {
+            yaml.push_str(
+                "  - adapter: adapters/dummy-out.yaml\n    connection:\n      driver: dummy-out\n",
+            );
+        }
         let mut file = tempfile::Builder::new()
-            .prefix(&format!("midori-mew54-{tag}-"))
+            .prefix(&format!("midori-mew55-{tag}-"))
             .suffix(".yaml")
             .tempfile()
             .expect("tempfile");
-        std::io::Write::write_all(&mut file, b"name: test\n").expect("write profile");
+        std::io::Write::write_all(&mut file, yaml.as_bytes()).expect("write profile");
         file
     }
 
-    /// 任意の events.yaml 文字列を temp ファイルに書き出す。
-    fn write_tmp_events_yaml(tag: &str, body: &str) -> tempfile::NamedTempFile {
-        let mut file = tempfile::Builder::new()
-            .prefix(&format!("midori-mew54-events-{tag}-"))
-            .suffix(".yaml")
-            .tempfile()
-            .expect("tempfile");
-        std::io::Write::write_all(&mut file, body.as_bytes()).expect("write events.yaml");
-        file
+    /// `<app-data-dir>/plugins/driver-<name>/events.yaml` 構造を tempdir に
+    /// 用意する。`bodies` で `name -> events.yaml 内容` を渡す。
+    fn setup_app_data_dir(bodies: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::Builder::new()
+            .prefix("midori-mew55-app-")
+            .tempdir()
+            .expect("tempdir");
+        for (name, body) in bodies {
+            let plugin_dir = dir.path().join("plugins").join(format!("driver-{name}"));
+            std::fs::create_dir_all(&plugin_dir).expect("mkdir plugin");
+            std::fs::write(plugin_dir.join("events.yaml"), body).expect("write events.yaml");
+        }
+        dir
     }
 
     /// 正常通過する最小 events.yaml フィクスチャ（noteOn の range が
@@ -303,38 +322,30 @@ mod tests {
     /// 末尾の `[` が閉じておらず `serde_yml::from_str` が Parse error を返す。
     const EVENTS_YAML_MALFORMED: &str = "schema_version: [\n";
 
+    fn run_args(profile_path: &Path, app_data_dir: &Path) -> Vec<String> {
+        vec![
+            "midori".to_owned(),
+            "--app-data-dir".to_owned(),
+            app_data_dir.to_str().expect("utf-8").to_owned(),
+            "run".to_owned(),
+            profile_path.to_str().expect("utf-8").to_owned(),
+        ]
+    }
+
     #[test]
-    fn it_should_pass_startup_when_driver_events_yaml_is_valid() {
-        let profile = write_tmp_profile("happy");
-        let events = write_tmp_events_yaml("happy", EVENTS_YAML_VALID_NOTEON);
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            &format!("midi={}", events.path().display()),
-        ])
-        .expect("parse");
-
+    fn it_should_pass_startup_when_profile_drivers_have_valid_events_yaml() {
+        let app = setup_app_data_dir(&[("midi", EVENTS_YAML_VALID_NOTEON)]);
+        let profile = write_tmp_profile("happy", &[("input", "midi"), ("output", "midi")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
         let result = super::dispatch(&cli);
-
         assert!(result.is_ok(), "valid events.yaml should pass: {result:?}");
     }
 
     #[test]
     fn it_should_fail_startup_when_driver_events_yaml_violates_schema() {
-        // `range:` の min > max は validator が違反として検出する。
-        let profile = write_tmp_profile("invalid");
-        let events = write_tmp_events_yaml("invalid", EVENTS_YAML_INVALID_RANGE);
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            &format!("midi={}", events.path().display()),
-        ])
-        .expect("parse");
-
+        let app = setup_app_data_dir(&[("midi", EVENTS_YAML_INVALID_RANGE)]);
+        let profile = write_tmp_profile("invalid", &[("input", "midi"), ("output", "midi")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
         let err = super::dispatch(&cli).expect_err("schema violation must fail");
         assert!(
             matches!(
@@ -349,37 +360,22 @@ mod tests {
 
     #[test]
     fn it_should_warn_and_continue_when_driver_events_yaml_is_missing() {
-        let profile = write_tmp_profile("missing");
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            "midi=/nonexistent/midori-mew54/events.yaml",
-        ])
-        .expect("parse");
-
+        // app-data-dir 配下に該当 driver の events.yaml を配置しない → Missing 扱い
+        let app = setup_app_data_dir(&[]);
+        let profile = write_tmp_profile("missing", &[("input", "midi"), ("output", "midi")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
         let result = super::dispatch(&cli);
-
         assert!(
             result.is_ok(),
-            "missing events.yaml should be a warning, not a startup failure: {result:?}"
+            "missing events.yaml should be a warning: {result:?}"
         );
     }
 
     #[test]
     fn it_should_fail_startup_when_driver_declares_streamed_tier() {
-        let profile = write_tmp_profile("streamed");
-        let events = write_tmp_events_yaml("streamed", EVENTS_YAML_STREAMED_OSCBLOB);
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            &format!("osc={}", events.path().display()),
-        ])
-        .expect("parse");
-
+        let app = setup_app_data_dir(&[("osc", EVENTS_YAML_STREAMED_OSCBLOB)]);
+        let profile = write_tmp_profile("streamed", &[("input", "osc"), ("output", "osc")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
         let err = super::dispatch(&cli).expect_err("streamed must be rejected at startup");
         assert!(
             matches!(
@@ -393,148 +389,10 @@ mod tests {
     }
 
     #[test]
-    fn it_should_reject_malformed_driver_events_argument() {
-        let profile = write_tmp_profile("malformed");
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            "no-equals-sign",
-        ])
-        .expect("parse");
-
-        let err = super::dispatch(&cli).expect_err("malformed arg must fail");
-        assert!(
-            matches!(err, CliError::InvalidDriverEventsArg { .. }),
-            "expected InvalidDriverEventsArg, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn it_should_reject_driver_events_argument_with_empty_name() {
-        let profile = write_tmp_profile("empty-name");
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            "=/tmp/events.yaml",
-        ])
-        .expect("parse");
-
-        let err = super::dispatch(&cli).expect_err("empty name must fail");
-        assert!(
-            matches!(err, CliError::InvalidDriverEventsArg { .. }),
-            "expected InvalidDriverEventsArg, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn it_should_reject_driver_events_argument_with_empty_path() {
-        let profile = write_tmp_profile("empty-path");
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            "midi=",
-        ])
-        .expect("parse");
-
-        let err = super::dispatch(&cli).expect_err("empty path must fail");
-        assert!(
-            matches!(err, CliError::InvalidDriverEventsArg { .. }),
-            "expected InvalidDriverEventsArg, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn it_should_reject_driver_events_argument_with_whitespace_only_name() {
-        let profile = write_tmp_profile("ws-name");
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            "   =/tmp/events.yaml",
-        ])
-        .expect("parse");
-
-        let err = super::dispatch(&cli).expect_err("whitespace-only name must fail");
-        assert!(
-            matches!(err, CliError::InvalidDriverEventsArg { .. }),
-            "expected InvalidDriverEventsArg, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn it_should_reject_driver_events_argument_with_whitespace_only_path() {
-        let profile = write_tmp_profile("ws-path");
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            "midi=   ",
-        ])
-        .expect("parse");
-
-        let err = super::dispatch(&cli).expect_err("whitespace-only path must fail");
-        assert!(
-            matches!(err, CliError::InvalidDriverEventsArg { .. }),
-            "expected InvalidDriverEventsArg, got {err:?}"
-        );
-    }
-
-    #[test]
-    fn it_should_render_startup_check_error_display_with_driver_and_violation_context() {
-        // schema 違反をわざと作って、Display 文字列に driver 名と違反内容が
-        // 両方含まれることを担保する。trailing newline がないことも検査する。
-        let profile = write_tmp_profile("display");
-        let events = write_tmp_events_yaml("display", EVENTS_YAML_INVALID_RANGE);
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            &format!("midi={}", events.path().display()),
-        ])
-        .expect("parse");
-
-        let err = super::dispatch(&cli).expect_err("schema violation");
-        let rendered = err.to_string();
-        assert!(
-            rendered.contains("midi"),
-            "Display should mention the driver name, got: {rendered}"
-        );
-        assert!(
-            rendered.contains("schema 違反"),
-            "Display should mention the violation kind, got: {rendered}"
-        );
-        assert!(
-            !rendered.ends_with('\n'),
-            "Display must not end with a trailing newline, got: {rendered:?}"
-        );
-    }
-
-    #[test]
     fn it_should_fail_startup_when_driver_events_yaml_cannot_be_loaded() {
-        // YAML 構文エラーは loader 段階で検出され、StartupCheckError::Load が
-        // CliError::StartupCheck に包まれて返る。3 variant のうち Validate /
-        // FeatureUnavailable は別テストで担保しているので、Load 分岐の回帰
-        // 経路を本テストで埋める。
-        let profile = write_tmp_profile("load-error");
-        let events = write_tmp_events_yaml("load-error", EVENTS_YAML_MALFORMED);
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            &format!("midi={}", events.path().display()),
-        ])
-        .expect("parse");
-
+        let app = setup_app_data_dir(&[("midi", EVENTS_YAML_MALFORMED)]);
+        let profile = write_tmp_profile("load-error", &[("input", "midi"), ("output", "midi")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
         let err = super::dispatch(&cli).expect_err("malformed YAML must fail");
         assert!(
             matches!(
@@ -548,24 +406,14 @@ mod tests {
     }
 
     #[test]
-    fn it_should_iterate_through_multiple_driver_events_and_fail_on_the_violating_entry() {
-        // 1 件目は通過、2 件目で schema 違反 → fail。複数 `--driver-events`
-        // を全件走査し、後続エントリの違反でも CliError::StartupCheck が
-        // 返ることを担保する。
-        let profile = write_tmp_profile("multi-fail");
-        let valid = write_tmp_events_yaml("multi-fail-ok", EVENTS_YAML_VALID_NOTEON);
-        let invalid = write_tmp_events_yaml("multi-fail-bad", EVENTS_YAML_INVALID_RANGE);
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            &format!("ok={}", valid.path().display()),
-            "--driver-events",
-            &format!("bad={}", invalid.path().display()),
-        ])
-        .expect("parse");
-
+    fn it_should_iterate_through_input_and_output_drivers_and_fail_on_violating_one() {
+        // 1 件目 (input=midi) は valid、2 件目 (output=osc) で schema 違反
+        let app = setup_app_data_dir(&[
+            ("midi", EVENTS_YAML_VALID_NOTEON),
+            ("osc", EVENTS_YAML_INVALID_RANGE),
+        ]);
+        let profile = write_tmp_profile("multi-fail", &[("input", "midi"), ("output", "osc")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
         let err = super::dispatch(&cli).expect_err("second entry violates schema");
         assert!(
             matches!(
@@ -579,22 +427,11 @@ mod tests {
     }
 
     #[test]
-    fn it_should_continue_through_missing_entry_when_other_driver_events_are_valid() {
-        // Missing entry を挟んでも warning + 継続し、後続の正常 entry まで
-        // 全件走査することを担保する。
-        let profile = write_tmp_profile("multi-mixed");
-        let valid = write_tmp_events_yaml("multi-mixed-ok", EVENTS_YAML_VALID_NOTEON);
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            "absent=/nonexistent/midori-mew54-multi/events.yaml",
-            "--driver-events",
-            &format!("ok={}", valid.path().display()),
-        ])
-        .expect("parse");
-
+    fn it_should_continue_through_missing_driver_when_others_are_valid() {
+        // input は events.yaml 配置済、output は Missing
+        let app = setup_app_data_dir(&[("midi", EVENTS_YAML_VALID_NOTEON)]);
+        let profile = write_tmp_profile("multi-mixed", &[("input", "midi"), ("output", "absent")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
         let result = super::dispatch(&cli);
         assert!(
             result.is_ok(),
@@ -603,52 +440,55 @@ mod tests {
     }
 
     #[test]
-    fn it_should_reject_malformed_driver_events_argument_before_reading_profile() {
-        // profile path が存在しない + arg が不正なケース。引数検証が profile
-        // I/O より先に走るので、root cause の InvalidDriverEventsArg が返り
-        // ReadProfile でマスクされないことを担保する。
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            "/nonexistent/midori-mew54/profile.yaml",
-            "--driver-events",
-            "no-equals-sign",
-        ])
-        .expect("parse");
+    fn it_should_dedupe_drivers_appearing_in_both_input_and_output() {
+        // 同一 driver が input と output 双方に出現するケース。events.yaml は
+        // 1 度だけ load される（dedupe）想定で、無効な 2 度目 load が走らない
+        // ことは少なくとも「正常通過」で観測できる。
+        let app = setup_app_data_dir(&[("midi", EVENTS_YAML_VALID_NOTEON)]);
+        let profile = write_tmp_profile("dedupe", &[("input", "midi"), ("output", "midi")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
+        let result = super::dispatch(&cli);
+        assert!(result.is_ok(), "dedupe path: {result:?}");
+    }
 
-        let err = super::dispatch(&cli).expect_err("arg validation must fail first");
-        assert!(
-            matches!(err, CliError::InvalidDriverEventsArg { .. }),
-            "expected InvalidDriverEventsArg (arg validated before profile I/O), got {err:?}"
-        );
+    #[test]
+    fn it_should_fail_when_profile_yaml_is_invalid() {
+        // 必須フィールド (transform) を欠いた profile YAML
+        let app = setup_app_data_dir(&[]);
+        let mut bad = tempfile::Builder::new()
+            .prefix("midori-mew55-bad-")
+            .suffix(".yaml")
+            .tempfile()
+            .expect("tempfile");
+        let yaml = "inputs:\n  - adapter: a.yaml\n    connection: { driver: midi }\noutputs:\n  - adapter: b.yaml\n    connection: { driver: osc }\n";
+        std::io::Write::write_all(&mut bad, yaml.as_bytes()).expect("write");
+
+        let cli = Cli::try_parse_from(run_args(bad.path(), app.path())).expect("parse");
+        let err = super::dispatch(&cli).expect_err("missing transform");
+        assert!(matches!(err, CliError::LoadProfile { .. }));
+    }
+
+    #[test]
+    fn it_should_render_startup_check_error_display_with_driver_and_violation_context() {
+        let app = setup_app_data_dir(&[("midi", EVENTS_YAML_INVALID_RANGE)]);
+        let profile = write_tmp_profile("display", &[("input", "midi"), ("output", "midi")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
+        let err = super::dispatch(&cli).expect_err("schema violation");
+        let rendered = err.to_string();
+        assert!(rendered.contains("midi"), "got: {rendered}");
+        assert!(rendered.contains("schema 違反"), "got: {rendered}");
+        assert!(!rendered.ends_with('\n'), "got: {rendered:?}");
     }
 
     #[test]
     fn it_should_render_startup_check_error_display_with_streamed_feature_reason() {
-        let profile = write_tmp_profile("display-streamed");
-        let events = write_tmp_events_yaml("display-streamed", EVENTS_YAML_STREAMED_OSCBLOB);
-        let cli = Cli::try_parse_from([
-            "midori",
-            "run",
-            profile.path().to_str().expect("profile utf-8"),
-            "--driver-events",
-            &format!("osc={}", events.path().display()),
-        ])
-        .expect("parse");
-
+        let app = setup_app_data_dir(&[("osc", EVENTS_YAML_STREAMED_OSCBLOB)]);
+        let profile = write_tmp_profile("display-streamed", &[("input", "osc"), ("output", "osc")]);
+        let cli = Cli::try_parse_from(run_args(profile.path(), app.path())).expect("parse");
         let err = super::dispatch(&cli).expect_err("streamed");
         let rendered = err.to_string();
-        assert!(
-            rendered.contains("osc"),
-            "Display should mention the driver name, got: {rendered}"
-        );
-        assert!(
-            rendered.contains("streamed"),
-            "Display should mention the unsupported feature, got: {rendered}"
-        );
-        assert!(
-            !rendered.ends_with('\n'),
-            "Display must not end with a trailing newline, got: {rendered:?}"
-        );
+        assert!(rendered.contains("osc"), "got: {rendered}");
+        assert!(rendered.contains("streamed"), "got: {rendered}");
+        assert!(!rendered.ends_with('\n'), "got: {rendered:?}");
     }
 }

--- a/crates/midori-runtime/src/profile.rs
+++ b/crates/midori-runtime/src/profile.rs
@@ -1,0 +1,296 @@
+//! profile YAML loader and driver-name resolver for Bridge startup.
+//!
+//! `midori run <profile>` で渡されるプロファイル YAML をパースし、
+//! `inputs[]` / `outputs[]` の `connection.driver` から起動対象の driver 名
+//! を抽出する。各 driver の `events.yaml` path 解決は本 module の責務外で、
+//! caller（main）が `<app-data-dir>/plugins/driver-<name>/events.yaml` の
+//! 規約で組み立てる。
+//!
+//! 対象スキーマは `design/config/05-profile.md` 確定版に従う。adapter YAML /
+//! transform YAML の本格パースは別 subtask の責務で、本 module ではそれぞれ
+//! `PathBuf` として保持するに留める。
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// `profiles/*.yaml` の最上位構造。
+///
+/// `name` / `description` は GUI 表示用で起動経路では参照しないが、parser
+/// の網羅性を担保するため受理する。`adapter` / `transform` の path は
+/// 本 module ではロードしない（後続 subtask の責務）。
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileYaml {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub inputs: Vec<ProfileEndpoint>,
+    pub transform: PathBuf,
+    pub outputs: Vec<ProfileEndpoint>,
+}
+
+/// `inputs[]` / `outputs[]` の各エントリ。input/output は同一スキーマで
+/// `direction` フィールドを持たない（spec 準拠）。
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileEndpoint {
+    /// 変換グラフから参照する識別子。省略時はアダプターファイルのベース名。
+    /// 起動時 events.yaml チェックでは未使用。
+    #[serde(default)]
+    pub id: Option<String>,
+    /// アダプター YAML への path。本 module ではロードしない。
+    pub adapter: PathBuf,
+    /// 実デバイスとの接続設定。`driver` キーが必須で、その他は driver 固有。
+    pub connection: ProfileConnection,
+}
+
+/// `connection` セクション。`driver` 以外のフィールドは driver 固有で、
+/// 本 module では解釈せず生 YAML 値として保持する。adapter 側で各 driver
+/// の `connection_fields` 宣言と照合する経路は別 subtask。
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct ProfileConnection {
+    /// driver 識別子（`driver.yaml` の `name` フィールドと一致する想定）。
+    pub driver: String,
+    /// driver 固有の追加フィールド（`device_name` / `host` / `port` 等）。
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yml::Value>,
+}
+
+/// profile YAML のロード失敗。
+#[derive(Debug)]
+pub enum ProfileLoadError {
+    /// I/O 失敗。
+    Io {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    /// YAML パース / deserialize 失敗。
+    Parse {
+        path: PathBuf,
+        source: serde_yml::Error,
+    },
+    /// パースは通ったが意味論的に invalid（inputs / outputs が空など）。
+    Invalid { path: PathBuf, message: String },
+}
+
+impl std::fmt::Display for ProfileLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io { path, source } => write!(
+                f,
+                "プロファイルの読み込みに失敗しました ({}): {source}",
+                path.display()
+            ),
+            Self::Parse { path, source } => write!(
+                f,
+                "プロファイルの YAML パースに失敗しました ({}): {source}",
+                path.display()
+            ),
+            Self::Invalid { path, message } => {
+                write!(f, "プロファイル ({}) が不正です: {message}", path.display())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ProfileLoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io { source, .. } => Some(source),
+            Self::Parse { source, .. } => Some(source),
+            Self::Invalid { .. } => None,
+        }
+    }
+}
+
+/// `path` の profile YAML を読み込み、最低限の意味論検証まで通したものを返す。
+///
+/// # Errors
+///
+/// I/O 失敗 / YAML パース失敗 / `inputs` または `outputs` が空、のいずれかで
+/// 対応する [`ProfileLoadError`] を返す。
+pub fn load_from_path(path: &Path) -> Result<ProfileYaml, ProfileLoadError> {
+    let yaml = fs::read_to_string(path).map_err(|source| ProfileLoadError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let profile: ProfileYaml =
+        serde_yml::from_str(&yaml).map_err(|source| ProfileLoadError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if profile.inputs.is_empty() {
+        return Err(ProfileLoadError::Invalid {
+            path: path.to_path_buf(),
+            message: "inputs が空です（最低 1 件必要）".to_owned(),
+        });
+    }
+    if profile.outputs.is_empty() {
+        return Err(ProfileLoadError::Invalid {
+            path: path.to_path_buf(),
+            message: "outputs が空です（最低 1 件必要）".to_owned(),
+        });
+    }
+    Ok(profile)
+}
+
+/// profile から driver 名のリストを抽出する。重複（input/output で同じ
+/// driver が出る、あるいは複数 endpoint が同じ driver を使う）は最初の
+/// 出現順を維持しつつ dedupe する。
+#[must_use]
+pub fn collect_driver_names(profile: &ProfileYaml) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut out = Vec::new();
+    for endpoint in profile.inputs.iter().chain(profile.outputs.iter()) {
+        let name = endpoint.connection.driver.as_str();
+        if seen.insert(name.to_owned()) {
+            out.push(name.to_owned());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(yaml: &str) -> Result<ProfileYaml, ProfileLoadError> {
+        // 直接 from_str を呼ばず、load_from_path 経由の分岐も含めて検査する
+        // ため tempfile を経由する。
+        let mut file = tempfile::Builder::new()
+            .prefix("midori-mew55-profile-")
+            .suffix(".yaml")
+            .tempfile()
+            .expect("tempfile");
+        std::io::Write::write_all(&mut file, yaml.as_bytes()).expect("write");
+        load_from_path(file.path())
+    }
+
+    const VALID_MIN: &str = r#"
+inputs:
+  - adapter: adapters/midi.yaml
+    connection:
+      driver: midi
+      device_name: "ELS-03 Series"
+transform: mappers/example.yaml
+outputs:
+  - adapter: adapters/osc.yaml
+    connection:
+      driver: osc
+      host: 127.0.0.1
+      port: 9000
+"#;
+
+    #[test]
+    fn it_should_parse_minimal_valid_profile() {
+        let profile = parse(VALID_MIN).expect("valid");
+        assert_eq!(profile.inputs.len(), 1);
+        assert_eq!(profile.outputs.len(), 1);
+        assert_eq!(profile.inputs[0].connection.driver, "midi");
+        assert_eq!(profile.outputs[0].connection.driver, "osc");
+        assert_eq!(profile.transform, PathBuf::from("mappers/example.yaml"));
+    }
+
+    #[test]
+    fn it_should_collect_driver_names_in_first_seen_order_and_dedupe() {
+        let yaml = r"
+inputs:
+  - adapter: a.yaml
+    connection: { driver: midi }
+  - adapter: b.yaml
+    connection: { driver: midi }
+transform: t.yaml
+outputs:
+  - adapter: c.yaml
+    connection: { driver: osc }
+  - adapter: d.yaml
+    connection: { driver: midi }
+";
+        let profile = parse(yaml).expect("valid");
+        let names = collect_driver_names(&profile);
+        assert_eq!(names, vec!["midi".to_owned(), "osc".to_owned()]);
+    }
+
+    #[test]
+    fn it_should_reject_profile_without_inputs() {
+        let yaml = r"
+inputs: []
+transform: t.yaml
+outputs:
+  - adapter: a.yaml
+    connection: { driver: osc }
+";
+        let err = parse(yaml).expect_err("inputs empty");
+        assert!(matches!(err, ProfileLoadError::Invalid { .. }));
+    }
+
+    #[test]
+    fn it_should_reject_profile_without_outputs() {
+        let yaml = r"
+inputs:
+  - adapter: a.yaml
+    connection: { driver: midi }
+transform: t.yaml
+outputs: []
+";
+        let err = parse(yaml).expect_err("outputs empty");
+        assert!(matches!(err, ProfileLoadError::Invalid { .. }));
+    }
+
+    #[test]
+    fn it_should_reject_unknown_top_level_field() {
+        let yaml = r"
+inputs:
+  - adapter: a.yaml
+    connection: { driver: midi }
+transform: t.yaml
+outputs:
+  - adapter: b.yaml
+    connection: { driver: osc }
+unknown_top: 42
+";
+        let err = parse(yaml).expect_err("unknown field");
+        assert!(matches!(err, ProfileLoadError::Parse { .. }));
+    }
+
+    #[test]
+    fn it_should_reject_endpoint_without_driver() {
+        let yaml = r#"
+inputs:
+  - adapter: a.yaml
+    connection:
+      device_name: "X"
+transform: t.yaml
+outputs:
+  - adapter: b.yaml
+    connection: { driver: osc }
+"#;
+        let err = parse(yaml).expect_err("missing driver");
+        assert!(matches!(err, ProfileLoadError::Parse { .. }));
+    }
+
+    #[test]
+    fn it_should_preserve_extra_connection_fields() {
+        let profile = parse(VALID_MIN).expect("valid");
+        let osc = &profile.outputs[0].connection;
+        assert_eq!(
+            osc.extra.get("host"),
+            Some(&serde_yml::Value::String("127.0.0.1".into()))
+        );
+        assert_eq!(
+            osc.extra.get("port"),
+            Some(&serde_yml::Value::Number(9000.into()))
+        );
+    }
+
+    #[test]
+    fn it_should_fail_when_profile_file_is_missing() {
+        let err = load_from_path(Path::new("/nonexistent/midori-mew55/profile.yaml"))
+            .expect_err("missing");
+        assert!(matches!(err, ProfileLoadError::Io { .. }));
+    }
+}

--- a/crates/midori-runtime/src/profile.rs
+++ b/crates/midori-runtime/src/profile.rs
@@ -148,7 +148,9 @@ pub fn load_from_path(path: &Path) -> Result<ProfileYaml, ProfileLoadError> {
 /// driver 名は `<app-data-dir>/plugins/driver-<name>/events.yaml` の path 構築
 /// にそのまま使うため、path-traversal 攻撃（`../../etc/passwd` 等）や空白のみ
 /// の値、path セパレータ含みなど、想定外の文字列を受け入れると plugins
-/// ディレクトリ外を読み取ってしまう。安全側でホワイトリスト的に検査する。
+/// ディレクトリ外を読み取ってしまう。Windows reserved characters / device
+/// names もクロスプラットフォーム対応として全プラットフォームで一律 reject
+/// する（POSIX 環境で書かれた profile が Windows でも安全に読めることを担保）。
 fn validate_driver_name(name: &str, profile_path: &Path) -> Result<(), ProfileLoadError> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
@@ -163,9 +165,15 @@ fn validate_driver_name(name: &str, profile_path: &Path) -> Result<(), ProfileLo
             message: format!("connection.driver の前後に空白が含まれています: `{name}`"),
         });
     }
-    let invalid_char = name
-        .chars()
-        .find(|c| matches!(c, '/' | '\\' | '\0') || c.is_control() || c.is_whitespace());
+    // POSIX 系で危険な文字（path separator / 制御文字 / 空白）+ Windows で
+    // ファイル名に使えない文字（`< > : " | ? *`）を一括で弾く。
+    let invalid_char = name.chars().find(|c| {
+        matches!(
+            c,
+            '/' | '\\' | '\0' | ':' | '*' | '?' | '"' | '<' | '>' | '|'
+        ) || c.is_control()
+            || c.is_whitespace()
+    });
     if let Some(c) = invalid_char {
         return Err(ProfileLoadError::Invalid {
             path: profile_path.to_path_buf(),
@@ -180,7 +188,44 @@ fn validate_driver_name(name: &str, profile_path: &Path) -> Result<(), ProfileLo
             ),
         });
     }
+    // Windows のファイル名末尾 `.` / ` ` は OS が無視するため、`midi.` /
+    // `midi ` は実質 `midi` と同名のディレクトリを指す。あらかじめ拒否する。
+    if name.ends_with('.') || name.ends_with(' ') {
+        return Err(ProfileLoadError::Invalid {
+            path: profile_path.to_path_buf(),
+            message: format!(
+                "connection.driver の末尾に `.` または空白を含めることはできません: `{name}`"
+            ),
+        });
+    }
+    // Windows の予約デバイス名（拡張子の有無にかかわらず予約）。実際には
+    // `driver-<name>/` と prefix が付くため Windows 上で衝突する可能性は低い
+    // が、defense in depth として一律拒否する。
+    if is_windows_reserved_device_name(name) {
+        return Err(ProfileLoadError::Invalid {
+            path: profile_path.to_path_buf(),
+            message: format!("connection.driver に Windows 予約デバイス名は使えません: `{name}`"),
+        });
+    }
     Ok(())
+}
+
+/// Windows の予約デバイス名（`CON` / `PRN` / `AUX` / `NUL` / `COM1`〜`COM9`
+/// / `LPT1`〜`LPT9`）に該当するかを大文字小文字を問わず判定する。拡張子
+/// （`CON.txt` 等）が付いても予約扱いになるため、拡張子部分を除いた本体
+/// （最初の `.` まで）で照合する。
+fn is_windows_reserved_device_name(name: &str) -> bool {
+    let stem = name.split('.').next().unwrap_or(name);
+    let upper = stem.to_ascii_uppercase();
+    matches!(upper.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || matches!(
+            upper.as_str(),
+            "COM1" | "COM2" | "COM3" | "COM4" | "COM5" | "COM6" | "COM7" | "COM8" | "COM9"
+        )
+        || matches!(
+            upper.as_str(),
+            "LPT1" | "LPT2" | "LPT3" | "LPT4" | "LPT5" | "LPT6" | "LPT7" | "LPT8" | "LPT9"
+        )
 }
 
 /// profile から driver 名のリストを抽出する。重複（input/output で同じ
@@ -366,6 +411,62 @@ outputs:
         let yaml = "inputs:\n  - adapter: a.yaml\n    connection:\n      driver: \"   \"\ntransform: t.yaml\noutputs:\n  - adapter: b.yaml\n    connection: { driver: osc }\n";
         let err = parse(yaml).expect_err("whitespace driver");
         assert!(matches!(err, ProfileLoadError::Invalid { .. }));
+    }
+
+    #[test]
+    fn it_should_reject_driver_name_with_windows_reserved_characters() {
+        // Windows のファイル名で許容されない文字を含む driver 名を一律 reject。
+        // `"` は YAML 文字列終端と衝突するため serde-yml 側で `Parse` エラーに
+        // なるが、いずれにしても driver 名としては受理されないため両 variant
+        // を許容する。
+        for bad in [
+            "midi:foo", "midi*x", "midi?", "midi\"q", "midi<", "midi>", "midi|x",
+        ] {
+            let yaml = format!(
+                "inputs:\n  - adapter: a.yaml\n    connection:\n      driver: \"{bad}\"\ntransform: t.yaml\noutputs:\n  - adapter: b.yaml\n    connection: {{ driver: osc }}\n"
+            );
+            let outcome = parse(&yaml);
+            assert!(
+                matches!(
+                    outcome,
+                    Err(ProfileLoadError::Invalid { .. } | ProfileLoadError::Parse { .. })
+                ),
+                "driver `{bad}` should be rejected (Windows reserved char), got {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn it_should_reject_driver_name_ending_with_dot_or_space() {
+        // Windows は末尾の `.` / 空白を無視するため、`midi.` と `midi` が同一
+        // ディレクトリを指してしまう。一律拒否する。
+        for bad in ["midi.", "midi "] {
+            let yaml = format!(
+                "inputs:\n  - adapter: a.yaml\n    connection:\n      driver: \"{bad}\"\ntransform: t.yaml\noutputs:\n  - adapter: b.yaml\n    connection: {{ driver: osc }}\n"
+            );
+            let outcome = parse(&yaml);
+            assert!(
+                matches!(outcome, Err(ProfileLoadError::Invalid { .. })),
+                "driver `{bad}` should be rejected (trailing dot/space), got {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn it_should_reject_driver_name_matching_windows_reserved_device_name() {
+        // 大文字小文字を問わず Windows 予約デバイス名を拒否する。
+        for bad in [
+            "con", "CON", "PRN", "Aux", "nul", "COM1", "lpt9", "CON.txt", "com5.log",
+        ] {
+            let yaml = format!(
+                "inputs:\n  - adapter: a.yaml\n    connection:\n      driver: \"{bad}\"\ntransform: t.yaml\noutputs:\n  - adapter: b.yaml\n    connection: {{ driver: osc }}\n"
+            );
+            let outcome = parse(&yaml);
+            assert!(
+                matches!(outcome, Err(ProfileLoadError::Invalid { .. })),
+                "driver `{bad}` should be rejected (Windows reserved device name), got {outcome:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/midori-runtime/src/profile.rs
+++ b/crates/midori-runtime/src/profile.rs
@@ -38,8 +38,10 @@ pub struct ProfileYaml {
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct ProfileEndpoint {
-    /// 変換グラフから参照する識別子。省略時はアダプターファイルのベース名。
-    /// 起動時 events.yaml チェックでは未使用。
+    /// 変換グラフから参照する識別子。省略可（spec では「省略時はアダプター
+    /// ファイルのベース名から自動生成」とされるが、その自動生成は別 module
+    /// （変換グラフ resolver）の責務で本 module は YAML 上の値だけを保持
+    /// する）。起動時 events.yaml チェックでは未使用。
     #[serde(default)]
     pub id: Option<String>,
     /// アダプター YAML への path。本 module ではロードしない。
@@ -135,7 +137,50 @@ pub fn load_from_path(path: &Path) -> Result<ProfileYaml, ProfileLoadError> {
             message: "outputs が空です（最低 1 件必要）".to_owned(),
         });
     }
+    for endpoint in profile.inputs.iter().chain(profile.outputs.iter()) {
+        validate_driver_name(&endpoint.connection.driver, path)?;
+    }
     Ok(profile)
+}
+
+/// driver 名がファイルシステム経路として安全な識別子であることを検証する。
+///
+/// driver 名は `<app-data-dir>/plugins/driver-<name>/events.yaml` の path 構築
+/// にそのまま使うため、path-traversal 攻撃（`../../etc/passwd` 等）や空白のみ
+/// の値、path セパレータ含みなど、想定外の文字列を受け入れると plugins
+/// ディレクトリ外を読み取ってしまう。安全側でホワイトリスト的に検査する。
+fn validate_driver_name(name: &str, profile_path: &Path) -> Result<(), ProfileLoadError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(ProfileLoadError::Invalid {
+            path: profile_path.to_path_buf(),
+            message: format!("connection.driver が空白のみの値です: `{name}`"),
+        });
+    }
+    if trimmed != name {
+        return Err(ProfileLoadError::Invalid {
+            path: profile_path.to_path_buf(),
+            message: format!("connection.driver の前後に空白が含まれています: `{name}`"),
+        });
+    }
+    let invalid_char = name
+        .chars()
+        .find(|c| matches!(c, '/' | '\\' | '\0') || c.is_control() || c.is_whitespace());
+    if let Some(c) = invalid_char {
+        return Err(ProfileLoadError::Invalid {
+            path: profile_path.to_path_buf(),
+            message: format!("connection.driver に許容外の文字 `{c:?}` が含まれています: `{name}`"),
+        });
+    }
+    if name == "." || name == ".." || name.contains("..") {
+        return Err(ProfileLoadError::Invalid {
+            path: profile_path.to_path_buf(),
+            message: format!(
+                "connection.driver に path traversal 文字列を含めることはできません: `{name}`"
+            ),
+        });
+    }
+    Ok(())
 }
 
 /// profile から driver 名のリストを抽出する。重複（input/output で同じ
@@ -162,7 +207,7 @@ mod tests {
         // 直接 from_str を呼ばず、load_from_path 経由の分岐も含めて検査する
         // ため tempfile を経由する。
         let mut file = tempfile::Builder::new()
-            .prefix("midori-mew55-profile-")
+            .prefix("midori-profile-test-")
             .suffix(".yaml")
             .tempfile()
             .expect("tempfile");
@@ -289,8 +334,64 @@ outputs:
 
     #[test]
     fn it_should_fail_when_profile_file_is_missing() {
-        let err = load_from_path(Path::new("/nonexistent/midori-mew55/profile.yaml"))
+        let err = load_from_path(Path::new("/nonexistent/midori-profile-test/profile.yaml"))
             .expect_err("missing");
         assert!(matches!(err, ProfileLoadError::Io { .. }));
+    }
+
+    #[test]
+    fn it_should_reject_driver_name_with_path_traversal() {
+        // `connection.driver` から `<app-data-dir>/plugins/driver-<name>/`
+        // の path を作るため、`..` / path separator が入った driver 名は
+        // plugins ディレクトリを脱出させ得る。`validate_driver_name` が
+        // `ProfileLoadError::Invalid` として弾くことを担保する。
+        // （null byte / 制御文字は serde-yml 側で `Parse` 段階で拒否される
+        // ため本テストの対象外。validate_driver_name の defensive check は
+        // serde-yml が将来仕様変更しても破綻しないための二段防御として
+        // 残してある。）
+        for bad in ["../etc/passwd", "midi/../../foo", "a/b", "a\\b", "..", "."] {
+            let yaml = format!(
+                "inputs:\n  - adapter: a.yaml\n    connection:\n      driver: \"{bad}\"\ntransform: t.yaml\noutputs:\n  - adapter: b.yaml\n    connection: {{ driver: osc }}\n"
+            );
+            let outcome = parse(&yaml);
+            assert!(
+                matches!(outcome, Err(ProfileLoadError::Invalid { .. })),
+                "driver `{bad}` should be rejected by validate_driver_name as Invalid, got {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn it_should_reject_whitespace_only_driver_name() {
+        let yaml = "inputs:\n  - adapter: a.yaml\n    connection:\n      driver: \"   \"\ntransform: t.yaml\noutputs:\n  - adapter: b.yaml\n    connection: { driver: osc }\n";
+        let err = parse(yaml).expect_err("whitespace driver");
+        assert!(matches!(err, ProfileLoadError::Invalid { .. }));
+    }
+
+    #[test]
+    fn it_should_reject_driver_name_with_surrounding_whitespace() {
+        let yaml = "inputs:\n  - adapter: a.yaml\n    connection:\n      driver: \"  midi  \"\ntransform: t.yaml\noutputs:\n  - adapter: b.yaml\n    connection: { driver: osc }\n";
+        let err = parse(yaml).expect_err("padded driver");
+        assert!(matches!(err, ProfileLoadError::Invalid { .. }));
+    }
+
+    #[test]
+    fn it_should_render_profile_load_error_display_with_path_and_context() {
+        // Invalid 経路（inputs 空）で Display に path と理由を含むことを担保。
+        let yaml = "inputs: []\ntransform: t.yaml\noutputs:\n  - adapter: a.yaml\n    connection: { driver: osc }\n";
+        let err = parse(yaml).expect_err("invalid");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("inputs が空"),
+            "Display should mention violation reason, got: {rendered}"
+        );
+        // Io 経路（profile が存在しない）でも path を含むことを担保。
+        let io_err = load_from_path(Path::new("/nonexistent/midori-profile-test/profile.yaml"))
+            .expect_err("io");
+        let io_rendered = io_err.to_string();
+        assert!(
+            io_rendered.contains("/nonexistent/"),
+            "Io display should mention path, got: {io_rendered}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `midori run <profile>` の profile YAML を Rust 型としてパースし、`inputs[]` / `outputs[]` の `connection.driver` から起動対象 driver を抽出。各 driver について `<app-data-dir>/plugins/driver-<name>/events.yaml` を解決して既存 `check_driver_schema` を呼ぶ本物経路に切り替えた。
- MEW-54 で導入した暫定 hidden flag `--driver-events` を撤去。
- plugin.yaml / driver.yaml の本格 resolver / driver process spawn / 実 SPSC ingest は別 subtask（後続）。

## 主な変更

- `crates/midori-runtime/src/profile.rs`（新規）— `ProfileYaml` / `ProfileEndpoint` / `ProfileConnection` 型 + serde_yml パーサ + 意味論検証。`collect_driver_names` で input/output の driver を最初の出現順で dedupe。`ProfileLoadError { Io, Parse, Invalid }`。
- `crates/midori-runtime/src/main.rs` — `--driver-events` 撤去、profile YAML 経路化。`<app-data-dir>/plugins/driver-<name>/events.yaml` の固定規約で events.yaml path を resolve。`--app-data-dir` 省略時は `dirs::data_dir()` から OS 標準ディレクトリ解決。
- `crates/midori-runtime/src/error.rs` — `CliError` を `LoadProfile` / `AppDataDirUnavailable` / `StartupCheck` に再構成。
- `crates/midori-runtime/Cargo.toml` — `dirs = "5"` 追加。

## AC マッピング

- [x] profile YAML を Rust 型としてパース（`ProfileYaml { name, description, inputs, transform, outputs }`）
- [x] パース失敗 / `inputs` / `outputs` 空 / unknown field を `CliError::LoadProfile` で起動失敗
- [x] `connection.driver` から driver 名抽出 + dedupe（最初の出現順）
- [x] events.yaml path を `<app-data-dir>/plugins/driver-<name>/events.yaml` で resolve
- [x] `--app-data-dir` override 対応、省略時は OS 標準（macOS / Windows / Linux）
- [x] Missing は warning + 継続、それ以外は `CliError::StartupCheck` で起動失敗
- [x] `--driver-events` hidden flag 撤去
- [x] 統合テスト: 正常 / schema 違反 / Missing / streamed / Load 失敗 / multi-driver / dedupe / profile invalid / Display

## Out of Scope

- plugin.yaml / driver.yaml の本格 resolver（後続 subtask）
- driver process spawn / control channel wire format
- 実 SPSC ring 経由の event ingest
- adapter YAML / transform YAML パース

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`（profile 8 件 + main 17 件 + 既存、合計 177 件通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プロファイルYAMLから自動でドライバーを検出し、各プラグインのevents.yamlをアプリデータ領域で組み立て・検証するようになりました。
* **改善**
  * プロファイル読み込み時の構文・意味検証を強化し、無効なドライバー名や重複を検出・報告します。
  * エラーメッセージを明確化し、プロファイル読み込み失敗やアプリデータ未解決時に適切に通知します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->