### PR TITLE
chore(runtime): replace unmaintained serde_yml with serde_yaml_ng

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,16 +286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,7 +335,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "tempfile",
 ]
 
@@ -529,18 +519,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -665,16 +653,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -17,7 +17,7 @@ dirs = "5"
 rmpv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
-serde_yml = "0.0.12"
+serde_yaml_ng = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/midori-runtime/src/events_pipeline/runtime_check.rs
+++ b/crates/midori-runtime/src/events_pipeline/runtime_check.rs
@@ -499,16 +499,16 @@ fn uint64_bounds_from_range(range: Option<&RangeBound>) -> (u64, u64) {
         .unwrap_or((0, u64::MAX))
 }
 
-fn yaml_as_i64(v: &serde_yml::Value) -> Option<i64> {
+fn yaml_as_i64(v: &serde_yaml_ng::Value) -> Option<i64> {
     match v {
-        serde_yml::Value::Number(n) => n.as_i64(),
+        serde_yaml_ng::Value::Number(n) => n.as_i64(),
         _ => None,
     }
 }
 
-fn yaml_as_u64(v: &serde_yml::Value) -> Option<u64> {
+fn yaml_as_u64(v: &serde_yaml_ng::Value) -> Option<u64> {
     match v {
-        serde_yml::Value::Number(n) => n.as_u64(),
+        serde_yaml_ng::Value::Number(n) => n.as_u64(),
         _ => None,
     }
 }

--- a/crates/midori-runtime/src/events_pipeline/tests.rs
+++ b/crates/midori-runtime/src/events_pipeline/tests.rs
@@ -41,7 +41,7 @@ events:
       payload: { type: bytes, max_length: 8 }
     binding_filter: [type]
 ";
-    serde_yml::from_str(yaml).expect("fixture parses")
+    serde_yaml_ng::from_str(yaml).expect("fixture parses")
 }
 
 fn encode_map(entries: &[(&str, Value)]) -> Vec<u8> {
@@ -344,7 +344,7 @@ events:
       v: { type: uint8 }
     binding_filter: [type]
 ";
-    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+    let schema: EventsSchema = serde_yaml_ng::from_str(yaml).expect("parse");
     let p = payload(&[
         ("type", FieldValue::String("raw".into())),
         ("v", FieldValue::UInt(300)), // uint8 default は 0..=255
@@ -437,7 +437,7 @@ events:
       v: { type: int64 }
     binding_filter: [type]
 ";
-    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+    let schema: EventsSchema = serde_yaml_ng::from_str(yaml).expect("parse");
 
     #[allow(clippy::cast_sign_loss)]
     let just_above_i64_max: u64 = i64::MAX as u64 + 1;
@@ -463,7 +463,7 @@ events:
       v: { type: int64 }
     binding_filter: [type]
 ";
-    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+    let schema: EventsSchema = serde_yaml_ng::from_str(yaml).expect("parse");
 
     #[allow(clippy::cast_sign_loss)]
     let i64_max_as_u: u64 = i64::MAX as u64;
@@ -487,7 +487,7 @@ events:
       v: { type: uint64, range: [0, 9000000000000000000] }
     binding_filter: [type]
 ";
-    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+    let schema: EventsSchema = serde_yaml_ng::from_str(yaml).expect("parse");
 
     let p = payload(&[
         ("type", FieldValue::String("ping".into())),
@@ -508,7 +508,7 @@ events:
       v: { type: uint64 }
     binding_filter: [type]
 ";
-    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+    let schema: EventsSchema = serde_yaml_ng::from_str(yaml).expect("parse");
 
     let p = payload(&[
         ("type", FieldValue::String("ping".into())),
@@ -532,7 +532,7 @@ events:
       payload: { type: uint8 }
     binding_filter: [type]
 ";
-    let schema: EventsSchema = serde_yml::from_str(yaml).expect("parse");
+    let schema: EventsSchema = serde_yaml_ng::from_str(yaml).expect("parse");
 
     // ts 抜けは required missing
     let missing = payload(&[

--- a/crates/midori-runtime/src/events_schema/loader.rs
+++ b/crates/midori-runtime/src/events_schema/loader.rs
@@ -26,7 +26,7 @@ pub enum LoadError {
     /// YAML parse / deserialization failure.
     Parse {
         path: PathBuf,
-        source: serde_yml::Error,
+        source: serde_yaml_ng::Error,
     },
 }
 
@@ -79,10 +79,11 @@ pub fn load_from_path(path: &Path) -> Result<LoadOutcome, LoadError> {
             });
         }
     };
-    let schema: EventsSchema = serde_yml::from_str(&yaml).map_err(|source| LoadError::Parse {
-        path: path.to_path_buf(),
-        source,
-    })?;
+    let schema: EventsSchema =
+        serde_yaml_ng::from_str(&yaml).map_err(|source| LoadError::Parse {
+            path: path.to_path_buf(),
+            source,
+        })?;
     Ok(LoadOutcome::Loaded(schema))
 }
 

--- a/crates/midori-runtime/src/events_schema/tests.rs
+++ b/crates/midori-runtime/src/events_schema/tests.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use super::*;
 
 fn parse(yaml: &str) -> EventsSchema {
-    serde_yml::from_str(yaml).expect("parse should succeed")
+    serde_yaml_ng::from_str(yaml).expect("parse should succeed")
 }
 
 #[test]
@@ -68,7 +68,7 @@ events:
     fields:
       x: { type: uint8 }
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(result.is_err(), "unknown tier should fail to deserialize");
 }
 
@@ -82,7 +82,7 @@ events:
     fields:
       x: { type: uint8 }
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(
         result.is_err(),
         "non-string tier should fail to deserialize"
@@ -98,7 +98,7 @@ events:
     fields:
       x: { type: weirdType }
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(result.is_err(), "unknown type vocabulary should fail");
 }
 
@@ -244,7 +244,7 @@ events:
     fields:
       y: { type: uint8 }
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(
         result.is_err(),
         "duplicate event name should fail to deserialize"
@@ -260,7 +260,7 @@ events:
     fields:
       vals: { type: array<enum>, max_length: 4 }
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(
         result.is_err(),
         "array<enum> should fail (non-scalar inner type)"
@@ -276,7 +276,7 @@ events:
     fields:
       vals: { type: array<array<uint8>>, max_length: 4 }
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(
         result.is_err(),
         "nested array type should fail (non-scalar inner type)"
@@ -329,7 +329,7 @@ events:
       x: { type: uint8 }
 unknownTopLevel: oops
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(
         result.is_err(),
         "unknown top-level field should be rejected"
@@ -346,7 +346,7 @@ events:
       x: { type: uint8 }
     unknownProp: 1
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(result.is_err(), "unknown event field should be rejected");
 }
 
@@ -360,7 +360,7 @@ events:
       a: { type: uint8 }
       a: { type: uint8 }
 ";
-    let result: Result<EventsSchema, _> = serde_yml::from_str(yaml);
+    let result: Result<EventsSchema, _> = serde_yaml_ng::from_str(yaml);
     assert!(
         result.is_err(),
         "duplicate field in event should fail to deserialize"

--- a/crates/midori-runtime/src/events_schema/types.rs
+++ b/crates/midori-runtime/src/events_schema/types.rs
@@ -62,21 +62,21 @@ pub struct FieldSpec {
     #[serde(default)]
     pub optional: bool,
     #[serde(default)]
-    pub default: Option<serde_yml::Value>,
+    pub default: Option<serde_yaml_ng::Value>,
 }
 
 /// `range: [min, max]` bound. Stored as raw YAML values; validation checks
 /// numeric compatibility with the declared field type.
 #[derive(Debug, Deserialize, PartialEq, Clone)]
-#[serde(try_from = "Vec<serde_yml::Value>")]
+#[serde(try_from = "Vec<serde_yaml_ng::Value>")]
 pub struct RangeBound {
-    pub min: serde_yml::Value,
-    pub max: serde_yml::Value,
+    pub min: serde_yaml_ng::Value,
+    pub max: serde_yaml_ng::Value,
 }
 
-impl TryFrom<Vec<serde_yml::Value>> for RangeBound {
+impl TryFrom<Vec<serde_yaml_ng::Value>> for RangeBound {
     type Error = String;
-    fn try_from(v: Vec<serde_yml::Value>) -> Result<Self, Self::Error> {
+    fn try_from(v: Vec<serde_yaml_ng::Value>) -> Result<Self, Self::Error> {
         let mut iter = v.into_iter();
         let min = iter
             .next()
@@ -286,7 +286,7 @@ where
     )
 }
 
-/// `serde_yml::Value` の数値を `f64` に変換する。
+/// `serde_yaml_ng::Value` の数値を `f64` に変換する。
 ///
 /// `as_f64()` 単独では実装によって整数リテラル（`range: [0, 127]` 等）が
 /// `None` を返す可能性があるため、`as_i64()` / `as_u64()` への fallback を
@@ -294,9 +294,9 @@ where
 /// `events_pipeline::runtime_check`（イベントごとの runtime 検査）の両方が
 /// 範囲比較で使うため、ここに共通定義を置く。
 #[allow(clippy::cast_precision_loss)]
-pub(crate) fn yaml_to_f64(v: &serde_yml::Value) -> Option<f64> {
+pub(crate) fn yaml_to_f64(v: &serde_yaml_ng::Value) -> Option<f64> {
     match v {
-        serde_yml::Value::Number(n) => n
+        serde_yaml_ng::Value::Number(n) => n
             .as_f64()
             .or_else(|| n.as_i64().map(|i| i as f64))
             .or_else(|| n.as_u64().map(|u| u as f64)),

--- a/crates/midori-runtime/src/events_schema/types.rs
+++ b/crates/midori-runtime/src/events_schema/types.rs
@@ -288,9 +288,11 @@ where
 
 /// `serde_yaml_ng::Value` の数値を `f64` に変換する。
 ///
-/// `as_f64()` 単独では実装によって整数リテラル（`range: [0, 127]` 等）が
-/// `None` を返す可能性があるため、`as_i64()` / `as_u64()` への fallback を
-/// 順に試す。`Value::Number` 以外は `None`。validator（schema 起動時検査）と
+/// 現行の `serde_yaml_ng::Number::as_f64()` は整数リテラル（`range: [0, 127]`
+/// 等）に対しても `Some` を返すため通常は `as_f64()` 一発で足りるが、将来の
+/// パーサ差し替えで整数リテラルに対して `None` を返す実装に当たっても安全に
+/// 倒れるよう、`as_i64()` / `as_u64()` への fallback を defense-in-depth で
+/// 残してある。`Value::Number` 以外は `None`。validator（schema 起動時検査）と
 /// `events_pipeline::runtime_check`（イベントごとの runtime 検査）の両方が
 /// 範囲比較で使うため、ここに共通定義を置く。
 #[allow(clippy::cast_precision_loss)]

--- a/crates/midori-runtime/src/events_schema/validator.rs
+++ b/crates/midori-runtime/src/events_schema/validator.rs
@@ -210,10 +210,10 @@ fn validate_range(
 fn validate_default(
     path: &str,
     spec: &FieldSpec,
-    default: &serde_yml::Value,
+    default: &serde_yaml_ng::Value,
     errors: &mut Vec<ValidationError>,
 ) {
-    use serde_yml::Value;
+    use serde_yaml_ng::Value;
     let push = |msg: String, errors: &mut Vec<ValidationError>| {
         errors.push(ValidationError {
             path: path.to_owned(),

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -333,7 +333,7 @@ mod tests {
                payload: { type: bytes, max_length: 1024 }\n";
 
     /// loader 段階の YAML パースで失敗する events.yaml フィクスチャ。
-    /// 末尾の `[` が閉じておらず `serde_yml::from_str` が Parse error を返す。
+    /// 末尾の `[` が閉じておらず `serde_yaml_ng::from_str` が Parse error を返す。
     const EVENTS_YAML_MALFORMED: &str = "schema_version: [\n";
 
     /// `transform` フィールドを欠いた profile YAML フィクスチャ。

--- a/crates/midori-runtime/src/plugin_resolver.rs
+++ b/crates/midori-runtime/src/plugin_resolver.rs
@@ -318,7 +318,7 @@ fn load_plugin_into(
         }
     };
 
-    let manifest: PluginManifest = match serde_yml::from_str(&plugin_yaml) {
+    let manifest: PluginManifest = match serde_yaml_ng::from_str(&plugin_yaml) {
         Ok(m) => m,
         Err(err) => {
             logging::warn(
@@ -491,7 +491,7 @@ fn load_driver_entry_into_staged(
         }
     };
 
-    let driver: DriverManifest = match serde_yml::from_str(&driver_yaml) {
+    let driver: DriverManifest = match serde_yaml_ng::from_str(&driver_yaml) {
         Ok(d) => d,
         Err(err) => {
             logging::warn(

--- a/crates/midori-runtime/src/profile.rs
+++ b/crates/midori-runtime/src/profile.rs
@@ -59,7 +59,7 @@ pub struct ProfileConnection {
     pub driver: String,
     /// driver 固有の追加フィールド（`device_name` / `host` / `port` 等）。
     #[serde(flatten)]
-    pub extra: BTreeMap<String, serde_yml::Value>,
+    pub extra: BTreeMap<String, serde_yaml_ng::Value>,
 }
 
 /// profile YAML のロード失敗。
@@ -73,7 +73,7 @@ pub enum ProfileLoadError {
     /// YAML パース / deserialize 失敗。
     Parse {
         path: PathBuf,
-        source: serde_yml::Error,
+        source: serde_yaml_ng::Error,
     },
     /// パースは通ったが意味論的に invalid（inputs / outputs が空など）。
     Invalid { path: PathBuf, message: String },
@@ -121,7 +121,7 @@ pub fn load_from_path(path: &Path) -> Result<ProfileYaml, ProfileLoadError> {
         source,
     })?;
     let profile: ProfileYaml =
-        serde_yml::from_str(&yaml).map_err(|source| ProfileLoadError::Parse {
+        serde_yaml_ng::from_str(&yaml).map_err(|source| ProfileLoadError::Parse {
             path: path.to_path_buf(),
             source,
         })?;
@@ -369,11 +369,11 @@ outputs:
         let osc = &profile.outputs[0].connection;
         assert_eq!(
             osc.extra.get("host"),
-            Some(&serde_yml::Value::String("127.0.0.1".into()))
+            Some(&serde_yaml_ng::Value::String("127.0.0.1".into()))
         );
         assert_eq!(
             osc.extra.get("port"),
-            Some(&serde_yml::Value::Number(9000.into()))
+            Some(&serde_yaml_ng::Value::Number(9000.into()))
         );
     }
 
@@ -390,9 +390,9 @@ outputs:
         // の path を作るため、`..` / path separator が入った driver 名は
         // plugins ディレクトリを脱出させ得る。`validate_driver_name` が
         // `ProfileLoadError::Invalid` として弾くことを担保する。
-        // （null byte / 制御文字は serde-yml 側で `Parse` 段階で拒否される
+        // （null byte / 制御文字は YAML パーサ側で `Parse` 段階で拒否される
         // ため本テストの対象外。validate_driver_name の defensive check は
-        // serde-yml が将来仕様変更しても破綻しないための二段防御として
+        // YAML パーサが将来仕様変更しても破綻しないための二段防御として
         // 残してある。）
         for bad in ["../etc/passwd", "midi/../../foo", "a/b", "a\\b", "..", "."] {
             let yaml = format!(
@@ -416,7 +416,7 @@ outputs:
     #[test]
     fn it_should_reject_driver_name_with_windows_reserved_characters() {
         // Windows のファイル名で許容されない文字を含む driver 名を一律 reject。
-        // `"` は YAML 文字列終端と衝突するため serde-yml 側で `Parse` エラーに
+        // `"` は YAML 文字列終端と衝突するため YAML パーサ側で `Parse` エラーに
         // なるが、いずれにしても driver 名としては受理されないため両 variant
         // を許容する。
         for bad in [


### PR DESCRIPTION
## Summary
- `midori-runtime` の YAML パーサを unmaintained な `serde_yml` から maintained な `serde_yaml_ng` に置換
- CodeRabbit が PR #47 で critical finding として `unmaintained: serde_yml` を指摘していたのを解消
- events.yaml / plugin.yaml / driver.yaml / profile.yaml の wire format は変更なし

## Changes
- `crates/midori-runtime/Cargo.toml`: `serde_yml = "0.0.12"` → `serde_yaml_ng = "0.10"`
- `events_schema/{loader,types,validator}.rs`, `events_pipeline/{runtime_check,tests}.rs`, `events_schema/tests.rs`, `plugin_resolver.rs`, `profile.rs`, `main.rs` の `serde_yml::*` 参照を `serde_yaml_ng::*` に置換
- 公開型 `LoadError::Parse.source` / `ProfileLoadError::Parse.source` / `FieldSpec.default` / `RangeBound.{min,max}` / `ProfileConnection.extra` / `yaml_to_f64` の引数型などに `serde_yaml_ng::{Value,Error}` がそのまま現れる（`midori-runtime` 内部完結のため意図的に alias を介さない）
- `cargo tree -p midori-runtime` から `serde_yml` が完全消滅、推移依存も `unsafe-libyaml v0.2.11` のみ

## Test
- `cargo build --workspace --all-targets`（warning ゼロ）
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --workspace`（midori-runtime: 137 + 5、midori-core: 29、その他全グリーン）
- 既存の YAML フィクスチャ（`midi_schema()` 等の events.yaml 文字列、plugin.yaml / driver.yaml / profile.yaml ハーネス）は無変更で新パーサでも受理されることをテスト全 pass で確認

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * YAML処理ライブラリを更新し、ランタイムの安定性とメンテナンス性を向上させました。

* **Tests**
  * 関連するテストを新しいライブラリに対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->