### PR TITLE
chore(claude): add CLAUDE.md philosophy and project-local flow skills

### DIFF
--- a/.claude/skills/create-prs-as-draft-until-ready/SKILL.md
+++ b/.claude/skills/create-prs-as-draft-until-ready/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: create-prs-as-draft-until-ready
+description: Use this skill before running `gh pr create` for any branch in this repository. PRs in this repo are created as draft and only marked ready after local pre-merge reviews complete; this prevents GitHub-side automated reviewers (CodeRabbit) from firing prematurely on an unreviewed change. Triggers on "PR を作る", "open a PR", "create pull request", and any moment Claude is about to compose a `gh pr create` command.
+---
+
+# create-prs-as-draft-until-ready
+
+New PRs are created **with `--draft`** and only transitioned to ready *after* local pre-merge reviews complete.
+
+## Core rule
+
+- `gh pr create` must always include `--draft`.
+- Mark the PR ready (`gh pr ready <N>`) only after the local pre-merge review loop completes with no outstanding actionable findings (skill: `run-local-code-review-before-push`).
+
+## Why
+
+GitHub-side reviewers (notably CodeRabbit) fire automatically when a PR enters `ready` state. Running a half-reviewed change through them wastes their quota and produces noisy comment threads that need manual cleanup. Keeping the PR draft until local review settles ensures CodeRabbit only sees the final pass.
+
+## Operational sequence
+
+1. Push branch to origin.
+2. `gh pr create --draft --title "..." --body "..."` — include the conventional body sections (Summary / Changes / Test, plus `Closes #N` where applicable).
+3. Run the local pre-merge review loop (skill: `run-local-code-review-before-push`).
+4. Address any actionable findings, push follow-up commits.
+5. Once local review returns no actionable findings, `gh pr ready <N>`.
+6. Hand off to the user for merge (skill: `defer-pr-merge-to-user`).
+
+## Anti-patterns
+
+- ❌ `gh pr create` without `--draft`.
+- ❌ Marking the PR ready before local review has run.
+- ❌ Marking the PR ready while actionable findings from local review are still unaddressed.
+- ✅ `gh pr create --draft` → local review → fixes → `gh pr ready` → hand off to user.

--- a/.claude/skills/create-prs-as-draft-until-ready/SKILL.md
+++ b/.claude/skills/create-prs-as-draft-until-ready/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-prs-as-draft-until-ready
-description: Use this skill before running `gh pr create` for any branch in this repository. PRs in this repo are created as draft and only marked ready after local pre-merge reviews complete; this prevents GitHub-side automated reviewers (CodeRabbit) from firing prematurely on an unreviewed change. Triggers on "PR を作る", "open a PR", "create pull request", and any moment Claude is about to compose a `gh pr create` command.
+description: Use this skill before running `gh pr create` for any branch in this repository. PRs in this repo are created as draft and only marked ready after local pre-merge reviews complete; this prevents GitHub-side automated reviewers (CodeRabbit) from firing prematurely on an unreviewed change. Triggers on "PR を作る", "PR 作成", "PR 出して", "プルリク作って", "ドラフト PR", "open a PR", "create pull request", "draft PR", and any moment Claude is about to compose a `gh pr create` command.
 ---
 
 # create-prs-as-draft-until-ready
@@ -10,7 +10,7 @@ New PRs are created **with `--draft`** and only transitioned to ready *after* lo
 ## Core rule
 
 - `gh pr create` must always include `--draft`.
-- Mark the PR ready (`gh pr ready <N>`) only after the local pre-merge review loop completes with no outstanding actionable findings (skill: `run-local-code-review-before-push`).
+- Mark the PR ready (`gh pr ready <N>`) only after the local pre-merge review loop completes with no outstanding actionable findings (skill: `run-local-code-review-before-marking-ready`).
 
 ## Why
 
@@ -20,7 +20,7 @@ GitHub-side reviewers (notably CodeRabbit) fire automatically when a PR enters `
 
 1. Push branch to origin.
 2. `gh pr create --draft --title "..." --body "..."` — include the conventional body sections (Summary / Changes / Test, plus `Closes #N` where applicable).
