### PR TITLE
ci(deps): expand cargo-deny gate to licenses/bans/sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,19 @@ jobs:
       - name: check (cross-platform)
         run: cargo check --workspace
 
-  rust-advisories:
-    name: Rust advisories
+  rust-deny:
+    name: Rust cargo-deny
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Advisory scan reads only Cargo.lock and the RustSec database, so
-      # one Linux invocation covers every target platform of the workspace.
-      # `command: check advisories` keeps the gate scoped to RUSTSEC entries
-      # while leaving licenses / bans / sources for a separate effort.
+      # cargo-deny reads only Cargo.lock plus its configuration, so one
+      # Linux invocation covers every target platform of the workspace.
+      # The default `check` subcommand exercises advisories, licenses,
+      # bans, and sources together; the policy for each section lives
+      # in `deny.toml`.
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check advisories
+          command: check
 
   js:
     name: JS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
 
+# Read-only is sufficient for every job in this workflow: cargo / cargo-deny
+# / pnpm-biome all consume the checked-out tree without writing to PRs,
+# Releases, or Pages. Pinning to a minimal scope follows the GitHub
+# Actions hardening guidance flagged by CodeQL `actions/missing-workflow-permissions`.
+permissions:
+  contents: read
+
 jobs:
   rust:
     name: Rust (${{ matrix.os }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,22 +2,32 @@
 
 Quality gates and local-repro commands for the gates that CI enforces.
 
-## Rust advisory scan
+## Rust dependency policy (cargo-deny)
 
-CI fails the PR if any RustSec advisory (vulnerability, unmaintained,
-unsound, notice, or yanked-crate entry) matches a crate in the workspace
-dependency graph.
+CI fails the PR if any of the following surface in the workspace
+dependency graph:
+
+- **advisories** — RustSec vulnerability, unmaintained, unsound, notice,
+  or yanked-crate entries.
+- **licenses** — a crate whose license is not in the `[licenses].allow`
+  list and not acknowledged in `[licenses.exceptions]`.
+- **bans** — a wildcard version requirement, or a crate listed in
+  `[bans].deny`. Multiple-version duplicates surface as warnings (not
+  errors) for now.
+- **sources** — a crate sourced from anywhere other than crates.io
+  (`https://github.com/rust-lang/crates.io-index`).
 
 Reproduce the same gate locally:
 
 ```sh
 cargo install cargo-deny --locked   # one-time
-cargo deny check advisories
+cargo deny check
 ```
 
 The configuration lives in `deny.toml` at the repo root. Acknowledged
-advisories (with reason and revisit timing) belong in the
-`[advisories].ignore` list there — never silenced inline.
+advisories belong in `[advisories].ignore` (with reason and revisit
+timing); per-crate license carve-outs belong in `[licenses.exceptions]`
+(with a one-line justification). Never silence findings inline.
 
 ## Rust format / lint / test
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,14 +1,11 @@
 # cargo-deny configuration
 #
-# Scope: advisory scanning only. License, ban, and source policies are
-# intentionally left unconfigured so cargo-deny applies its built-in
-# defaults; tightening those is tracked as a separate effort.
-#
 # Run locally:
-#   cargo deny check advisories
+#   cargo deny check
 #
-# CI invokes the same subcommand, so a clean local run mirrors the
-# gate that protects `main`.
+# CI invokes the same command, so a clean local run mirrors the gate that
+# protects `main`. The default `cargo deny check` exercises every section
+# below: advisories, licenses, bans, and sources.
 
 [graph]
 # Evaluate the full dependency graph regardless of host/target. CI runs
@@ -31,7 +28,75 @@ yanked = "deny"
 # the advisory is acknowledged and (where reasonable) when to revisit.
 ignore = []
 
-# [licenses], [bans], [sources] are intentionally omitted. cargo-deny
-# applies permissive defaults for them, so `cargo deny check advisories`
-# is unaffected; introducing license / ban / source policy is tracked
-# as a separate effort.
+[licenses]
+# SPDX expressions allowed workspace-wide. Restricted to permissive
+# licenses that are compatible with an eventual crates.io publish track
+# for `midori-core` / `midori-sdk` (both currently MIT OR Apache-2.0).
+# Only licenses actually present in the current dependency graph are
+# listed; introducing a new permissive license should be an explicit,
+# reviewed addition rather than a pre-allowlisted blanket.
+# Any license outside this list must be acknowledged per-crate in
+# `[licenses.exceptions]` below, with a one-line justification.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-3.0",
+]
+# Confidence threshold for license-text matching. 0.8 is the cargo-deny
+# default; raising it would reject licenses with minor textual drift,
+# lowering it would accept noisy matches. Keep at the default unless a
+# specific crate forces a justified deviation.
+confidence-threshold = 0.8
+
+[[licenses.exceptions]]
+# Build-time C-header generator for the SDK FFI surface. MPL-2.0 is
+# file-level weak copyleft; using cbindgen as an unmodified tool does
+# not propagate to the consuming workspace.
+name = "cbindgen"
+allow = ["MPL-2.0"]
+
+[[licenses.exceptions]]
+# Transitive dep of `dirs` → `dirs-sys`. MPL-2.0 obligations apply only
+# to modified upstream files, which the workspace does not do.
+name = "option-ext"
+allow = ["MPL-2.0"]
+
+[[licenses.exceptions]]
+# Public-domain dedication used by the `memchr` crate. Functionally
+# permissive but kept as a per-crate exception so it does not implicitly
+# allow Unlicense-only code to enter the workspace elsewhere.
+name = "memchr"
+allow = ["Unlicense"]
+
+[[licenses.exceptions]]
+# Boost Software License is permissive and OSI-approved. Scoped to
+# `ryu` so unrelated BSL-1.0 deps would still require a deliberate
+# review before being admitted.
+name = "ryu"
+allow = ["BSL-1.0"]
+
+[bans]
+# Surface duplicate versions of the same crate without failing CI.
+# Multiple-versions noise is a quality signal worth seeing on every PR;
+# tightening to `deny` is deferred until the dep graph stabilizes.
+multiple-versions = "warn"
+# Wildcard version requirements (`*`) make Cargo.lock unpredictable;
+# fail the gate if one is introduced.
+wildcards = "deny"
+# Crates explicitly disallowed at the workspace level.
+deny = []
+# Crates whose presence is acknowledged and explicitly skipped from the
+# bans audit (e.g. multiple-versions exemptions). Empty until needed.
+skip = []
+skip-tree = []
+
+[sources]
+# Reject any crate sourced from a registry not listed in `allow-registry`
+# or from a git URL not listed in `allow-git`. The workspace publishes
+# (eventually) to crates.io, so anything outside crates.io is a release
+# blocker that must be made explicit before it lands.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -63,16 +63,19 @@ name = "option-ext"
 allow = ["MPL-2.0"]
 
 [[licenses.exceptions]]
-# Public-domain dedication used by the `memchr` crate. Functionally
-# permissive but kept as a per-crate exception so it does not implicitly
-# allow Unlicense-only code to enter the workspace elsewhere.
+# memchr's SPDX expression is `Unlicense OR MIT`, so today it satisfies
+# the global allow via MIT and the Unlicense branch goes unused. The
+# exception is kept as a safety net: if MIT is ever narrowed out of the
+# global allow, this entry keeps memchr compliant without admitting
+# Unlicense-only code from any other crate.
 name = "memchr"
 allow = ["Unlicense"]
 
 [[licenses.exceptions]]
-# Boost Software License is permissive and OSI-approved. Scoped to
-# `ryu` so unrelated BSL-1.0 deps would still require a deliberate
-# review before being admitted.
+# ryu's SPDX expression is `Apache-2.0 OR BSL-1.0`, so today it
+# satisfies the global allow via Apache-2.0. The BSL-1.0 entry is kept
+# as a safety net for if Apache-2.0 is narrowed later, without admitting
+# BSL-1.0 from any other crate.
 name = "ryu"
 allow = ["BSL-1.0"]
 


### PR DESCRIPTION
## Summary

Promotes the cargo-deny CI gate from advisories-only (introduced in #52 / MEW-61) to the full default suite, closing the deliberate Out-of-Scope deferral that landed with the original gate.

- `[licenses]` enumerates the permissive set actually present in today's dep graph (`MIT`, `Apache-2.0`, `Apache-2.0 WITH LLVM-exception`, `Unicode-3.0`). Four outliers are recorded as per-crate `[licenses.exceptions]` with one-line justifications: `cbindgen` / `option-ext` (MPL-2.0), `memchr` (Unlicense), `ryu` (BSL-1.0).
- `[bans]` sets `multiple-versions = \"warn\"` (deferred to `deny` per the Issue) and `wildcards = \"deny\"`.
- `[sources]` restricts crates to the crates.io registry; `unknown-registry` and `unknown-git` both `deny`. No `allow-git` entries were needed — the dep graph is 100% crates.io today.
- `.github/workflows/ci.yml` job runs `command: check` (full) instead of `command: check advisories`.
- Job renamed from `rust-advisories` to `rust-deny` since the old name now actively misleads. Verified `main` has no branch-protection required-checks that reference the old name.
- `deny.toml`'s leading comment block that said license / ban / source were intentionally deferred has been removed; the file now reads as a self-explanatory current-state config.
- `CONTRIBUTING.md` repro updated from `cargo deny check advisories` to `cargo deny check`, and the gate description rewritten to cover all four sections.

## Linear

- MEW-62 — https://linear.app/mewton/issue/MEW-62/tighten-cargo-deny-config-with-license-ban-and-source-policies

## DoD checklist

- [x] AC #1 — `[licenses]` allow list covers every license in the current dep graph
- [x] AC #2 — `[licenses.exceptions]` records every required carve-out with WHY comments
- [x] AC #3 — `[bans]` flags `multiple-versions` (warn, justified inline) and adds `wildcards = deny`
- [x] AC #4 — `[sources]` restricts to crates.io
- [x] AC #5 — CI runs `cargo deny check` (full) and will fail on license/ban/source violations
- [x] AC #6 — CONTRIBUTING repro updated to `cargo deny check`
- [x] AC #7 — Deferral comment removed from `deny.toml`
- [x] AC #8 — `cargo deny check` exits 0 locally; only multiple-versions warnings remain (warn, not silently escalated)

## Local verification

```text
cargo deny check         → exit 0   (advisories ok, bans ok, licenses ok, sources ok)
cargo fmt --all --check  → exit 0
cargo clippy ...         → exit 0
cargo test --workspace   → exit 0   (38 + 1 tests pass)
```

Multiple-version warnings surfaced (won't fail CI; tightening to `deny` is deferred per the Issue Notes):
- `getrandom` (0.2 vs 0.4)
- `windows-sys` (0.48 vs 0.61)
- `winnow` (0.7 vs 1.0)
- `wit-bindgen` (0.51 vs 0.57)

## Test plan

- [ ] CI green on the new `rust-deny` job (advisories + licenses + bans + sources all ok)
- [ ] CI green on existing rust matrix and js jobs (no regression)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * CI ワークフローを更新し、依存関係チェックを advisories のみからライセンス、禁止ルール、ソース検証を含む包括的なチェックへ拡張しました（cargo-deny を利用）。
* **ドキュメント**
  * 貢献ガイドを更新し、ローカル再現手順やライセンス例外の扱いなど、新しい依存関係ポリシーに関する説明を追加しました。
* **設定**
  * 依存関係ポリシー設定を拡充し、ライセンス許可リスト、例外、禁止ルール、ソース制限を明示しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->