### PR TITLE
test(sdk): C smoke test linking staticlib via cbindgen header (MEW-39)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,16 +89,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,12 +182,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -369,7 +353,6 @@ name = "midori-sdk"
 version = "0.2.0"
 dependencies = [
  "cbindgen",
- "cc",
  "midori-core",
  "serde",
  "serde_json",
@@ -557,12 +540,6 @@ dependencies = [
  "serde",
  "version_check",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +192,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -353,6 +369,7 @@ name = "midori-sdk"
 version = "0.2.0"
 dependencies = [
  "cbindgen",
+ "cc",
  "midori-core",
  "serde",
  "serde_json",
@@ -540,6 +557,12 @@ dependencies = [
  "serde",
  "version_check",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"

--- a/crates/midori-sdk/Cargo.toml
+++ b/crates/midori-sdk/Cargo.toml
@@ -11,6 +11,12 @@ readme = "README.md"
 keywords = ["midi", "osc", "ipc", "driver", "sdk"]
 categories = ["api-bindings", "external-ffi-bindings", "development-tools"]
 
+# `staticlib` は C/C++ などの外部ツールチェーンから `lib*.a` (Linux/macOS) /
+# `*.lib` (Windows MSVC) としてリンクするために必要。`rlib` は workspace 内の
+# Rust crate（midori-runtime / midori-driver-* など）が引き続き使う。
+[lib]
+crate-type = ["staticlib", "rlib"]
+
 [dependencies]
 midori-core = { workspace = true }
 serde = { version = "1", features = ["derive"] }
@@ -19,6 +25,9 @@ signal-hook = "0.4"
 
 [build-dependencies]
 cbindgen = { version = "0.29", default-features = false }
+
+[dev-dependencies]
+cc = "1"
 
 # midori-sdk は SPSC リングバッファ実装で UnsafeCell を扱うため、
 # workspace の `unsafe_code = "forbid"` をクレート単位で `deny` に緩める。

--- a/crates/midori-sdk/Cargo.toml
+++ b/crates/midori-sdk/Cargo.toml
@@ -26,9 +26,6 @@ signal-hook = "0.4"
 [build-dependencies]
 cbindgen = { version = "0.29", default-features = false }
 
-[dev-dependencies]
-cc = "1"
-
 # midori-sdk は SPSC リングバッファ実装で UnsafeCell を扱うため、
 # workspace の `unsafe_code = "forbid"` をクレート単位で `deny` に緩める。
 # unsafe を使う箇所には個別に `#[allow(unsafe_code)]` を付け、SAFETY コメントで根拠を示す。

--- a/crates/midori-sdk/build.rs
+++ b/crates/midori-sdk/build.rs
@@ -22,6 +22,14 @@ fn main() {
 
     bindings.write_to_file(&header_path);
 
+    // 生成ヘッダの絶対 path を `MIDORI_SDK_HEADER_PATH` 環境変数として下流に
+    // 公開する。`tests/c_smoke.rs` はこれを `env!("MIDORI_SDK_HEADER_PATH")`
+    // で取り出し、ホスト C コンパイラの `-I` ディレクトリに渡す。
+    println!(
+        "cargo:rustc-env=MIDORI_SDK_HEADER_PATH={}",
+        header_path.display()
+    );
+
     println!("cargo:rerun-if-changed=src/ffi.rs");
     println!("cargo:rerun-if-changed=src/spsc.rs");
     println!("cargo:rerun-if-changed=cbindgen.toml");

--- a/crates/midori-sdk/tests/c_smoke.rs
+++ b/crates/midori-sdk/tests/c_smoke.rs
@@ -1,0 +1,163 @@
+//! C smoke test: hosts a real C compile + link cycle of `tests/c_smoke/
+//! spsc_round_trip.c`, links against `midori-sdk` as a staticlib, and runs
+//! the produced binary. Exit code 0 indicates the FFI round-trip succeeded.
+//!
+//! C コンパイラが見つからなかった場合は warning を出して skip する
+//! （ビルド全体は失敗しない）。Windows MSVC でのリンク検証は本テストの
+//! 対象外で、`*-pc-windows-msvc` ターゲットでは早期 skip する。
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[test]
+fn c_smoke_links_and_round_trips_spsc() {
+    if cfg!(target_env = "msvc") {
+        eprintln!("[c-smoke] SKIP: Windows MSVC target は本テストの対象外（README 参照）");
+        return;
+    }
+
+    let Some(cc) = detect_c_compiler() else {
+        eprintln!(
+            "[c-smoke] SKIP: C コンパイラが見つかりませんでした（CC env / cc / gcc / clang のいずれも未検出）"
+        );
+        return;
+    };
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let c_source = manifest_dir
+        .join("tests")
+        .join("c_smoke")
+        .join("spsc_round_trip.c");
+    assert!(
+        c_source.is_file(),
+        "C source missing: {}",
+        c_source.display()
+    );
+
+    // build.rs から `cargo:rustc-env=MIDORI_SDK_HEADER_PATH=...` で渡される
+    // 生成ヘッダの絶対パス。parent を `-I` ディレクトリに渡す。
+    let header_path = PathBuf::from(env!("MIDORI_SDK_HEADER_PATH"));
+    let header_dir = header_path
+        .parent()
+        .expect("header path has parent")
+        .to_path_buf();
+    assert!(
+        header_path.is_file(),
+        "generated header missing: {}",
+        header_path.display()
+    );
+
+    let staticlib_path = locate_midori_sdk_staticlib();
+    assert!(
+        staticlib_path.is_file(),
+        "midori-sdk staticlib missing: {}",
+        staticlib_path.display()
+    );
+
+    let out_dir = std::env::temp_dir().join("midori-sdk-c-smoke");
+    std::fs::create_dir_all(&out_dir).expect("create out dir");
+    let bin_path = out_dir.join(if cfg!(target_os = "windows") {
+        "spsc_round_trip.exe"
+    } else {
+        "spsc_round_trip"
+    });
+
+    // Linux: staticlib のリンクには pthread / dl / m / system が必要になる
+    // ことがある（Rust std crate の依存）。macOS は libSystem に統合されて
+    // いるため `-framework Security` 相当が要らないケースも多い。最小構成
+    // で gcc/clang に任せ、未解決シンボルが出たら都度追加する方針で書く。
+    let mut cmd = Command::new(&cc);
+    cmd.arg("-O2")
+        .arg("-Wall")
+        .arg(format!("-I{}", header_dir.display()))
+        .arg(&c_source)
+        .arg(&staticlib_path)
+        .arg("-o")
+        .arg(&bin_path);
+    if cfg!(target_os = "linux") {
+        // libstd の依存。GNU ld の順序ルールで staticlib より後ろに置く。
+        cmd.arg("-lpthread").arg("-ldl").arg("-lm");
+    }
+
+    let compile = cmd.output().expect("spawn C compiler");
+    assert!(
+        compile.status.success(),
+        "C compile/link failed (status={:?})\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        compile.status,
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&bin_path)
+        .output()
+        .expect("spawn smoke binary");
+    assert!(
+        run.status.success(),
+        "C smoke binary exited non-zero (status={:?})\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        stdout.contains("[c-smoke] OK"),
+        "expected OK marker, got stdout: {stdout}"
+    );
+}
+
+/// `CC` env / `cc` / `gcc` / `clang` の順で C コンパイラを探す。見つから
+/// なければ `None`（caller が skip する）。
+fn detect_c_compiler() -> Option<PathBuf> {
+    if let Ok(cc) = std::env::var("CC") {
+        if !cc.trim().is_empty() {
+            return Some(PathBuf::from(cc));
+        }
+    }
+    for candidate in ["cc", "gcc", "clang"] {
+        if which_in_path(candidate).is_some() {
+            return Some(PathBuf::from(candidate));
+        }
+    }
+    None
+}
+
+/// 指定コマンドが `PATH` から見つかるかを `which`（POSIX）/ `where`
+/// （Windows）でチェックする。
+fn which_in_path(cmd: &str) -> Option<PathBuf> {
+    let finder = if cfg!(target_os = "windows") {
+        "where"
+    } else {
+        "which"
+    };
+    let output = Command::new(finder).arg(cmd).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8(output.stdout).ok()?;
+    let first = line.lines().next()?.trim();
+    if first.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(first))
+    }
+}
+
+/// `<target>/<profile>/libmidori_sdk.a`（Linux / macOS）を解決する。
+/// 本テストは integration test で実行ファイル自身が
+/// `<target>/<profile>/deps/c_smoke-XXX` に置かれることを利用し、その 2 階層
+/// 上を target profile dir として扱う。`CARGO_TARGET_DIR` が設定されている
+/// 場合も `current_exe()` 経由で正しく解決される。
+fn locate_midori_sdk_staticlib() -> PathBuf {
+    let test_exe = std::env::current_exe().expect("current_exe");
+    // <target>/<profile>/deps/c_smoke-XXX → <target>/<profile>/
+    let profile_dir = test_exe
+        .parent()
+        .and_then(Path::parent)
+        .expect("test exe has grandparent");
+    profile_dir.join(if cfg!(target_os = "windows") {
+        "midori_sdk.lib"
+    } else {
+        "libmidori_sdk.a"
+    })
+}

--- a/crates/midori-sdk/tests/c_smoke.rs
+++ b/crates/midori-sdk/tests/c_smoke.rs
@@ -48,6 +48,13 @@ fn c_smoke_links_and_round_trips_spsc() {
     );
 
     let staticlib_path = locate_midori_sdk_staticlib();
+    // `cargo test` は test binary に必要な rlib しか build しないため、
+    // C 側からリンクする staticlib（`crate-type = ["staticlib"]` の出力物）が
+    // target dir に無い状態で test が走るケースがある（CI のクリーンビルド
+    // 等）。ここで明示的に `cargo build -p midori-sdk --lib` を spawn して
+    // staticlib を生成しておく。cargo は同じ target dir でもプロセス間で
+    // ロックを取るため、test runner と並行実行しても安全。
+    ensure_midori_sdk_staticlib(&staticlib_path);
     assert!(
         staticlib_path.is_file(),
         "midori-sdk staticlib missing: {}",
@@ -156,6 +163,29 @@ fn which_in_path(cmd: &str) -> Option<PathBuf> {
     } else {
         Some(PathBuf::from(first))
     }
+}
+
+/// `staticlib_path` が存在しなければ `cargo build -p midori-sdk --lib` を
+/// 起動して生成する。test profile (debug / release) を `cfg!(debug_assertions)`
+/// から推定し、`--release` 必要時は付加する。
+fn ensure_midori_sdk_staticlib(staticlib_path: &Path) {
+    if staticlib_path.is_file() {
+        return;
+    }
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+    let mut cmd = Command::new(&cargo);
+    cmd.args(["build", "-p", "midori-sdk", "--lib"]);
+    if !cfg!(debug_assertions) {
+        cmd.arg("--release");
+    }
+    let out = cmd.output().expect("spawn cargo build");
+    assert!(
+        out.status.success(),
+        "cargo build -p midori-sdk failed (status={:?})\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
 }
 
 /// `<target>/<profile>/libmidori_sdk.a`（Linux / macOS）を解決する。

--- a/crates/midori-sdk/tests/c_smoke.rs
+++ b/crates/midori-sdk/tests/c_smoke.rs
@@ -188,7 +188,8 @@ fn ensure_midori_sdk_staticlib(staticlib_path: &Path) {
     );
 }
 
-/// `<target>/<profile>/libmidori_sdk.a`（Linux / macOS）を解決する。
+/// `<target>/<profile>/libmidori_sdk.a`（Linux / macOS / Windows GNU）または
+/// `<target>/<profile>/midori_sdk.lib`（Windows MSVC）を解決する。
 /// 本テストは integration test で実行ファイル自身が
 /// `<target>/<profile>/deps/c_smoke-XXX` に置かれることを利用し、その 2 階層
 /// 上を target profile dir として扱う。`CARGO_TARGET_DIR` が設定されている
@@ -200,7 +201,10 @@ fn locate_midori_sdk_staticlib() -> PathBuf {
         .parent()
         .and_then(Path::parent)
         .expect("test exe has grandparent");
-    profile_dir.join(if cfg!(target_os = "windows") {
+    // Windows MSVC のみ `.lib` 形式。Windows GNU (x86_64-pc-windows-gnu) も
+    // `lib*.a` 形式で出力されるため `target_os` 単独ではなく target_env と
+    // の組み合わせで判定する。
+    profile_dir.join(if cfg!(all(target_os = "windows", target_env = "msvc")) {
         "midori_sdk.lib"
     } else {
         "libmidori_sdk.a"

--- a/crates/midori-sdk/tests/c_smoke.rs
+++ b/crates/midori-sdk/tests/c_smoke.rs
@@ -94,7 +94,11 @@ fn c_smoke_links_and_round_trips_spsc() {
         String::from_utf8_lossy(&compile.stderr)
     );
 
+    // C 側にハードコード値を残さず、Rust の `DEFAULT_SLOT_SIZE` を argv で
+    // 渡して silent drift を防ぐ（Rust 側 const が変われば C 側はそれに
+    // 追従、内部 buffer 配列の大きさだけ runtime check で守る）。
     let run = Command::new(&bin_path)
+        .arg(midori_core::shm::DEFAULT_SLOT_SIZE.to_string())
         .output()
         .expect("spawn smoke binary");
     assert!(

--- a/crates/midori-sdk/tests/c_smoke.rs
+++ b/crates/midori-sdk/tests/c_smoke.rs
@@ -16,7 +16,7 @@ fn c_smoke_links_and_round_trips_spsc() {
         return;
     }
 
-    let Some(cc) = detect_c_compiler() else {
+    let Some((cc, cc_args)) = detect_c_compiler() else {
         eprintln!(
             "[c-smoke] SKIP: C コンパイラが見つかりませんでした（CC env / cc / gcc / clang のいずれも未検出）"
         );
@@ -54,7 +54,10 @@ fn c_smoke_links_and_round_trips_spsc() {
         staticlib_path.display()
     );
 
-    let out_dir = std::env::temp_dir().join("midori-sdk-c-smoke");
+    // 同ホスト上で並行実行された `cargo test` が同じ binary 出力を奪い合う
+    // のを防ぐため、process id を含めた専用ディレクトリに出力する（cargo
+    // nextest や retry job 等の並行実行で race が起きないように）。
+    let out_dir = std::env::temp_dir().join(format!("midori-sdk-c-smoke-{}", std::process::id()));
     std::fs::create_dir_all(&out_dir).expect("create out dir");
     let bin_path = out_dir.join(if cfg!(target_os = "windows") {
         "spsc_round_trip.exe"
@@ -67,6 +70,9 @@ fn c_smoke_links_and_round_trips_spsc() {
     // いるため `-framework Security` 相当が要らないケースも多い。最小構成
     // で gcc/clang に任せ、未解決シンボルが出たら都度追加する方針で書く。
     let mut cmd = Command::new(&cc);
+    // `CC=cc -O2` のように env 値が args 込みのケースを尊重するため、
+    // detect_c_compiler が分離した残り token を先頭に積む。
+    cmd.args(&cc_args);
     cmd.arg("-O2")
         .arg("-Wall")
         .arg(format!("-I{}", header_dir.display()))
@@ -108,15 +114,20 @@ fn c_smoke_links_and_round_trips_spsc() {
 
 /// `CC` env / `cc` / `gcc` / `clang` の順で C コンパイラを探す。見つから
 /// なければ `None`（caller が skip する）。
-fn detect_c_compiler() -> Option<PathBuf> {
+///
+/// `CC=cc -O2` のように引数込みで設定されている環境を尊重するため、
+/// 戻り値は `(プログラム path, それ以降の args)` のペア。args は caller が
+/// 自前のフラグより先に積むことで Honor される。
+fn detect_c_compiler() -> Option<(PathBuf, Vec<String>)> {
     if let Ok(cc) = std::env::var("CC") {
-        if !cc.trim().is_empty() {
-            return Some(PathBuf::from(cc));
+        let mut tokens = cc.split_whitespace().map(str::to_owned);
+        if let Some(prog) = tokens.next() {
+            return Some((PathBuf::from(prog), tokens.collect()));
         }
     }
     for candidate in ["cc", "gcc", "clang"] {
         if which_in_path(candidate).is_some() {
-            return Some(PathBuf::from(candidate));
+            return Some((PathBuf::from(candidate), Vec::new()));
         }
     }
     None

--- a/crates/midori-sdk/tests/c_smoke/README.md
+++ b/crates/midori-sdk/tests/c_smoke/README.md
@@ -1,0 +1,38 @@
+# C smoke test for midori-sdk
+
+`midori-sdk` が公開する C ABI（`midori_sdk_spsc_*`）が、外部 C コンパイラ /
+リンカ経由で実際に成立することを確認する smoke test です。`cargo test
+-p midori-sdk` の一部として実行されます。
+
+## 内容
+
+- `spsc_round_trip.c` — `cbindgen` が生成した `midori_sdk.h` を `#include`
+  して、`midori_sdk_spsc_init` / `midori_sdk_spsc_push` /
+  `midori_sdk_spsc_pop` の round-trip を確認する。失敗時は非ゼロで exit。
+- `tests/c_smoke.rs`（リポジトリの 1 つ上）— ホスト C コンパイラを検出して
+  `spsc_round_trip.c` をコンパイル、midori-sdk の staticlib をリンク、
+  生成バイナリを起動して exit code が 0 であることを assert する。
+
+## ローカル実行時の前提
+
+ホストに C コンパイラ（`gcc` / `clang` / 環境変数 `CC` で指定したもの）が
+必要です。Linux / macOS の典型的な開発環境にはデフォルトで利用可能な C
+コンパイラが入っていますが、minimal な container などで未インストールの
+場合は test が **skip** され、ビルド全体は失敗しません（warning のみ）。
+
+```sh
+# Linux: build-essential 同梱の gcc で十分
+sudo apt install build-essential
+
+# macOS: xcrun が利用可能であれば clang が使える
+xcode-select --install
+
+# 任意のコンパイラを指定する場合
+CC=clang cargo test -p midori-sdk
+```
+
+## Out of Scope
+
+- Windows MSVC でのリンク検証（Linux / macOS 上で通れば本 smoke test の範囲）
+- C++ 互換性（`extern "C++"`）
+- CI runner の C コンパイラ環境整備（別 Issue で扱う）

--- a/crates/midori-sdk/tests/c_smoke/spsc_round_trip.c
+++ b/crates/midori-sdk/tests/c_smoke/spsc_round_trip.c
@@ -1,0 +1,95 @@
+/*
+ * midori-sdk SPSC ring buffer C smoke test.
+ *
+ * `midori_sdk.h` を include して midori-sdk の C ABI 経由で
+ *   1. storage 確保 (aligned_alloc + midori_sdk_spsc_init)
+ *   2. push (4 byte payload)
+ *   3. pop  (out_buf に書き戻し / out_len 更新)
+ *   4. 値一致検証
+ *   5. 空状態の pop が 0 を返すこと
+ * を確認する。失敗時は非ゼロで exit する。Rust 側 integration test
+ * (`tests/c_smoke.rs`) が exit code を assert する。
+ */
+
+#include "midori_sdk.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define EXPECT(cond, msg)                                                       \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            fprintf(stderr, "[c-smoke] FAIL: %s (line %d)\n", (msg), __LINE__); \
+            return 1;                                                           \
+        }                                                                       \
+    } while (0)
+
+int main(void) {
+    /* DEFAULT_SLOT_SIZE = 1032 を使う（C 側に const は出力されないため
+     * 数値を直接書く。値は midori-core::shm::DEFAULT_SLOT_SIZE と一致）。 */
+    const uint32_t slot_size = 1032;
+
+    size_t storage_size = midori_sdk_spsc_storage_size(slot_size);
+    EXPECT(storage_size > 0, "storage_size > 0");
+
+    size_t storage_align = midori_sdk_spsc_storage_alignment();
+    EXPECT(storage_align >= 8, "storage_align >= 8");
+    EXPECT((storage_align & (storage_align - 1)) == 0, "alignment is power of two");
+
+    /* aligned_alloc は size が alignment の倍数であることを要求する。 */
+    size_t alloc_size = (storage_size + storage_align - 1) & ~(storage_align - 1);
+    void *storage = aligned_alloc(storage_align, alloc_size);
+    EXPECT(storage != NULL, "aligned_alloc succeeded");
+
+    int32_t init_rc = midori_sdk_spsc_init(storage, slot_size);
+    EXPECT(init_rc == 1, "init returned 1");
+
+    /* 空状態では pop が 0 を返す。 */
+    uint8_t out_buf[1024];
+    size_t out_len = 0;
+    int32_t empty_rc = midori_sdk_spsc_pop(storage, out_buf, sizeof(out_buf), &out_len);
+    EXPECT(empty_rc == 0, "empty pop returns 0");
+
+    /* 4 byte の payload を push → pop して値一致を確認。 */
+    const uint8_t payload[4] = {0xDE, 0xAD, 0xBE, 0xEF};
+    int32_t push_rc = midori_sdk_spsc_push(storage, payload, sizeof(payload));
+    EXPECT(push_rc == 1, "push returned 1");
+
+    int32_t pop_rc = midori_sdk_spsc_pop(storage, out_buf, sizeof(out_buf), &out_len);
+    EXPECT(pop_rc == 1, "pop returned 1");
+    EXPECT(out_len == sizeof(payload), "pop wrote expected length");
+    EXPECT(memcmp(out_buf, payload, sizeof(payload)) == 0, "pop bytes match push bytes");
+
+    /* もう一度 pop すると 0（空）。 */
+    int32_t empty_rc2 = midori_sdk_spsc_pop(storage, out_buf, sizeof(out_buf), &out_len);
+    EXPECT(empty_rc2 == 0, "subsequent pop on empty returns 0");
+
+    /* 最大サイズ payload (slot_size - 8 = 1024 byte) でも round-trip する。 */
+    uint8_t large_payload[1024];
+    for (size_t i = 0; i < sizeof(large_payload); ++i) {
+        large_payload[i] = (uint8_t)(i % 251);
+    }
+    int32_t push_max_rc =
+        midori_sdk_spsc_push(storage, large_payload, sizeof(large_payload));
+    EXPECT(push_max_rc == 1, "push max-size payload returned 1");
+
+    int32_t pop_max_rc =
+        midori_sdk_spsc_pop(storage, out_buf, sizeof(out_buf), &out_len);
+    EXPECT(pop_max_rc == 1, "pop max-size returned 1");
+    EXPECT(out_len == sizeof(large_payload), "max payload length matches");
+    EXPECT(memcmp(out_buf, large_payload, sizeof(large_payload)) == 0,
+           "max payload bytes match");
+
+    /* slot 容量超過の push は -2 を返す（events.yaml 違反 / driver 実装バグ
+     * 相当。本テストでは契約検証のみ）。 */
+    uint8_t too_large[1025];
+    memset(too_large, 0, sizeof(too_large));
+    int32_t over_rc = midori_sdk_spsc_push(storage, too_large, sizeof(too_large));
+    EXPECT(over_rc == -2, "oversize push returns -2");
+
+    free(storage);
+    fprintf(stdout, "[c-smoke] OK\n");
+    return 0;
+}

--- a/crates/midori-sdk/tests/c_smoke/spsc_round_trip.c
+++ b/crates/midori-sdk/tests/c_smoke/spsc_round_trip.c
@@ -26,10 +26,22 @@
         }                                                                       \
     } while (0)
 
-int main(void) {
-    /* DEFAULT_SLOT_SIZE = 1032 を使う（C 側に const は出力されないため
-     * 数値を直接書く。値は midori-core::shm::DEFAULT_SLOT_SIZE と一致）。 */
-    const uint32_t slot_size = 1032;
+int main(int argc, char **argv) {
+    /* slot_size は Rust test harness (`tests/c_smoke.rs`) から argv[1] で
+     * 渡される。harness 側で `midori_core::shm::DEFAULT_SLOT_SIZE` を
+     * 直接 stringify するため、C 側にハードコードを残さず Rust 側 const
+     * との silent drift を防ぐ。argv[1] が無い場合は default 1032 で
+     * 単独実行も可能（手動デバッグ用 fallback）。 */
+    uint32_t slot_size = 1032;
+    if (argc >= 2) {
+        unsigned long parsed = strtoul(argv[1], NULL, 10);
+        EXPECT(parsed > 0 && parsed <= 0x10000UL, "slot_size argv must be in (0, 65536]");
+        slot_size = (uint32_t)parsed;
+    }
+    /* 本テストは max_payload = 1024 byte の固定 buffer に依存している。
+     * Rust 側 default が変わったら C 側も追従する必要があるため、ここで
+     * 不一致を runtime で検出する。 */
+    EXPECT(slot_size == 1032, "this smoke test expects DEFAULT_SLOT_SIZE = 1032");
 
     /* `midori_sdk.h` の signature と一致させるため `uintptr_t` を使う。
      * LP64 環境では size_t と同サイズだが、type-correctness のため厳密に。 */

--- a/crates/midori-sdk/tests/c_smoke/spsc_round_trip.c
+++ b/crates/midori-sdk/tests/c_smoke/spsc_round_trip.c
@@ -31,16 +31,18 @@ int main(void) {
      * 数値を直接書く。値は midori-core::shm::DEFAULT_SLOT_SIZE と一致）。 */
     const uint32_t slot_size = 1032;
 
-    size_t storage_size = midori_sdk_spsc_storage_size(slot_size);
+    /* `midori_sdk.h` の signature と一致させるため `uintptr_t` を使う。
+     * LP64 環境では size_t と同サイズだが、type-correctness のため厳密に。 */
+    uintptr_t storage_size = midori_sdk_spsc_storage_size(slot_size);
     EXPECT(storage_size > 0, "storage_size > 0");
 
-    size_t storage_align = midori_sdk_spsc_storage_alignment();
+    uintptr_t storage_align = midori_sdk_spsc_storage_alignment();
     EXPECT(storage_align >= 8, "storage_align >= 8");
     EXPECT((storage_align & (storage_align - 1)) == 0, "alignment is power of two");
 
     /* aligned_alloc は size が alignment の倍数であることを要求する。 */
-    size_t alloc_size = (storage_size + storage_align - 1) & ~(storage_align - 1);
-    void *storage = aligned_alloc(storage_align, alloc_size);
+    uintptr_t alloc_size = (storage_size + storage_align - 1) & ~(storage_align - 1);
+    void *storage = aligned_alloc((size_t)storage_align, (size_t)alloc_size);
     EXPECT(storage != NULL, "aligned_alloc succeeded");
 
     int32_t init_rc = midori_sdk_spsc_init(storage, slot_size);
@@ -48,7 +50,7 @@ int main(void) {
 
     /* 空状態では pop が 0 を返す。 */
     uint8_t out_buf[1024];
-    size_t out_len = 0;
+    uintptr_t out_len = 0;
     int32_t empty_rc = midori_sdk_spsc_pop(storage, out_buf, sizeof(out_buf), &out_len);
     EXPECT(empty_rc == 0, "empty pop returns 0");
 
@@ -88,6 +90,23 @@ int main(void) {
     memset(too_large, 0, sizeof(too_large));
     int32_t over_rc = midori_sdk_spsc_push(storage, too_large, sizeof(too_large));
     EXPECT(over_rc == -2, "oversize push returns -2");
+
+    /* caller buffer が payload より小さいケースは -3 を返し、`*out_len` には
+     * 本来必要だった byte 数が書かれる。SPSC 規律上 slot は消費されるため、
+     * 直後の pop は empty (0) を返す。 */
+    const uint8_t small_payload[64] = {0};
+    int32_t push_small_rc =
+        midori_sdk_spsc_push(storage, small_payload, sizeof(small_payload));
+    EXPECT(push_small_rc == 1, "push 64-byte payload returned 1");
+    uint8_t tiny_buf[32];
+    uintptr_t tiny_len = 0;
+    int32_t cap_rc =
+        midori_sdk_spsc_pop(storage, tiny_buf, sizeof(tiny_buf), &tiny_len);
+    EXPECT(cap_rc == -3, "capacity-insufficient pop returns -3");
+    EXPECT(tiny_len == sizeof(small_payload), "out_len reports required bytes");
+    int32_t empty_rc3 =
+        midori_sdk_spsc_pop(storage, out_buf, sizeof(out_buf), &out_len);
+    EXPECT(empty_rc3 == 0, "slot was consumed even though pop returned -3");
 
     free(storage);
     fprintf(stdout, "[c-smoke] OK\n");


### PR DESCRIPTION
## Summary

外部 C コンパイラで生成ヘッダ `midori_sdk.h` を `#include` し、midori-sdk の staticlib をリンクして `init → push → pop` のラウンドトリップを検証する smoke test を `cargo test -p midori-sdk` の一部として追加する。

midori-sdk 0.2.0 の新 FFI（`int32_t` 戻り値 / payload bytes API / `-2` oversize / `-3` capacity-insufficient）が C 側ツールチェーン経由でも成立することを、Node/Python バインディング着手前に凍結する。

## 主な変更

- `crates/midori-sdk/Cargo.toml` — `[lib] crate-type = ["staticlib", "rlib"]` 追加（`rlib` は workspace 内 Rust crate が引き続き使用、`staticlib` が C smoke 用）。`[dev-dependencies] cc = "1"` 追加
- `crates/midori-sdk/build.rs` — `cargo:rustc-env=MIDORI_SDK_HEADER_PATH=<OUT_DIR>/midori_sdk.h` で生成ヘッダ絶対 path を下流テストに公開
- `crates/midori-sdk/tests/c_smoke/spsc_round_trip.c` — storage 確保 (aligned_alloc) → init → empty pop = 0 → push → pop の値一致 → empty pop 再確認 → 最大 payload (slot_size - 8 = 1024 byte) round-trip → oversize push = -2 を確認
- `crates/midori-sdk/tests/c_smoke.rs` — ホスト C コンパイラ検出 (`CC` env / `cc` / `gcc` / `clang` の順)、staticlib path を `current_exe()` 経由で `<target>/<profile>/libmidori_sdk.a` に解決、`cc` 直接呼び出しで compile + link して生成バイナリを `Command` 起動。exit code 0 + stdout の `[c-smoke] OK` マーカーを assert
- `crates/midori-sdk/tests/c_smoke/README.md` — ローカル実行時の C コンパイラ前提と Out of Scope を記載

## skip 制御

- C コンパイラが見つからない環境（minimal container 等）では warning を出して **skip**（ビルド全体は失敗しない）
- `target_env = "msvc"` の Windows MSVC ターゲットでも **skip**（Out of Scope）

## AC マッピング

- [x] `cargo test -p midori-sdk` 実行時に C smoke test が走り、合格する
- [x] テストは生成ヘッダ (`midori_sdk.h`) を `#include` した実 C ソースをホスト C コンパイラでコンパイル
- [x] テストは midori-sdk を staticlib としてリンクする
- [x] C 側で `init → push → pop` を実行し、push した payload バイト列と pop 結果が一致することを assert（旧 AC の `value_i64`/`value_tag` は MEW-43 で撤去済 RingSlot 仕様。新 raw payload bytes 仕様で同等のラウンドトリップを検証）
- [x] バッファ空状態で pop が 0 を返すことを assert
- [x] C コンパイラが見つからない環境ではテストが skip され、ビルド全体は失敗しない
- [x] `crates/midori-sdk/tests/c_smoke/README.md` にローカル実行時の C コンパイラ前提を記載

## Out of Scope

- Windows MSVC でのリンク検証
- CI runner の C コンパイラ前提整備（別 Issue）
- C++ 互換性 (`extern "C++"`)
- Node.js / Python バインディング本体の実装

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`（C smoke 1 件 + 既存合計 185 件通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * midori-sdk を C から静的ライブラリとして利用可能にしました。

* **Chores**
  * ビルド成果物に静的ライブラリを含め、ヘッダーファイルのパスを環境変数で参照可能にしました。

* **Tests**
  * C ソースをビルド・リンク・実行するエンドツーエンドのスモークテストを追加しました。

* **Documentation**
  * C ABI スモークテストの手順・要件を記載したドキュメントを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->