-3. Run the local pre-merge review loop (skill: `run-local-code-review-before-push`).
+3. Run the local pre-merge review loop (skill: `run-local-code-review-before-marking-ready`).
 4. Address any actionable findings, push follow-up commits.
 5. Once local review returns no actionable findings, `gh pr ready <N>`.
 6. Hand off to the user for merge (skill: `defer-pr-merge-to-user`).

--- a/.claude/skills/defer-implementing-midi-driver-to-user/SKILL.md
+++ b/.claude/skills/defer-implementing-midi-driver-to-user/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: defer-implementing-midi-driver-to-user
+description: Use this skill before writing or editing implementation code under `crates/midori-driver-midi/`. The user implements this crate themselves as a Rust learning exercise; Claude assists with design, review, and explanation but does not produce implementation code in this crate. Triggers on any Edit / Write / NotebookEdit targeting `crates/midori-driver-midi/src/**`, plus natural-language requests like "MIDI driver の実装", "midi-driver 書いて", "implement the MIDI driver".
+---
+
+# defer-implementing-midi-driver-to-user
+
+Implementation code under `crates/midori-driver-midi/` is **written by the user**, not by Claude. The crate exists primarily as a Rust learning vehicle for the user; Claude generating the code defeats that purpose.
+
+## Core rule
+
+- Do not produce implementation code (`fn` bodies, `impl` blocks, type definitions, module wiring) under `crates/midori-driver-midi/src/**`.
+- Tests in the same crate (`crates/midori-driver-midi/src/**/*tests*.rs`, `tests/`) follow the same rule — the user writes them.
+- `Cargo.toml`, `README.md`, and structural scaffolding files are exempt — Claude may edit those when needed for the broader workspace (e.g. dependency updates, lint config alignment).
+
+## What Claude does instead
+
+When the user is working on `midori-driver-midi`:
+
+- **Design support**: discuss API shape, error model, lifecycle, threading, FFI boundaries. Refer to `design/10-driver-plugin.md`, `design/17-driver-comm/`, and the `events.yaml` spec.
+- **Explanation**: walk through Rust idioms, `serde` patterns, `tokio` / `crossbeam` / channel choices, error propagation, when the user asks.
+- **Review**: read user-written code, point out bugs, suggest refactors, flag inconsistencies with the design docs. The user applies the changes.
+- **Investigation**: read related crates (`midori-core`, `midori-runtime`, other drivers) to answer questions about how `midori-driver-midi` fits the larger system.
+
+## What Claude does NOT do
+
+- Write `fn handle_event(...)` bodies in this crate.
+- Add new types, traits, or modules to this crate.
+- Apply diffs that the user requested in vague terms ("いい感じに直して") to this crate. Instead, propose the diff in chat for the user to apply.
+- Run `cargo fmt` / `cargo clippy --fix` against this crate without the user opting in turn-by-turn (formatter / linter changes still touch user-authored code).
+
+## Edge cases
+
+- **Mechanical workspace-wide changes** (e.g. dependency rename like the MEW-60 `serde_yml` → `serde_yaml_ng` migration) MAY touch this crate when the user has explicitly authorized a workspace-scoped change. Confirm scope before applying.
+- **CI / lint failures originating from this crate** — surface them with explanation; do not silently fix them.
+- **User pastes code and asks "review this"** — read-only review; do not commit a "fix" branch on their behalf.
+
+## Why
+
+The user is learning Rust. Production code from Claude in this crate would deny them practice on idioms, ownership, async, and FFI — the parts they want to internalize. Claude's value here is *unblocking understanding*, not *producing artifacts*.

