### PR TITLE
feat(runtime): structured JSON logger for Bridge runtime (MEW-56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,6 +344,7 @@ dependencies = [
  "midori-core",
  "rmpv",
  "serde",
+ "serde_json",
  "serde_yml",
  "tempfile",
 ]

--- a/crates/midori-core/src/ipc.rs
+++ b/crates/midori-core/src/ipc.rs
@@ -11,13 +11,16 @@ pub enum Direction {
     Output,
 }
 
-/// Log severity level.
+/// Log severity level. `--log-level` の正式値は
+/// `design/04-runtime-cli.md` で `error | warn | info | debug` と定義されて
+/// いるため、wire 仕様もそれに合わせる。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum LogLevel {
     Error,
     Warn,
     Info,
+    Debug,
 }
 
 /// Events streamed as JSON Lines from the runtime to the GUI over stdout.

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4", features = ["derive"] }
 dirs = "5"
 rmpv = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_yml = "0.0.12"
 
 [dev-dependencies]

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "4", features = ["derive"] }
 dirs = "5"
 rmpv = "1"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 serde_yml = "0.0.12"
 
 [dev-dependencies]

--- a/crates/midori-runtime/src/logging.rs
+++ b/crates/midori-runtime/src/logging.rs
@@ -17,6 +17,7 @@
 //! 本 module は `type: log` のみを扱う。
 
 use std::fmt;
+use std::io::{self, Write};
 use std::sync::OnceLock;
 
 use clap::ValueEnum;
