### PR TITLE
ci(deps): add cargo-deny advisory check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,19 @@ jobs:
       - name: check (cross-platform)
         run: cargo check --workspace
 
+  rust-advisories:
+    name: Rust advisories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Advisory scan reads only Cargo.lock and the RustSec database, so
+      # one Linux invocation covers every target platform of the workspace.
+      # `command: check advisories` keeps the gate scoped to RUSTSEC entries
+      # while leaving licenses / bans / sources for a separate effort.
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+
   js:
     name: JS
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Quality gates and local-repro commands for the gates that CI enforces.
+
+## Rust advisory scan
+
+CI fails the PR if any RustSec advisory (vulnerability, unmaintained,
+unsound, notice, or yanked-crate entry) matches a crate in the workspace
+dependency graph.
+
+Reproduce the same gate locally:
+
+```sh
+cargo install cargo-deny --locked   # one-time
+cargo deny check advisories
+```
+
+The configuration lives in `deny.toml` at the repo root. Acknowledged
+advisories (with reason and revisit timing) belong in the
+`[advisories].ignore` list there — never silenced inline.
+
+## Rust format / lint / test
+
+```sh
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+## JS / TS lint and format
+
+```sh
+pnpm install --frozen-lockfile
+pnpm check
+pnpm format:check
+```

--- a/deny.toml
+++ b/deny.toml
@@ -21,10 +21,11 @@ all-features = true
 # during the run.
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# Hard-fail on yanked crates as well as the default-denied vulnerability,
-# unmaintained, unsound, and notice categories. Keeping these at the
-# default "deny" level is the whole point of the scan — downgrading any
-# of them silently re-opens the gap this configuration was added to close.
+# `vulnerability` / `unmaintained` / `unsound` / `notice` already default to
+# `deny` in cargo-deny; `yanked` defaults to `warn`, so it is upgraded here
+# to match the error-level behavior of the others. Keeping every category at
+# `deny` is the whole point of the scan — downgrading any of them silently
+# re-opens the gap this configuration was added to close.
 yanked = "deny"
 # Format: ["RUSTSEC-YYYY-NNNN"] with a comment per entry recording why
 # the advisory is acknowledged and (where reasonable) when to revisit.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,36 @@
+# cargo-deny configuration
+#
+# Scope: advisory scanning only. License, ban, and source policies are
+# intentionally left unconfigured so cargo-deny applies its built-in
+# defaults; tightening those is tracked as a separate effort.
+#
+# Run locally:
+#   cargo deny check advisories
+#
+# CI invokes the same subcommand, so a clean local run mirrors the
+# gate that protects `main`.
+
+[graph]
+# Evaluate the full dependency graph regardless of host/target. CI runs
+# only on Linux but the workspace ships drivers used on macOS / Windows,
+# so advisories on platform-specific deps must still surface.
+all-features = true
+
+[advisories]
+# RustSec advisory database. cargo-deny clones / refreshes this path
+# during the run.
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# Hard-fail on yanked crates as well as the default-denied vulnerability,
+# unmaintained, unsound, and notice categories. Keeping these at the
+# default "deny" level is the whole point of the scan — downgrading any
+# of them silently re-opens the gap this configuration was added to close.
+yanked = "deny"
+# Format: ["RUSTSEC-YYYY-NNNN"] with a comment per entry recording why
+# the advisory is acknowledged and (where reasonable) when to revisit.
+ignore = []
+
+# [licenses], [bans], [sources] are intentionally omitted. cargo-deny
+# applies permissive defaults for them, so `cargo deny check advisories`
+# is unaffected; introducing license / ban / source policy is tracked
+# as a separate effort.


### PR DESCRIPTION
## Summary

- Wire `cargo-deny` into CI so RustSec advisories hard-fail PRs and pushes to `main`.
- Covers the AC verification gap from the recent `serde_yml` -> `serde_yaml_ng` swap (the unmaintained-crate advisory was caught only by an external reviewer; CI was silent).
- Configures `[advisories]` only; license / ban / source policy is intentionally deferred.

## Tool choice — cargo-deny

Picked `cargo-deny` over `cargo audit`:
- The workspace is set to grow (multiple drivers / SDK bindings); future license / ban / source policies can ride on the same tool and config file rather than introducing a second one.
- `cargo-deny` covers `cargo audit`'s RustSec scope plus the four extra advisory categories (`unmaintained`, `unsound`, `notice`, `yanked`). The `serde_yml` advisory that motivated this Issue is `unsound + unmaintained`, which `cargo audit`'s default profile would not have flagged.
- Embark publishes `cargo-deny-action@v2`, so CI integration is one step.

`[licenses]` / `[bans]` / `[sources]` are left at cargo-deny defaults; tightening those is out of scope here.

## Changes

- `deny.toml` (new) — `[advisories]` config; ignore list empty.
- `.github/workflows/ci.yml` — new `rust-advisories` job (Ubuntu, runs once; scan is OS-independent) using `EmbarkStudios/cargo-deny-action@v2` with `command: check advisories`.
- `CONTRIBUTING.md` (new) — local-repro commands for every CI gate.

## Regression check — would CI have caught the MEW-60 advisory?

Reproduced against the parent of `12fbb01` (the `serde_yml` -> `serde_yaml_ng` swap) using a scratch worktree with the new `deny.toml` copied in. `cargo deny check advisories` exited non-zero:

\`\`\`
error[unsound]: serde_yml crate is unsound and unmaintained
   ID: RUSTSEC-2025-0068
   Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0068
   serde_yml v0.0.12
     -> midori-runtime v0.1.0

advisories FAILED
\`\`\`

So the configured CI would have blocked the pre-swap dep tree. (Scratch worktree was discarded; not pushed.)

## DoD

- [x] Tool selected and rationale recorded (this body + comment header in `deny.toml`)
- [x] Config committed at repo root (`deny.toml`)
- [x] CI runs the scan on PR + push-to-main (new `rust-advisories` job; uses workflow-level `on:` trigger covering both)
- [x] CI fails (not warns) — `cargo-deny-action` propagates the non-zero exit; no `continue-on-error`
- [x] Local 1-command repro in `CONTRIBUTING.md` (`cargo deny check advisories`)
- [x] Initial scan: 0 advisories on current `main` dep tree (`advisories ok`)
- [x] Regression check: `serde_yml` RUSTSEC-2025-0068 reproduced as `advisories FAILED` against pre-swap commit (output above)

## Test plan

- [ ] CI: `rust-advisories` job runs on this PR and reports green
- [ ] CI: existing `Rust (ubuntu/macos/windows)` and `JS` jobs still pass

## Related

Closes MEW-61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * コントリビューションガイドを追加しました。品質管理プロセスとローカル環境での検証方法を記載しています。

* **Chores**
  * Rustセキュリティアドバイザリースキャンを継続的インテグレーションパイプラインに統合しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->