--- a/.claude/skills/defer-pr-merge-to-user/SKILL.md
+++ b/.claude/skills/defer-pr-merge-to-user/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: defer-pr-merge-to-user
+description: Use this skill before running `gh pr merge` or `gh pr review --approve` against any PR (including PRs reviewed by /soloscrum:review, automated reviewers, or local reviewers). The user holds the final approve / merge authority; Claude must stop after presenting a Pass summary instead of merging. Triggers on "PR をマージ", "merge PR", "approve PR", "ready にする", a `/soloscrum:review` Pass verdict, and any moment Claude is about to compose `gh pr merge` or `gh pr review --approve`.
+---
+
+# defer-pr-merge-to-user
+
+Final approve and merge of any PR is performed **by the user**, never by Claude. Claude assembles the verdict material and stops at the summary.
+
+## Core rule
+
+- Do not call `gh pr merge`.
+- Do not call `gh pr review --approve` (GitHub also rejects self-approval with "Can not approve your own pull request", but the rule is to not attempt it regardless).
+- `gh pr ready` (draft → ready transition) **is** allowed once local pre-merge reviews are complete. Do not conflate the ready transition with merge.
+
+## When this skill should fire
+
+- Right after `/soloscrum:review` returns a Pass verdict.
+- When the user asks "マージしよう" / "merge it" / "approve to merge" or similar in natural language.
+- The instant Claude is about to compose `gh pr merge` or `gh pr review --approve` — re-read this skill body before issuing the command.
+
+## What to present at Pass verdict
+
+1. **AC reconciliation**: walk every literal AC checkbox from the Issue body. Bucket as satisfied / out-of-scope (carved into a separate Issue) / unmet.
+2. **DoD checklist**: verdict against `soloscrum-define-dod` plus `.claude/rules/dod-extra.md` if it exists.
+3. **CI / automated review status**: per-check SUCCESS / FAILURE, count of CodeRabbit actionable comments, any pre-merge gate results.
+4. **Outstanding concerns**: things the user may want to confirm before merging (e.g. expected auto-close on `Closes #N`, existence of carve-out Issues, branch protection state).
+5. **Declared post-merge follow-up**: the work Claude will pick up *after* the user merges (Linear status transition, post-merge AC verification, task cleanup).
+
+After presenting, wait for the next user input. **Do not advance to merge.**
+
+## After the user merges
+
+Once Claude can verify the user has merged (e.g. `gh pr view <N> --json state,mergedAt` shows `MERGED`), proceed autonomously with:
+
+- Transition the Linear Issue to Done.
+- Confirm the GitHub Issue auto-closed via the PR body's `Closes #N`.
+- Execute any post-merge AC items from the Issue body (e.g. re-run CodeRabbit and confirm the targeted finding count is zero).
+- Close out related task tracker entries.
+
+## Why
+
+The final gate into `main` is something the user wants to hold personally. CI, CodeRabbit, `/code-review`, and `soloscrum-review` verdicts are *evidence*, not *authority*. Auto-merging removes the user's ability to time the merge against other in-flight work, perform a final visual check, or coordinate with downstream consumers.
+
+## Anti-patterns
+
+- ❌ Treating a Pass verdict as authorization to merge ("Pass なのでマージします").
+- ❌ Composing `gh pr merge --squash --delete-branch` (or any merge variant).
+- ❌ Asking the user "Shall I merge?" and merging on a "yes" — even an explicit yes does not transfer the merge action to Claude. The user must run merge themselves.
+- ✅ "マージ準備完了。GitHub UI でマージしてください。マージ確認後 post-merge 作業に移ります。" — and stop.

