### PR TITLE
chore(claude): document autonomy default in pre-ready review skill

### DIFF
--- a/.claude/skills/run-local-code-review-before-marking-ready/SKILL.md
+++ b/.claude/skills/run-local-code-review-before-marking-ready/SKILL.md
@@ -35,9 +35,19 @@ Running both before `gh pr ready` keeps the GitHub-side CodeRabbit auto-review c
 5. Re-run reviewers if substantial fixes were applied.
 6. Mark PR ready (`gh pr ready <N>`).
 
+## Autonomy
+
+- Both reviewers green (or all findings addressed) is the unambiguous trigger for `gh pr ready` — proceed without pre-confirmation. The action is reversible (`gh pr ready --undo`).
+- Pre-confirm only when one of these is true:
+  - A reviewer raised a judgment-required item that needs the user to adjudicate (scope, design tradeoff, "is this even the right approach")
+  - Addressing the findings expanded the PR beyond its originating Issue's scope
+  - Local sanity checks (formatter / lint / tests / project-specific gates) failed and direction is needed on whether to fix in this PR or defer
+- Otherwise: fix → push → `gh pr ready` → Linear → In Review → summarize. No pre-confirmation prompt.
+
 ## Anti-patterns
 
 - ❌ Skip either reviewer "to save time" — they cover different ground.
 - ❌ Mark PR ready while actionable findings are unaddressed.
 - ❌ Wait for GitHub-side CodeRabbit to surface findings on a ready PR (defeats the purpose of the draft window).
-- ✅ Both reviewers complete with 0 actionable findings (or all addressed) → `gh pr ready`.
+- ❌ Pause for user go-ahead before `gh pr ready` when reviewers are green and the fix stayed in scope.
+- ✅ Both reviewers complete with 0 actionable findings (or all addressed) → `gh pr ready` autonomously.


### PR DESCRIPTION
## Summary

Adds an **Autonomy** section to `.claude/skills/run-local-code-review-before-marking-ready/SKILL.md` so a future reader knows when to proceed to `gh pr ready` without pre-confirmation.

The previous skill described the operational sequence (run `/code-review:code-review`, then `/coderabbit:review`, then `gh pr ready`) but did not call out the autonomy posture. That ambiguity led to redundant pre-confirmation prompts during a real `develop` flow earlier today.

## Why

CLAUDE.md states: "Self-direction is the long-term mode; default to acting and then summarizing when integrity is clearly preserved. Pre-confirm when the action is irreversible or when the integrity case is uncertain." `gh pr ready` is reversible (`gh pr ready --undo`), so blanket pre-confirmation contradicts the project's stated working principle.

## What changed

- New **Autonomy** section listing the unambiguous trigger to proceed (both reviewers green / findings addressed) and the narrow exceptions that warrant pre-confirmation (judgment-required reviewer items, scope expansion beyond the originating Issue, sanity-check failures).
- One additional anti-pattern bullet covering the redundant pre-confirmation prompt case.

## Test plan

- [x] `git diff main...HEAD -- .claude/skills/run-local-code-review-before-marking-ready/SKILL.md` reads cleanly without session-specific context (verified that no Japanese phrases or tool names tied to a particular PR survive in the skill body)
- [x] Skill frontmatter unchanged; trigger description still matches existing invocation behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* PR 準備完了マークアップの自動実行ポリシーを明確化しました。レビュー結果に基づく条件付き自動処理と確認が必要なシナリオを定義し、運用ガイドラインを更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->