### PR TITLE
docs(events-schema): finalize tier field cross-references (MEW-47)

### DIFF
--- a/design/16-driver-events-schema.md
+++ b/design/16-driver-events-schema.md
@@ -325,7 +325,7 @@ events:
     fields:
       payload:
         type: bytes
-        max_length: 1024  # SysEx payload の最大長（1 KiB）。実 ring の payload 収容量は実装の slot 設計による（design/17-driver-comm/01-inline-ring.md の DEFAULT_SLOT_SIZE / HARD_SLOT_SIZE 参照）
+        max_length: 1024  # MIDI SysEx 1 KiB 上限。inline tier の DEFAULT_SLOT_SIZE (1032 byte) - ヘッダ 8 byte = 1024 byte に収まる（典型 driver は handshake で slot_size 要求が不要）。slot_size 規約・HARD_SLOT_SIZE 上限は design/17-driver-comm/01-inline-ring.md 参照
     binding_filter: [type]
 ```
 

--- a/design/17-driver-comm/00-overview.md
+++ b/design/17-driver-comm/00-overview.md
@@ -27,7 +27,7 @@ driver の event は性質ごとに要求が異なる:
 
 ## tier 宣言の所在
 
-driver の `events.yaml` で **event 型ごとに `tier`** を宣言する（`design/16-driver-events-schema.md` の schema 拡張で `tier: inline | streamed` を追加予定）。default は `inline`。
+driver の `events.yaml` で **event 型ごとに `tier`** を宣言する（schema 文法は `design/16-driver-events-schema.md`「tier」節で `tier: inline | streamed` として定義）。default は `inline`。
 
 ```yaml
 events:
@@ -112,6 +112,6 @@ settle するまで、driver 作者は `tier: streamed` event を宣言しても
 ## 参考リンク
 
 - `design/15-sdk-bindings-api.md` — SDK バインディング API（C / Node / Python）と driver プロセスモデル
-- `design/16-driver-events-schema.md` — events.yaml schema（`tier` 宣言の文法は本書と連動して別 Issue で追加予定）
+- `design/16-driver-events-schema.md` — events.yaml schema（`tier` 宣言の文法は本書と連動した「tier」節で定義）
 - `design/10-driver-plugin.md` — Driver プラグイン仕様（プロセス分離原則）
 - `crates/midori-core/src/shm.rs` — `RingSlot` / `ShmHeader` 実装

--- a/design/17-driver-comm/01-inline-ring.md
+++ b/design/17-driver-comm/01-inline-ring.md
@@ -37,7 +37,7 @@
 スコープ外（**Out of Scope**）:
 
 - streamed tier の実装（[00-overview.md](./00-overview.md) で予約のみ）
-- events.yaml schema への `tier` フィールド追加（別 Issue で `design/16-driver-events-schema.md` を改訂）
+- events.yaml schema 文法そのもの（`tier` フィールドの定義は `design/16-driver-events-schema.md`「tier」節）
 - driver lifetime 中の `slot_size` 変更（driver 再起動でしか変えられない）
 - 同一プロセス内 multi-driver（`design/15-sdk-bindings-api.md` の方針通り別プロセス化）
 - 圧縮（msgpack バイト列をそのまま運ぶ）


### PR DESCRIPTION
## Summary

Linear: https://linear.app/mewton/issue/MEW-47/add-tier-field-to-eventsyaml-schema-inline-or-streamed

events.yaml の `tier: inline | streamed` フィールドは先行 Issue（MEW-48 / MEW-49 / MEW-51 / MEW-54）で schema 文法の定義・parser・validator・runtime feature-availability check・startup pipeline 統合まで一式実装済み。本 PR は MEW-47 の AC のうち未消化だった **設計ドキュメント側の整合** を仕上げる:

- `design/16-driver-events-schema.md` の SysEx 節: `max_length: 1024` の **由来** を inline tier の `DEFAULT_SLOT_SIZE (1032 byte) - ヘッダ 8 byte = 1024 byte` に紐付け、`design/17-driver-comm/01-inline-ring.md` への明示リンクを追加
- `design/17-driver-comm/00-overview.md` の 2 箇所: 「schema 拡張で `tier` を追加予定」の確定済み予告を、`design/16` 「tier」節へのリンクに置換
- `design/17-driver-comm/01-inline-ring.md` Out of Scope: 「`tier` フィールド追加 (別 Issue)」の未来形を、定義済みリンクへ更新

これら 3 件の `find-contradiction` で検出した不整合（先行実装後に design 側の予告文言が現実と乖離）を解消する。

## AC Mapping (verbatim from Linear)

### `design/16-driver-events-schema.md` 改訂
- [x] events 定義の文法に `tier: inline | streamed` フィールドを追加（default `inline`）— MEW-48 で着地済（line 64 の表に `tier` 行、line 192-215 の「tier」節）
- [x] `tier` の構文を schema validator が静的検証する旨を明記 — MEW-48（line 219）
- [x] streamed tier の実利用可否は runtime feature-availability check の責務である旨を明記 — MEW-48（line 220-221）
- [x] 「SysEx の表現」節の `max_length: 1024` 由来コメントを `design/17-driver-comm/01-inline-ring.md` にリンク — **本 PR**
- [x] バリデーションルール表に `tier` 行を追加 — MEW-48（line 558）

### Bridge 側 events.yaml schema validator
- [x] `tier` フィールドのパース（unknown 値・型不正は reject）— MEW-49 (`EventDef.tier` + serde rename_all = lowercase)
- [x] driver 起動時に `tier: streamed` を含む events.yaml は runtime feature-availability check で reject — MEW-51 (`check_runtime_features` + `FeatureUnavailable`)
- [x] `tier` 省略時に `inline` を default として補完 — MEW-49 (`#[serde(default)]` + `Tier::Inline` 既定)

## Test Plan

- [x] `cargo fmt --all -- --check` クリーン
- [x] `cargo clippy --workspace --all-targets -- -D warnings` クリーン
- [x] `cargo test --workspace` 全 212 テスト pass（events_schema sub-module の `tier` 関連テスト 7 件 + startup pipeline の `it_should_fail_startup_when_driver_declares_streamed_tier` 含む）
- [x] `cargo deny check` advisories / bans / licenses / sources ok

## Notes

- 本 PR は doc-only。Rust コード変更なし
- 先行 Issue で AC の大半が消化済みだったため、本 PR の差分は 3 ファイル / +4 -4 行と小さい
- `find-contradiction` で検出した 3 件は本 PR 内で全て解消（design/15、binding-requirements 等への波及スキャンも実施し、追加の不整合なし）

Closes #MEW-47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * ドライバイベントスキーマのドキュメンテーションを更新しました。MIDIシステムエクスクルーシブペイロードサイズの説明を明確化し、ドライバ通信プロトコルドキュメント間の参照関係を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->