--- a/.claude/skills/route-task-management-through-soloscrum/SKILL.md
+++ b/.claude/skills/route-task-management-through-soloscrum/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: route-task-management-through-soloscrum
+description: Use this skill whenever a task-management intent surfaces — creating an Issue, picking the next task, decomposing a feature, estimating SP, setting priority, transitioning status, or asking "what should I do next". All such intents are routed through soloscrum slash commands rather than handled ad hoc. Triggers on "issue を起票", "次のタスク", "分解", "優先度", "SP", "進捗", "create an issue", "what's next", "break this down".
+---
+
+# route-task-management-through-soloscrum
+
+All task lifecycle work is delegated to soloscrum's slash commands. Do not improvise issue creation, priority decisions, decomposition, or status transitions outside this routing.
+
+## Core rule
+
+When a task-management intent surfaces, route it to the appropriate soloscrum command instead of handling it directly:
+
+| Intent | Command |
+|---|---|
+| Turn an idea / request into a tracked Issue | `/refine` |
+| Decompose an Issue into subtasks | `/breakdown` |
+| Pick the next task to work on | `/next` |
+| Check current state across Linear | `/status` |
+| Implement a develop subtask | `/develop` |
+| Review a PR / Figma against an Issue | `/review` |
+| Design UI in Figma | `/design-ui` |
+
+## Why
+
+Soloscrum encodes a consistent shape for Issues (format, size thresholds, priority criteria, SP scale) and ensures Linear / GitHub stay in sync. Bypassing it produces Issues that drift in shape, priority decisions that lack defensible rationale, and status that desyncs across tools. Routing through the slash commands keeps task management auditable and reproducible.
+
+## Operational sequence
+
+When the user expresses a task-management intent:
+
+1. Identify the matching command from the table above.
+2. Invoke it (`Skill` tool or instruct the user to type `/<command>`).
+3. The relevant soloscrum subagent (`soloscrum-po`, `soloscrum-dev`, `soloscrum-review`, etc.) handles the structured work.
+4. Present the subagent's structured output to the user with the rationale alongside the conclusion (per CLAUDE.md `## Task design`).
+
+If the intent is ambiguous (e.g. "整理して" — could be `/refine` or `/breakdown` depending on whether an Issue exists), surface the ambiguity and ask which entry point fits.
+
+## Anti-patterns
+
+- ❌ Directly call `gh issue create` / `mcp__linear-server__save_issue` outside a `/refine` flow.
+- ❌ Decide priority or SP unilaterally without going through soloscrum-po's criteria (`soloscrum-define-priority`, `soloscrum-define-story-points`).
+- ❌ Decompose a task into subtasks ad hoc instead of running `/breakdown`.
+- ❌ Transition a Linear status manually outside the post-merge / post-review hand-off declared in `defer-pr-merge-to-user`.
+- ✅ Receive intent → route to soloscrum command → present structured output with rationale.
+
+## Edge case: Linear-side mechanical updates
+
+After the user merges a PR, transitioning the corresponding Linear Issue to Done is a **mechanical follow-through** of the soloscrum `/review` flow, not an ad hoc decision. This kind of post-merge sync is allowed without re-invoking a soloscrum command. The same applies to GitHub Issue auto-close via `Closes #N`.

--- a/.claude/skills/run-local-code-review-before-marking-ready/SKILL.md
+++ b/.claude/skills/run-local-code-review-before-marking-ready/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: run-local-code-review-before-push
+name: run-local-code-review-before-marking-ready
 description: Use this skill when a feature branch is ready to be reviewed against `main` — typically after `gh pr create --draft` has produced a draft PR, but before marking it ready. Runs `/code-review:code-review` and `/coderabbit:review` locally so issues are caught before GitHub-side reviewers fire. Triggers on "ローカルレビュー", "事前レビュー", "pre-merge review", "before marking ready", and any moment Claude is about to call `gh pr ready` without having run local reviews.
 ---
 
-# run-local-code-review-before-push
+# run-local-code-review-before-marking-ready
 
 Before transitioning a draft PR to ready, run **both** local reviewers — they cover different ground and the union of findings is what should be addressed.
 