@@ -136,26 +137,38 @@ fn render_json(
 /// process-wide な logger。`init` で一度設定したらそれ以降は固定。
 static LOGGER: OnceLock<Logger> = OnceLock::new();
 
+/// `init` 前に呼ばれた場合の fallback。**`OnceLock` を初期化せず**に値だけ
+/// を返すので、後続の `init` が成功する。
+const DEFAULT_LOGGER: Logger = Logger::new(LogLevel::Info, LogFormat::Text);
+
 /// CLI parse 直後に 1 度だけ呼んで logger を確定する。再呼び出し（テストで
 /// 連続 init するケース等）は **silent に無視**して先勝ちを採用する。
 pub fn init(level: LogLevel, format: LogFormat) {
     let _ = LOGGER.set(Logger::new(level, format));
 }
 
-/// global logger を取得する。`init` 前に呼ばれた場合は default
-/// (`Info` / `Text`) を返す。default が固定されるのは「`main` で init する
-/// 前にログが出される経路」を防ぐ防衛的挙動で、運用上 main からは必ず init
-/// される前提。
+/// global logger を取得する。`init` 前に呼ばれた場合は [`DEFAULT_LOGGER`]
+/// を返す。`get_or_init` を使うと cell が永久に Default で固定され、後続の
+/// `init` が silent fail（`set` は初期化済 cell に Err を返す）して
+/// `--log-level` / `--log-format` が無視されるため、`get().copied()` で
+/// **read-only に取得**して fallback を返す形にしている。
 fn current() -> Logger {
-    *LOGGER.get_or_init(|| Logger::new(LogLevel::Info, LogFormat::Text))
+    LOGGER.get().copied().unwrap_or(DEFAULT_LOGGER)
 }
 
 /// 1 件のログを **stdout** に書く（`design/04-runtime-cli.md`「ログは JSON
 /// 形式で stdout に出力する」、Electron 側 stdout pipe ingestion との整合
 /// のため）。filter 通過時のみ実出力する。
+///
+/// `println!` は stdout が closed なとき panic する（Rust std は SIGPIPE を
+/// ignore する仕様）が、本 logger では stdout が IPC transport なので
+/// consumer 側 pipe が閉じた瞬間に runtime プロセスが abort してしまう。
+/// `io::stdout().lock()` + `writeln!` で書き込み、`Err` は握り潰して
+/// panic を避ける（broken pipe は consumer 終了の正常経路）。
 pub fn log(level: LogLevel, layer: &str, device: Option<&str>, message: impl fmt::Display) {
     if let Some(line) = current().render(level, layer, device, &message) {
-        println!("{line}");
+        let mut stdout = io::stdout().lock();
+        let _ = writeln!(stdout, "{line}");
     }
 }
 

--- a/crates/midori-runtime/src/logging.rs
+++ b/crates/midori-runtime/src/logging.rs
@@ -1,6 +1,8 @@
 //! Bridge 起動経路で使う中央集約 logger。`design/04-runtime-cli.md` の
 //! 「ログフォーマット」表に従い、`type: log` の JSON 行（`json` 形式）または
-//! 人間可読の 1 行（`text` 形式）を stderr に出す。
+//! 人間可読の 1 行（`text` 形式）を **stdout** に出す。Electron 側が stdout
+//! pipe で受信して GUI に転送する経路と整合させるため、stderr ではなく
+//! stdout を使う（spec line 33: 「ログは JSON 形式で stdout に出力する」）。
 //!
 //! 設計上の役割分担:
 //!
@@ -73,7 +75,7 @@ impl Logger {
 
     /// 1 件のログを「出すべき行」（filter を通過する場合）の文字列として返す。
     /// `None` のとき severity が filter で落とされたことを示す。caller は
-    /// 戻り値をそのまま `eprintln!` するか、テストで内容検証する。
+    /// 戻り値をそのまま `println!` するか、テストで内容検証する。
     #[must_use]
     pub fn render(
         self,
@@ -148,10 +150,12 @@ fn current() -> Logger {
     *LOGGER.get_or_init(|| Logger::new(LogLevel::Info, LogFormat::Text))
 }
 
-/// 1 件のログを stderr に書く。filter 通過時のみ実出力する。
+/// 1 件のログを **stdout** に書く（`design/04-runtime-cli.md`「ログは JSON
+/// 形式で stdout に出力する」、Electron 側 stdout pipe ingestion との整合
+/// のため）。filter 通過時のみ実出力する。
 pub fn log(level: LogLevel, layer: &str, device: Option<&str>, message: impl fmt::Display) {
     if let Some(line) = current().render(level, layer, device, &message) {
-        eprintln!("{line}");
+        println!("{line}");
     }
 }
 
@@ -193,16 +197,16 @@ mod tests {
     #[test]
     fn it_should_render_text_format_with_layer_and_message() {
         let logger = Logger::new(LogLevel::Info, LogFormat::Text);
-        let line = render(logger, LogLevel::Info, "startup", None, "hello").expect("info passes");
-        assert_eq!(line, "midori [info] startup: hello");
+        let line = render(logger, LogLevel::Info, "bridge", None, "hello").expect("info passes");
+        assert_eq!(line, "midori [info] bridge: hello");
     }
 
     #[test]
     fn it_should_render_text_format_with_device_segment() {
         let logger = Logger::new(LogLevel::Info, LogFormat::Text);
-        let line = render(logger, LogLevel::Warn, "startup", Some("midi"), "missing")
-            .expect("warn passes");
-        assert_eq!(line, "midori [warn] startup (midi): missing");
+        let line =
+            render(logger, LogLevel::Warn, "bridge", Some("midi"), "missing").expect("warn passes");
+        assert_eq!(line, "midori [warn] bridge (midi): missing");
     }
 
     #[test]
@@ -227,7 +231,7 @@ mod tests {
         let line = render(
             logger,
             LogLevel::Info,
-            "startup",
+            "bridge",
             Some("midi"),
             "events.yaml loaded",
         )

--- a/crates/midori-runtime/src/logging.rs
+++ b/crates/midori-runtime/src/logging.rs
@@ -1,0 +1,281 @@
+//! Bridge 起動経路で使う中央集約 logger。`design/04-runtime-cli.md` の
+//! 「ログフォーマット」表に従い、`type: log` の JSON 行（`json` 形式）または
+//! 人間可読の 1 行（`text` 形式）を stderr に出す。
+//!
+//! 設計上の役割分担:
+//!
+//! - [`Logger`]: format / level filter を持つ純粋な値型。`render` で「出すべき
+//!   行」を `Option<String>` として返す。テストはこの値型のみで完結する
+//! - [`init`] / [`log`]: process-wide な `OnceLock<Logger>` を介した便利関数。
+//!   `main()` の CLI parse 直後に [`init`] を一度だけ呼び、各 module からは
+//!   [`log`] / [`error`] / [`warn`] / [`info`] / [`debug`] を経由してアクセス
+//!
+//! `type: raw-event` / `type: device-state` / `type: signal` / `type: error-path`
+//! の構造化は driver spawn / SPSC ingest 配線時に追加する別経路の責務で、
+//! 本 module は `type: log` のみを扱う。
+
+use std::fmt;
+use std::sync::OnceLock;
+
+use clap::ValueEnum;
+
+/// ログ severity。`Error` が最強で `Debug` が最弱。`--log-level <X>` のとき
+/// X より弱い severity（数値が大きい側）は出力されない。
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+}
+
+impl LogLevel {
+    /// JSON / text 出力で使う小文字の文字列表現。
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+        }
+    }
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// 出力フォーマット。`Text` は人間可読、`Json` は machine readable な 1 行 JSON。
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+/// level filter と format を保持する logger 値型。`OnceLock` 経由でも値直接でも
+/// 使えるよう構造体として独立させる（テストは値直接を使うことで global state
+/// に依存せず並列実行できる）。
+#[derive(Debug, Clone, Copy)]
+pub struct Logger {
+    level: LogLevel,
+    format: LogFormat,
+}
+
+impl Logger {
+    /// 指定した filter / format の logger を生成する。
+    #[must_use]
+    pub const fn new(level: LogLevel, format: LogFormat) -> Self {
+        Self { level, format }
+    }
+
+    /// 1 件のログを「出すべき行」（filter を通過する場合）の文字列として返す。
+    /// `None` のとき severity が filter で落とされたことを示す。caller は
+    /// 戻り値をそのまま `eprintln!` するか、テストで内容検証する。
+    #[must_use]
+    pub fn render(
+        self,
+        level: LogLevel,
+        layer: &str,
+        device: Option<&str>,
+        message: &dyn fmt::Display,
+    ) -> Option<String> {
+        if level > self.level {
+            return None;
+        }
+        let rendered = match self.format {
+            LogFormat::Text => match device {
+                Some(dev) => format!("midori [{level}] {layer} ({dev}): {message}"),
+                None => format!("midori [{level}] {layer}: {message}"),
+            },
+            LogFormat::Json => render_json(level, layer, device, message),
+        };
+        Some(rendered)
+    }
+}
+
+fn render_json(
+    level: LogLevel,
+    layer: &str,
+    device: Option<&str>,
+    message: &dyn fmt::Display,
+) -> String {
+    // フィールド順は `design/04-runtime-cli.md` のサンプル
+    // `{"type":"log","level":...,"layer":...,"device":...,"message":...}`
+    // に揃える（`device` は省略可）。
+    let mut entry = serde_json::Map::new();
+    entry.insert(
+        "type".to_owned(),
+        serde_json::Value::String("log".to_owned()),
+    );
+    entry.insert(
+        "level".to_owned(),
+        serde_json::Value::String(level.as_str().to_owned()),
+    );
+    entry.insert(
+        "layer".to_owned(),
+        serde_json::Value::String(layer.to_owned()),
+    );
+    if let Some(device) = device {
+        entry.insert(
+            "device".to_owned(),
+            serde_json::Value::String(device.to_owned()),
+        );
+    }
+    entry.insert(
+        "message".to_owned(),
+        serde_json::Value::String(format!("{message}")),
+    );
+    serde_json::Value::Object(entry).to_string()
+}
+
+/// process-wide な logger。`init` で一度設定したらそれ以降は固定。
+static LOGGER: OnceLock<Logger> = OnceLock::new();
+
+/// CLI parse 直後に 1 度だけ呼んで logger を確定する。再呼び出し（テストで
+/// 連続 init するケース等）は **silent に無視**して先勝ちを採用する。
+pub fn init(level: LogLevel, format: LogFormat) {
+    let _ = LOGGER.set(Logger::new(level, format));
+}
+
+/// global logger を取得する。`init` 前に呼ばれた場合は default
+/// (`Info` / `Text`) を返す。default が固定されるのは「`main` で init する
+/// 前にログが出される経路」を防ぐ防衛的挙動で、運用上 main からは必ず init
+/// される前提。
+fn current() -> Logger {
+    *LOGGER.get_or_init(|| Logger::new(LogLevel::Info, LogFormat::Text))
+}
+
+/// 1 件のログを stderr に書く。filter 通過時のみ実出力する。
+pub fn log(level: LogLevel, layer: &str, device: Option<&str>, message: impl fmt::Display) {
+    if let Some(line) = current().render(level, layer, device, &message) {
+        eprintln!("{line}");
+    }
+}
+
+/// `Error` レベルの便利関数。
+pub fn error(layer: &str, device: Option<&str>, message: impl fmt::Display) {
+    log(LogLevel::Error, layer, device, message);
+}
+
+/// `Warn` レベルの便利関数。
+pub fn warn(layer: &str, device: Option<&str>, message: impl fmt::Display) {
+    log(LogLevel::Warn, layer, device, message);
+}
+
+/// `Info` レベルの便利関数。
+pub fn info(layer: &str, device: Option<&str>, message: impl fmt::Display) {
+    log(LogLevel::Info, layer, device, message);
+}
+
+/// `Debug` レベルの便利関数。
+#[allow(dead_code)]
+pub fn debug(layer: &str, device: Option<&str>, message: impl fmt::Display) {
+    log(LogLevel::Debug, layer, device, message);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(
+        logger: Logger,
+        level: LogLevel,
+        layer: &str,
+        device: Option<&str>,
+        message: &str,
+    ) -> Option<String> {
+        logger.render(level, layer, device, &message)
+    }
+
+    #[test]
+    fn it_should_render_text_format_with_layer_and_message() {
+        let logger = Logger::new(LogLevel::Info, LogFormat::Text);
+        let line = render(logger, LogLevel::Info, "startup", None, "hello").expect("info passes");
+        assert_eq!(line, "midori [info] startup: hello");
+    }
+
+    #[test]
+    fn it_should_render_text_format_with_device_segment() {
+        let logger = Logger::new(LogLevel::Info, LogFormat::Text);
+        let line = render(logger, LogLevel::Warn, "startup", Some("midi"), "missing")
+            .expect("warn passes");
+        assert_eq!(line, "midori [warn] startup (midi): missing");
+    }
+
+    #[test]
+    fn it_should_render_json_format_with_required_fields() {
+        let logger = Logger::new(LogLevel::Info, LogFormat::Json);
+        let line = render(logger, LogLevel::Error, "runtime", None, "boom").expect("error passes");
+        let value: serde_json::Value = serde_json::from_str(&line).expect("valid json");
+        assert_eq!(value["type"], "log");
+        assert_eq!(value["level"], "error");
+        assert_eq!(value["layer"], "runtime");
+        assert_eq!(value["message"], "boom");
+        // device は省略時に出ない
+        assert!(
+            value.get("device").is_none(),
+            "device should be omitted: {line}"
+        );
+    }
+
+    #[test]
+    fn it_should_include_device_field_when_provided_in_json_format() {
+        let logger = Logger::new(LogLevel::Info, LogFormat::Json);
+        let line = render(
+            logger,
+            LogLevel::Info,
+            "startup",
+            Some("midi"),
+            "events.yaml loaded",
+        )
+        .expect("info passes");
+        let value: serde_json::Value = serde_json::from_str(&line).expect("valid json");
+        assert_eq!(value["device"], "midi");
+    }
+
+    #[test]
+    fn it_should_filter_out_levels_weaker_than_threshold() {
+        let logger = Logger::new(LogLevel::Warn, LogFormat::Text);
+        // Warn 設定下では Info / Debug は出ない、Warn / Error は出る
+        assert!(render(logger, LogLevel::Error, "x", None, "m").is_some());
+        assert!(render(logger, LogLevel::Warn, "x", None, "m").is_some());
+        assert!(render(logger, LogLevel::Info, "x", None, "m").is_none());
+        assert!(render(logger, LogLevel::Debug, "x", None, "m").is_none());
+    }
+
+    #[test]
+    fn it_should_pass_all_levels_when_filter_is_debug() {
+        let logger = Logger::new(LogLevel::Debug, LogFormat::Text);
+        for level in [
+            LogLevel::Error,
+            LogLevel::Warn,
+            LogLevel::Info,
+            LogLevel::Debug,
+        ] {
+            assert!(
+                render(logger, level, "x", None, "m").is_some(),
+                "debug filter should pass {level:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn it_should_only_emit_error_when_filter_is_error() {
+        let logger = Logger::new(LogLevel::Error, LogFormat::Text);
+        assert!(render(logger, LogLevel::Error, "x", None, "m").is_some());
+        assert!(render(logger, LogLevel::Warn, "x", None, "m").is_none());
+        assert!(render(logger, LogLevel::Info, "x", None, "m").is_none());
+        assert!(render(logger, LogLevel::Debug, "x", None, "m").is_none());
+    }
+
+    #[test]
+    fn it_should_render_log_level_as_lowercase_string() {
+        assert_eq!(LogLevel::Error.as_str(), "error");
+        assert_eq!(LogLevel::Warn.as_str(), "warn");
+        assert_eq!(LogLevel::Info.as_str(), "info");
+        assert_eq!(LogLevel::Debug.as_str(), "debug");
+    }
+}

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> ExitCode {
     match dispatch(&cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            logging::error("cli", None, err);
+            logging::error("bridge", None, err);
             ExitCode::FAILURE
         }
     }
@@ -83,7 +83,7 @@ fn run(profile_path: &Path, app_data_dir_override: Option<&Path>) -> Result<(), 
         {
             DriverSchemaOutcome::Loaded(_) => {
                 logging::info(
-                    "startup",
+                    "bridge",
                     Some(name),
                     format_args!(
                         "events.yaml ({}) のチェックが完了しました",
@@ -95,7 +95,7 @@ fn run(profile_path: &Path, app_data_dir_override: Option<&Path>) -> Result<(), 
                 // events.yaml が無い driver は spec 上「明示的な schema 未宣言モード」
                 // として warning に留めて起動を継続する。
                 logging::warn(
-                    "startup",
+                    "bridge",
                     Some(name),
                     format_args!(
                         "events.yaml ({}) が見つかりませんでした。schema 未宣言モードで起動します",

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -1,16 +1,18 @@
 mod error;
 mod events_pipeline;
 mod events_schema;
+mod logging;
 mod profile;
 mod ring_handshake;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Parser, Subcommand};
 
 use crate::error::CliError;
 use crate::events_pipeline::{check_driver_schema, DriverSchemaOutcome};
+use crate::logging::{LogFormat, LogLevel};
 use crate::profile::{collect_driver_names, load_from_path as load_profile};
 
 #[derive(Parser, Debug)]
@@ -47,26 +49,13 @@ enum Command {
     },
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
-enum LogLevel {
-    Error,
-    Warn,
-    Info,
-    Debug,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
-enum LogFormat {
-    Text,
-    Json,
-}
-
 fn main() -> ExitCode {
     let cli = Cli::parse();
+    logging::init(cli.log_level, cli.log_format);
     match dispatch(&cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            eprintln!("midori: {err}");
+            logging::error("cli", None, err);
             ExitCode::FAILURE
         }
     }
@@ -93,17 +82,25 @@ fn run(profile_path: &Path, app_data_dir_override: Option<&Path>) -> Result<(), 
             .map_err(|source| CliError::StartupCheck { source })?
         {
             DriverSchemaOutcome::Loaded(_) => {
-                eprintln!(
-                    "midori: driver `{name}` の events.yaml ({}) のチェックが完了しました",
-                    events_yaml_path.display()
+                logging::info(
+                    "startup",
+                    Some(name),
+                    format_args!(
+                        "events.yaml ({}) のチェックが完了しました",
+                        events_yaml_path.display()
+                    ),
                 );
             }
             DriverSchemaOutcome::Missing => {
                 // events.yaml が無い driver は spec 上「明示的な schema 未宣言モード」
                 // として warning に留めて起動を継続する。
-                eprintln!(
-                    "midori: warning: driver `{name}` の events.yaml ({}) が見つかりませんでした。schema 未宣言モードで起動します",
-                    events_yaml_path.display()
+                logging::warn(
+                    "startup",
+                    Some(name),
+                    format_args!(
+                        "events.yaml ({}) が見つかりませんでした。schema 未宣言モードで起動します",
+                        events_yaml_path.display()
+                    ),
                 );
             }
         }

--- a/crates/midori-runtime/tests/cli_log.rs
+++ b/crates/midori-runtime/tests/cli_log.rs
@@ -1,0 +1,170 @@
+//! CLI 経由で `--log-format json` の structured logger 出力を検証する統合
+//! テスト。`main()` 内で `logging::init` が動くこと、`logging::warn` 等が
+//! 実バイナリの stderr に 1 行 JSON を吐くことを end-to-end で担保する。
+//!
+//! 単体テスト（`logging.rs::tests`）は `Logger` 値直接で format / filter を
+//! 検証するため、本ファイルは実バイナリ spawn 経路（`OnceLock` 経由）に絞る。
+
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+/// `<app-data-dir>/plugins/driver-<name>/events.yaml` を持たない app-data-dir
+/// を temp dir で作る。startup chain が "Missing → warn" の経路に入る。
+fn setup_empty_app_data_dir() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("midori-cli-log-app-")
+        .tempdir()
+        .expect("tempdir")
+}
+
+fn write_tmp_profile(driver: &str) -> tempfile::NamedTempFile {
+    let yaml = format!(
+        "inputs:\n  - adapter: a.yaml\n    connection: {{ driver: {driver} }}\ntransform: t.yaml\noutputs:\n  - adapter: b.yaml\n    connection: {{ driver: {driver} }}\n"
+    );
+    let mut file = tempfile::Builder::new()
+        .prefix("midori-cli-log-profile-")
+        .suffix(".yaml")
+        .tempfile()
+        .expect("tempfile");
+    file.write_all(yaml.as_bytes()).expect("write profile");
+    file
+}
+
+fn spawn(profile: &Path, app_data_dir: &Path, format: &str) -> std::process::Output {
+    let bin = env!("CARGO_BIN_EXE_midori");
+    Command::new(bin)
+        .args([
+            "--log-format",
+            format,
+            "--app-data-dir",
+            app_data_dir.to_str().expect("utf-8"),
+            "run",
+            profile.to_str().expect("utf-8"),
+        ])
+        .output()
+        .expect("spawn midori")
+}
+
+#[test]
+fn it_should_emit_warn_log_as_single_json_line_when_events_yaml_is_missing() {
+    let app = setup_empty_app_data_dir();
+    let profile = write_tmp_profile("midi");
+    let output = spawn(profile.path(), app.path(), "json");
+    assert!(
+        output.status.success(),
+        "missing events.yaml should warn + continue, exit success: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8(output.stderr).expect("utf-8");
+    let warn_line = stderr
+        .lines()
+        .find(|line| line.contains("\"level\":\"warn\""))
+        .unwrap_or_else(|| panic!("warn line missing in stderr: {stderr}"));
+    let value: serde_json::Value =
+        serde_json::from_str(warn_line).expect("warn line is valid json");
+    assert_eq!(value["type"], "log");
+    assert_eq!(value["level"], "warn");
+    assert_eq!(value["layer"], "startup");
+    assert_eq!(value["device"], "midi");
+    let message = value["message"].as_str().unwrap_or("");
+    assert!(
+        message.contains("見つかりませんでした"),
+        "warn message should describe the missing-schema case: {message}"
+    );
+}
+
+#[test]
+fn it_should_emit_text_format_when_log_format_is_text() {
+    let app = setup_empty_app_data_dir();
+    let profile = write_tmp_profile("osc");
+    let output = spawn(profile.path(), app.path(), "text");
+    assert!(output.status.success(), "exit success");
+    let stderr = String::from_utf8(output.stderr).expect("utf-8");
+    // text 形式は `midori [warn] startup (osc): ...` の形
+    assert!(
+        stderr.contains("midori [warn] startup (osc)"),
+        "text-format warn line missing: {stderr}"
+    );
+    // text 形式は JSON シンボルを含まないこと（JSON 形式と排他）
+    assert!(
+        !stderr.contains("\"type\":\"log\""),
+        "text format should not emit json: {stderr}"
+    );
+}
+
+#[test]
+fn it_should_emit_error_log_when_profile_is_invalid() {
+    // profile が存在しない path を渡す → CliError::LoadProfile (Io) → main で
+    // logging::error 経由で出力。exit code は失敗。
+    let app = setup_empty_app_data_dir();
+    let bin = env!("CARGO_BIN_EXE_midori");
+    let output = Command::new(bin)
+        .args([
+            "--log-format",
+            "json",
+            "--app-data-dir",
+            app.path().to_str().expect("utf-8"),
+            "run",
+            "/nonexistent/midori-cli-log/profile.yaml",
+        ])
+        .output()
+        .expect("spawn");
+    assert!(
+        !output.status.success(),
+        "missing profile must fail: {output:?}"
+    );
+    let stderr = String::from_utf8(output.stderr).expect("utf-8");
+    let error_line = stderr
+        .lines()
+        .find(|line| line.contains("\"level\":\"error\""))
+        .unwrap_or_else(|| panic!("error line missing: {stderr}"));
+    let value: serde_json::Value =
+        serde_json::from_str(error_line).expect("error line is valid json");
+    assert_eq!(value["type"], "log");
+    assert_eq!(value["level"], "error");
+    assert_eq!(value["layer"], "cli");
+}
+
+#[test]
+fn it_should_filter_out_info_when_log_level_is_warn() {
+    // level=warn 設定下では Info / Debug は出ず、Warn のみが出る。
+    // events.yaml Missing は warn なので 1 件出るが、Loaded info は出ないこと
+    // を別 fixture（events.yaml が valid な driver）で確認する。
+    let app = tempfile::Builder::new()
+        .prefix("midori-cli-log-filter-")
+        .tempdir()
+        .expect("tempdir");
+    // valid な events.yaml を配置 → Loaded info 経路
+    let plugin_dir = app.path().join("plugins").join("driver-midi");
+    std::fs::create_dir_all(&plugin_dir).expect("mkdir plugin");
+    let valid_events = "schema_version: 1\n\
+         events:\n  \
+           noteOn:\n    \
+             fields:\n      \
+               channel: { type: uint8, range: [1, 16] }\n";
+    std::fs::write(plugin_dir.join("events.yaml"), valid_events).expect("write events.yaml");
+    let profile = write_tmp_profile("midi");
+
+    let bin = env!("CARGO_BIN_EXE_midori");
+    let output = Command::new(bin)
+        .args([
+            "--log-level",
+            "warn",
+            "--log-format",
+            "json",
+            "--app-data-dir",
+            app.path().to_str().expect("utf-8"),
+            "run",
+            profile.path().to_str().expect("utf-8"),
+        ])
+        .output()
+        .expect("spawn");
+    assert!(output.status.success(), "valid setup should succeed");
+    let stderr = String::from_utf8(output.stderr).expect("utf-8");
+    assert!(
+        !stderr.contains("\"level\":\"info\""),
+        "info should be filtered out by --log-level warn: {stderr}"
+    );
+}

--- a/crates/midori-runtime/tests/cli_log.rs
+++ b/crates/midori-runtime/tests/cli_log.rs
@@ -1,6 +1,6 @@
 //! CLI 経由で `--log-format json` の structured logger 出力を検証する統合
 //! テスト。`main()` 内で `logging::init` が動くこと、`logging::warn` 等が
-//! 実バイナリの stderr に 1 行 JSON を吐くことを end-to-end で担保する。
+//! 実バイナリの stdout に 1 行 JSON を吐くことを end-to-end で担保する。
 //!
 //! 単体テスト（`logging.rs::tests`）は `Logger` 値直接で format / filter を
 //! 検証するため、本ファイルは実バイナリ spawn 経路（`OnceLock` 経由）に絞る。
@@ -57,16 +57,16 @@ fn it_should_emit_warn_log_as_single_json_line_when_events_yaml_is_missing() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    let stderr = String::from_utf8(output.stderr).expect("utf-8");
-    let warn_line = stderr
+    let stdout = String::from_utf8(output.stdout).expect("utf-8");
+    let warn_line = stdout
         .lines()
         .find(|line| line.contains("\"level\":\"warn\""))
-        .unwrap_or_else(|| panic!("warn line missing in stderr: {stderr}"));
+        .unwrap_or_else(|| panic!("warn line missing in stdout: {stdout}"));
     let value: serde_json::Value =
         serde_json::from_str(warn_line).expect("warn line is valid json");
     assert_eq!(value["type"], "log");
     assert_eq!(value["level"], "warn");
-    assert_eq!(value["layer"], "startup");
+    assert_eq!(value["layer"], "bridge");
     assert_eq!(value["device"], "midi");
     let message = value["message"].as_str().unwrap_or("");
     assert!(
@@ -81,16 +81,16 @@ fn it_should_emit_text_format_when_log_format_is_text() {
     let profile = write_tmp_profile("osc");
     let output = spawn(profile.path(), app.path(), "text");
     assert!(output.status.success(), "exit success");
-    let stderr = String::from_utf8(output.stderr).expect("utf-8");
-    // text 形式は `midori [warn] startup (osc): ...` の形
+    let stdout = String::from_utf8(output.stdout).expect("utf-8");
+    // text 形式は `midori [warn] bridge (osc): ...` の形
     assert!(
-        stderr.contains("midori [warn] startup (osc)"),
-        "text-format warn line missing: {stderr}"
+        stdout.contains("midori [warn] bridge (osc)"),
+        "text-format warn line missing: {stdout}"
     );
     // text 形式は JSON シンボルを含まないこと（JSON 形式と排他）
     assert!(
-        !stderr.contains("\"type\":\"log\""),
-        "text format should not emit json: {stderr}"
+        !stdout.contains("\"type\":\"log\""),
+        "text format should not emit json: {stdout}"
     );
 }
 
@@ -115,16 +115,16 @@ fn it_should_emit_error_log_when_profile_is_invalid() {
         !output.status.success(),
         "missing profile must fail: {output:?}"
     );
-    let stderr = String::from_utf8(output.stderr).expect("utf-8");
-    let error_line = stderr
+    let stdout = String::from_utf8(output.stdout).expect("utf-8");
+    let error_line = stdout
         .lines()
         .find(|line| line.contains("\"level\":\"error\""))
-        .unwrap_or_else(|| panic!("error line missing: {stderr}"));
+        .unwrap_or_else(|| panic!("error line missing: {stdout}"));
     let value: serde_json::Value =
         serde_json::from_str(error_line).expect("error line is valid json");
     assert_eq!(value["type"], "log");
     assert_eq!(value["level"], "error");
-    assert_eq!(value["layer"], "cli");
+    assert_eq!(value["layer"], "bridge");
 }
 
 #[test]
@@ -162,9 +162,9 @@ fn it_should_filter_out_info_when_log_level_is_warn() {
         .output()
         .expect("spawn");
     assert!(output.status.success(), "valid setup should succeed");
-    let stderr = String::from_utf8(output.stderr).expect("utf-8");
+    let stdout = String::from_utf8(output.stdout).expect("utf-8");
     assert!(
-        !stderr.contains("\"level\":\"info\""),
-        "info should be filtered out by --log-level warn: {stderr}"
+        !stdout.contains("\"level\":\"info\""),
+        "info should be filtered out by --log-level warn: {stdout}"
     );
 }

--- a/design/00-naming.md
+++ b/design/00-naming.md
@@ -81,12 +81,15 @@
 
 | `layer` 値 | 対応する層 | `device` フィールド |
 |---|---|---|
+| `bridge` | Bridge プロセス本体（CLI 入力 / プロファイル読込 / events.yaml 起動チェック等、特定 driver / パイプライン層に紐づかない汎用ログ） | 任意（特定 driver に関連するときのみ driver 名を入れる） |
 | `input-profile` | Layer 2: binding.input の処理 | 入力デバイスID |
 | `mapper` | Layer 3: 変換グラフの処理 | なし（複数デバイス横断） |
 | `output-profile` | Layer 4: binding.output の処理 | 出力デバイスID |
 | `driver/<name>` | Layer 1/5: ドライバー外部プロセスの出力を Bridge が転送 | 対象デバイスID |
 
 ```json
+{"type":"log","level":"error","layer":"bridge",                                "message":"failed to load profile: ..."}
+{"type":"log","level":"info", "layer":"bridge",        "device":"midi",        "message":"events.yaml のチェックが完了しました"}
 {"type":"log","level":"error","layer":"input-profile", "device":"yamaha-els03","message":"unknown component: foo"}
 {"type":"log","level":"warn", "layer":"output-profile","device":"vrchat-osc",  "message":"unknown signal: bar"}
 {"type":"log","level":"error","layer":"mapper",                                "message":"division by zero","node":"vel_scale"}


### PR DESCRIPTION
## Summary

`midori run` の `--log-level` / `--log-format` を実際に尊重する中央集約 logger を導入する。design/04-runtime-cli.md の `type: log` JSON 仕様に従い、既存の `eprintln!` 散在を 1 箇所に集約する。

PR #39 (MEW-55) の CR R5 で reject した「startup messages が `eprintln!` を直接呼んで `--log-level` / `--log-format` を尊重しない」問題を解消し、後続の driver spawn / SPSC ingest 配線で `eprintln!` を増やさない前提を作る。

## 主な変更

- `crates/midori-runtime/src/logging.rs` (新規) — `Logger` / `LogLevel { Error, Warn, Info, Debug }` / `LogFormat { Text, Json }`。`Json` は `{"type":"log","level":...,"layer":...,"device":...,"message":...}` 形式、`Text` は `midori [<level>] <layer> (<device>): <message>`。severity ordering で `--log-level <X>` 設定下より弱い severity は filter out。
- `crates/midori-runtime/src/main.rs` — 旧 `LogLevel` / `LogFormat` 定義を logging module に移動。`main()` で `logging::init` を呼び、以降 process-wide で固定。startup chain の Loaded info / Missing warn と最終エラー出力を `logging::info` / `warn` / `error` 経由に置換。
- `crates/midori-runtime/tests/cli_log.rs` (新規) — 実 binary spawn で JSON warn 行 / Text 形式 / LoadProfile error / level filter を end-to-end 検証。
- `crates/midori-runtime/Cargo.toml` — `serde_json = "1"` を direct dep に追加。

## API 設計

- `Logger` は `Copy` 値型。`render(level, layer, device, message) -> Option<String>` で filter 通過行のみ Some を返す。テストは値直接で並列実行可能（global state に依存しない）。
- `OnceLock<Logger>` 経由の便利関数 (`init` / `log` / `error` / `warn` / `info` / `debug`) が main 経路用。init 前に log を呼んでも default (Info/Text) で動く防衛挙動。

## AC マッピング

- [x] `Logger` / `LogLevel` / `LogFormat` を導入
- [x] severity ordering、`--log-level info` で Debug filter out
- [x] `LogFormat::Json` は design/04 準拠 1 行 JSON
- [x] `LogFormat::Text` は人間可読
- [x] `main.rs::run` の `eprintln!` を Logger 経由に置換 (events_pipeline::startup / ring_handshake は元々 eprintln! を持たないため不要)
- [x] Logger は `OnceLock` で thread-safe global
- [x] 単体テスト 8 件（format / filter / device 有無）
- [x] 統合テスト 4 件（`midori run --log-format json` で JSON 行が stderr）

## Out of Scope

- `type: raw-event` / `type: device-state` / `type: signal` / `type: error-path` の構造化（driver spawn / SPSC ingest 配線時に追加、別 subtask）
- SSE 配信 / GUI 連携、log file 出力、log-level 動的変更
- `process_inline_payload` の log 流路（実 SPSC ingest 配線時に対応）

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`（runtime 123 件 + cli_log 4 件 + sdk c_smoke 1 件 + 既存、計 197 件通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 階層化された構造化ログを導入（レベル: Error/Warn/Info/Debug、出力形式: テキスト/JSON）。CLI出力がこれらの設定に従い、ブリッジ層のログはデバイス情報を任意で含む単一行ログとして出力されます。

* **Tests**
  * CLI向け統合テストを追加し、JSON/テキスト形式、レベルフィルタ、ブリッジ層の出力を検証します。

* **Documentation**
  * ブリッジ層のログ分類と例をドキュメントに追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->