--- a/.claude/skills/run-local-code-review-before-push/SKILL.md
+++ b/.claude/skills/run-local-code-review-before-push/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: run-local-code-review-before-push
+description: Use this skill when a feature branch is ready to be reviewed against `main` — typically after `gh pr create --draft` has produced a draft PR, but before marking it ready. Runs `/code-review:code-review` and `/coderabbit:review` locally so issues are caught before GitHub-side reviewers fire. Triggers on "ローカルレビュー", "事前レビュー", "pre-merge review", "before marking ready", and any moment Claude is about to call `gh pr ready` without having run local reviews.
+---
+
+# run-local-code-review-before-push
+
+Before transitioning a draft PR to ready, run **both** local reviewers — they cover different ground and the union of findings is what should be addressed.
+
+## Core rule
+
+- After the draft PR exists (skill: `create-prs-as-draft-until-ready`) and before `gh pr ready`, run:
+  1. `/code-review:code-review <PR URL>` — Anthropic-style multi-agent review
+  2. `/coderabbit:review` — local CodeRabbit CLI review against committed changes
+- Address every actionable finding from either reviewer before marking ready. Cosmetic / out-of-scope items can be deferred but must be acknowledged in the PR thread or in a follow-up Issue.
+
+## Why
+
+The two reviewers have different strengths:
+
+- `/code-review:code-review` runs parallel sonnet/haiku agents against bug, history, prior-PR, and comment-guidance axes. Strong for behavioral and contextual issues.
+- `/coderabbit:review` mirrors the GitHub-side CodeRabbit pass that will fire when the PR is marked ready. Catching its findings locally avoids back-and-forth on the GitHub PR thread.
+
+Running both before `gh pr ready` keeps the GitHub-side CodeRabbit auto-review clean (often "no actionable comments") and reduces reviewer fatigue.
+
+## Operational sequence
+
+1. PR is in draft state.
+2. Invoke `/code-review:code-review <PR URL>`. Wait for verdict.
+3. Invoke `/coderabbit:review` (operates on committed changes by default; pass `-t uncommitted` if needed).
+4. Triage findings:
+   - Actionable + in-scope → fix on this branch, push follow-up commit
+   - Actionable + out-of-scope → file follow-up Issue and link from PR thread
+   - Cosmetic / disputed → note rationale in PR thread
+5. Re-run reviewers if substantial fixes were applied.
+6. Mark PR ready (`gh pr ready <N>`).
+
+## Anti-patterns
+
+- ❌ Skip either reviewer "to save time" — they cover different ground.
+- ❌ Mark PR ready while actionable findings are unaddressed.
+- ❌ Wait for GitHub-side CodeRabbit to surface findings on a ready PR (defeats the purpose of the draft window).
+- ✅ Both reviewers complete with 0 actionable findings (or all addressed) → `gh pr ready`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# midori — working principles
+
+This file defines how Claude collaborates on this repository. Skills handle per-action mechanics; this document holds the philosophy that shapes decisions when no skill matches.
+
+## Integrity-driven development
+
+The aim of every change — design doc, implementation, refactor, task design — is to leave the system more internally consistent than it was found. Inconsistency is the primary debt being paid down.
+
+- When editing design docs, exhaustively verify the change introduces no contradictions with other parts of the design (skill: `find-contradiction`). Surface every contradiction; never paper over.
+- When implementing, perform refactors needed for consistency *now*, not later. Deferred inconsistencies compound into cognitive load.
+- Comments and docs must stand alone (skills: `write-self-contained-comments`, `doc-context-free`). External references (PR / Issue numbers, conversation history) belong only in transient markers like TODO/FIXME.
+
+## Judgeability
+
+Every change that lands must remain judgeable by at least one party still in the loop — the user, or an automated review mechanism (`/code-review:code-review`, CodeRabbit, `soloscrum-review`). The failure mode is *code that exists but no one can evaluate*.
+
+- Speed is not the constraint. Bulk generation and mechanical migrations are fine when the change is explainable and the review loop can evaluate it.
+- The constraint: at least one judge must be able to follow what changed and why. If a change risks exceeding that — large surface, unfamiliar territory, intersecting layers — split and narrate it.
+- Judgeability can be served either by pre-confirmation or by post-hoc summary. Self-direction is the long-term mode; default to acting and then summarizing when integrity is clearly preserved. Pre-confirm when the action is irreversible or when the integrity case is uncertain.
+- In areas the user is actively learning (currently Rust broadly, and `crates/midori-driver-midi/` specifically), prefer smaller steps with explanations to preserve the user's ability to judge. The user implements `crates/midori-driver-midi/` themselves; Claude assists with design and review only.
+
+## Task design
+
+Priority and granularity decisions must be defensible — explainable from principles, not "feels right". When delegating these to soloscrum's PO step, present the rationale alongside the conclusion so the user can challenge or accept on substance.
+
+## Decision authority
+
+The final gate into `main` belongs to the user. CI green and review verdicts are *evidence*, not *authority* (skill: `defer-pr-merge-to-user`).
+
+## Tool stewardship
+
+- Persistent behavior lives in skills (action-triggered) or this document (always loaded). Memory is treated as volatile; do not rely on it for rules that must survive across sessions.
+- If a skill should have triggered but did not, fix the skill's description (and PR upstream where applicable). Do not patch around the gap with memory entries.
+
+## Workflow
+
+- Task lifecycle (refining, breakdown, prioritization, story points, status) is delegated to soloscrum: `/refine`, `/breakdown`, `/develop`, `/review`, `/next`, `/status`.
+- PR mechanics (draft until ready, pre-push local review, merge handoff to user) are encoded in project-local skills under `.claude/skills/`. See those skills for operational steps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ Every change that lands must remain judgeable by at least one party still in the
 
 Priority and granularity decisions must be defensible — explainable from principles, not "feels right". When delegating these to soloscrum's PO step, present the rationale alongside the conclusion so the user can challenge or accept on substance.
 
+Quality gate setup (linter / formatter / test infrastructure) precedes the implementation work that depends on it — order priorities so gates land before the features they protect.
+
 ## Decision authority
 
 The final gate into `main` belongs to the user. CI green and review verdicts are *evidence*, not *authority* (skill: `defer-pr-merge-to-user`).


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` at the repo root capturing the working philosophy: integrity-driven development, judgeability as the gate, defensible task design, user-held final merge authority, skill-and-this-doc as the persistence layer (memory volatile), soloscrum as the single task-lifecycle entry point.
- Add 5 action-triggered project-local skills under `.claude/skills/` that encode the per-action mechanics referenced from CLAUDE.md.
- No product code change; this PR establishes the meta-tooling layer that should reduce per-session drift in development flow.

## Why
Across recent sessions the dev flow has drifted (PR merge attempted by Claude, draft / ready transition skipped, local pre-PR review order shuffled). The drift mostly traces to flow rules living in volatile memory rather than always-loaded context (CLAUDE.md) or action-triggered skills. This PR moves the rules to where they will actually fire.

## Changes
- `CLAUDE.md` (new): philosophy in 6 sections — Integrity-driven development / Judgeability / Task design / Decision authority / Tool stewardship / Workflow.
- `.claude/skills/defer-pr-merge-to-user/SKILL.md`: stop before `gh pr merge` / `gh pr review --approve`; present a Pass summary and let the user merge.
- `.claude/skills/create-prs-as-draft-until-ready/SKILL.md`: always pass `--draft` to `gh pr create`; mark ready only after local pre-merge review settles.
- `.claude/skills/run-local-code-review-before-push/SKILL.md`: run both `/code-review:code-review` and `/coderabbit:review` after the draft PR exists, before `gh pr ready`.
- `.claude/skills/route-task-management-through-soloscrum/SKILL.md`: route every issue / task / priority / SP / status intent through soloscrum slash commands.
- `.claude/skills/defer-implementing-midi-driver-to-user/SKILL.md`: do not produce implementation code in `crates/midori-driver-midi/`; assist with design, review, and explanation only.

## Test
- `cargo` is unchanged; CI for Rust / JS / CodeQL should pass identically to `main`.
- No new dependencies, no source-code changes, no schema changes.
- Skills register correctly (verified via the available-skills list surfacing all 5 entries with their description triggers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * Claude協働作業の運用哲学と手順に関する新規ドキュメント「CLAUDE.md」を追加
  * PRを下書きとして作成し、レビュー完了後にマーク済みにするワークフローのスキルを追加
  * タスク管理をSoloScrumコマンドにルーティングするスキルを追加
  * PR統合をユーザーに委譲するスキルを追加

* **チューニング**
  * ローカルコード レビュー実行要件を追加
  * 特定コンポーネントの実装制限を設定

<!-- end of auto-generated comment: release notes by coderabbit.ai -->