### PR TITLE
feat(runtime): spawn driver subprocess with hello handshake (MEW-64)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "midori-driver-dummy"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "midori-driver-midi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/midori-runtime",
     "crates/midori-driver-midi",
     "crates/midori-driver-osc",
+    "crates/midori-driver-dummy",
 ]
 resolver = "2"
 

--- a/crates/midori-driver-dummy/Cargo.toml
+++ b/crates/midori-driver-dummy/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "midori-driver-dummy"
+version = "0.1.0"
+edition = "2021"
+description = "Test fixture driver binary for the Midori signal bridge spawn / handshake suite"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/mew-ton/midori"
+publish = false
+
+[[bin]]
+name = "midori-driver-dummy"
+path = "src/main.rs"
+
+[dependencies]
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/midori-driver-dummy/Cargo.toml
+++ b/crates/midori-driver-dummy/Cargo.toml
@@ -11,6 +11,20 @@ publish = false
 name = "midori-driver-dummy"
 path = "src/main.rs"
 
+# The fixture variants compile from the same `src/main.rs` and select their
+# behavior via `env!("CARGO_BIN_NAME")` at build time. They exist as separate
+# binaries so the integration test can hand spawn_driver an exact path
+# instead of materialising a wrapper script — a pattern that races against
+# parallel tests under Linux fork-exec semantics (ETXTBSY).
+
+[[bin]]
+name = "midori-driver-dummy-no-hello"
+path = "src/main.rs"
+
+[[bin]]
+name = "midori-driver-dummy-bad-version"
+path = "src/main.rs"
+
 [dependencies]
 serde_json = "1"
 

--- a/crates/midori-driver-dummy/src/main.rs
+++ b/crates/midori-driver-dummy/src/main.rs
@@ -1,0 +1,113 @@
+//! Test fixture driver binary used by Bridge spawn / handshake tests.
+//!
+//! This binary speaks the driver-side half of the JSON Lines control protocol
+//! described in `design/10-driver-plugin.md`「通信アーキテクチャ」「バージョン互換性」.
+//! Its only job is to be deterministic enough that the Bridge's `spawn_driver`
+//! flow can be exercised in three regimes:
+//!
+//! - default: emit a valid `hello` and then enter the stdin `BufRead`
+//!   scaffold loop (the loop body is intentionally a no-op; subtask (b)
+//!   will plug in handlers for `connect` / `disconnect` / `configure`).
+//! - `--no-hello`: never emit `hello`. Used to exercise the Bridge's
+//!   handshake timeout path.
+//! - `--bad-version`: emit `hello` with an SDK major that the Bridge
+//!   rejects. Used to exercise the `IncompatibleSdk` path.
+//!
+//! The binary only ever exercises the `start` subcommand for the spawn /
+//! handshake test surface; the argument parser is structured so the `list`
+//! subcommand can be added later without reshaping the dispatcher.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::ExitCode;
+
+/// CLI flag that suppresses the hello emission entirely. The driver still
+/// enters the stdin read loop so the parent can observe stdin EOF on its own
+/// terms (the timeout test relies on the parent giving up first).
+const FLAG_NO_HELLO: &str = "--no-hello";
+
+/// CLI flag that emits a `hello` whose `sdk_version` reports a major that the
+/// Bridge will treat as incompatible. The exact value lives next to the
+/// Bridge's compatibility check so the two stay coupled by intent: see
+/// `BAD_SDK_VERSION` in `crates/midori-runtime/src/driver_proc.rs`.
+const FLAG_BAD_VERSION: &str = "--bad-version";
+
+/// SDK version reported by the default fixture path. Held as a constant so
+/// the test fixture and the Bridge-side compatibility check remain in lockstep.
+const DEFAULT_SDK_VERSION: &str = "0.1.0";
+
+/// SDK version reported by the `--bad-version` fixture path. Chosen to land
+/// outside the Bridge's accepted-major set so the Bridge replies with
+/// `hello_ack { compatible: false }` and surfaces `IncompatibleSdk`.
+const BAD_SDK_VERSION: &str = "99.0.0";
+
+fn main() -> ExitCode {
+    let mut args = std::env::args();
+    let _bin = args.next();
+    let subcommand = args.next();
+    match subcommand.as_deref() {
+        Some("start") => exec_start(args.collect::<Vec<_>>().as_slice()),
+        Some(other) => {
+            eprintln!("midori-driver-dummy: unknown subcommand: {other}");
+            ExitCode::FAILURE
+        }
+        None => {
+            eprintln!(
+                "midori-driver-dummy: usage: midori-driver-dummy start [--no-hello|--bad-version]"
+            );
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn exec_start(flags: &[String]) -> ExitCode {
+    let mut emit_hello = true;
+    let mut sdk_version = DEFAULT_SDK_VERSION;
+    for flag in flags {
+        match flag.as_str() {
+            FLAG_NO_HELLO => emit_hello = false,
+            FLAG_BAD_VERSION => sdk_version = BAD_SDK_VERSION,
+            other => {
+                eprintln!("midori-driver-dummy: unknown flag: {other}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    if emit_hello {
+        if let Err(err) = emit_hello_line(sdk_version) {
+            eprintln!("midori-driver-dummy: failed to write hello: {err}");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    // Stdin BufRead scaffold loop. Subtask (b) will replace the no-op body
+    // with `match` arms for `hello_ack` / `connect` / `disconnect` /
+    // `configure`. Today the loop just drains stdin until EOF, which is the
+    // signal the parent uses to terminate the child gracefully.
+    let stdin = std::io::stdin();
+    let reader = BufReader::new(stdin.lock());
+    for line in reader.lines() {
+        match line {
+            Ok(_line) => {
+                // Subtask (b) hook point: dispatch on parsed message type.
+            }
+            Err(err) => {
+                eprintln!("midori-driver-dummy: stdin read error: {err}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+fn emit_hello_line(sdk_version: &str) -> std::io::Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    let payload = serde_json::json!({
+        "type": "hello",
+        "sdk_version": sdk_version,
+    });
+    serde_json::to_writer(&mut out, &payload)?;
+    out.write_all(b"\n")?;
+    out.flush()
+}

--- a/crates/midori-driver-dummy/src/main.rs
+++ b/crates/midori-driver-dummy/src/main.rs
@@ -2,41 +2,74 @@
 //!
 //! This binary speaks the driver-side half of the JSON Lines control protocol
 //! described in `design/10-driver-plugin.md`「通信アーキテクチャ」「バージョン互換性」.
-//! Its only job is to be deterministic enough that the Bridge's `spawn_driver`
-//! flow can be exercised in three regimes:
+//! Three compiled binaries share this source file, each selecting a fixture
+//! mode via the build-time `CARGO_BIN_NAME`:
 //!
-//! - default: emit a valid `hello` and then drain stdin until EOF. The drain
-//!   loop is intentionally a no-op so future message handlers can slot in
-//!   without restructuring the binary.
-//! - `--no-hello`: never emit `hello`. Used to exercise the Bridge's
-//!   handshake timeout path.
-//! - `--bad-version`: emit `hello` with an SDK major that the Bridge
-//!   rejects. Used to exercise the `IncompatibleSdk` path.
+//! - `midori-driver-dummy`: emit a valid `hello` and drain stdin until EOF.
+//!   The drain loop is a deliberate no-op so a future change can slot a
+//!   message dispatcher in without restructuring the binary.
+//! - `midori-driver-dummy-no-hello`: never emit `hello`. Used to exercise
+//!   the Bridge's handshake-timeout path.
+//! - `midori-driver-dummy-bad-version`: emit a `hello` whose `sdk_version`
+//!   reports a major outside the Bridge's accepted-major set (defined as
+//!   `ACCEPTED_SDK_MAJORS` in the runtime crate's `driver_proc` module).
+//!   Used to exercise the `IncompatibleSdk` path.
 //!
-//! The binary only ever exercises the `start` subcommand for the spawn /
-//! handshake test surface; the argument parser is structured so the `list`
-//! subcommand can be added later without reshaping the dispatcher.
+//! Selecting fixture mode by binary name (rather than by CLI flag) lets the
+//! integration test hand `spawn_driver` an exact, pre-built binary path —
+//! avoiding any need to materialise a per-test wrapper script, which races
+//! against parallel tests on Linux (ETXTBSY at exec).
+//!
+//! The binary only ever exercises the `start` subcommand; the argument
+//! parser is structured so the `list` subcommand can be added later
+//! without reshaping the dispatcher.
 
 use std::io::{BufRead, BufReader, Write};
 use std::process::ExitCode;
 
-/// CLI flag that suppresses the hello emission entirely. The driver still
-/// enters the stdin read loop so the parent can observe stdin EOF on its own
-/// terms (the timeout test relies on the parent giving up first).
-const FLAG_NO_HELLO: &str = "--no-hello";
+/// Fixture mode resolved from the binary's compiled-in name. The runtime
+/// fall-through to `Success` is just for forward-compatibility — every
+/// binary actually shipped here matches one of the three known names.
+#[derive(Debug, Clone, Copy)]
+enum FixtureMode {
+    Success,
+    NoHello,
+    BadVersion,
+}
 
-/// CLI flag that emits a `hello` whose `sdk_version` reports a major that the
-/// Bridge will treat as incompatible. The major must fall outside the
-/// Bridge's accepted-major set (defined as `ACCEPTED_SDK_MAJORS` in the
-/// runtime crate's `driver_proc` module) for the `IncompatibleSdk` test to fire.
-const FLAG_BAD_VERSION: &str = "--bad-version";
+const fn fixture_mode_for(bin_name: &str) -> FixtureMode {
+    let bytes = bin_name.as_bytes();
+    if matches_const(bytes, b"midori-driver-dummy-no-hello") {
+        FixtureMode::NoHello
+    } else if matches_const(bytes, b"midori-driver-dummy-bad-version") {
+        FixtureMode::BadVersion
+    } else {
+        FixtureMode::Success
+    }
+}
 
-/// SDK version reported by the default fixture path. Held as a constant so
-/// the test fixture and the Bridge-side compatibility check remain in lockstep.
+const fn matches_const(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < left.len() {
+        if left[i] != right[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+const FIXTURE: FixtureMode = fixture_mode_for(env!("CARGO_BIN_NAME"));
+
+/// SDK version reported by the success path. Held as a constant so the
+/// fixture and the Bridge-side compatibility check remain in lockstep.
 const DEFAULT_SDK_VERSION: &str = "0.1.0";
 
-/// SDK version reported by the `--bad-version` fixture path. Chosen to land
-/// outside the Bridge's accepted-major set so the Bridge replies with
+/// SDK version reported by the bad-version fixture. Chosen to land outside
+/// the Bridge's accepted-major set so the Bridge replies with
 /// `hello_ack { compatible: false }` and surfaces `IncompatibleSdk`.
 const BAD_SDK_VERSION: &str = "99.0.0";
 
@@ -45,38 +78,34 @@ fn main() -> ExitCode {
     let _bin = args.next();
     let subcommand = args.next();
     match subcommand.as_deref() {
-        Some("start") => exec_start(args.collect::<Vec<_>>().as_slice()),
+        Some("start") => exec_start(),
         Some(other) => {
             eprintln!("midori-driver-dummy: unknown subcommand: {other}");
             ExitCode::FAILURE
         }
         None => {
-            eprintln!(
-                "midori-driver-dummy: usage: midori-driver-dummy start [--no-hello|--bad-version]"
-            );
+            eprintln!("midori-driver-dummy: usage: midori-driver-dummy start");
             ExitCode::FAILURE
         }
     }
 }
 
-fn exec_start(flags: &[String]) -> ExitCode {
-    let mut emit_hello = true;
-    let mut sdk_version = DEFAULT_SDK_VERSION;
-    for flag in flags {
-        match flag.as_str() {
-            FLAG_NO_HELLO => emit_hello = false,
-            FLAG_BAD_VERSION => sdk_version = BAD_SDK_VERSION,
-            other => {
-                eprintln!("midori-driver-dummy: unknown flag: {other}");
+fn exec_start() -> ExitCode {
+    match FIXTURE {
+        FixtureMode::Success => {
+            if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
+                eprintln!("midori-driver-dummy: failed to write hello: {err}");
                 return ExitCode::FAILURE;
             }
         }
-    }
-
-    if emit_hello {
-        if let Err(err) = emit_hello_line(sdk_version) {
-            eprintln!("midori-driver-dummy: failed to write hello: {err}");
-            return ExitCode::FAILURE;
+        FixtureMode::NoHello => {
+            // Skip hello emission; the test relies on the Bridge timing out.
+        }
+        FixtureMode::BadVersion => {
+            if let Err(err) = emit_hello_line(BAD_SDK_VERSION) {
+                eprintln!("midori-driver-dummy: failed to write hello: {err}");
+                return ExitCode::FAILURE;
+            }
         }
     }
 

--- a/crates/midori-driver-dummy/src/main.rs
+++ b/crates/midori-driver-dummy/src/main.rs
@@ -5,9 +5,9 @@
 //! Its only job is to be deterministic enough that the Bridge's `spawn_driver`
 //! flow can be exercised in three regimes:
 //!
-//! - default: emit a valid `hello` and then enter the stdin `BufRead`
-//!   scaffold loop (the loop body is intentionally a no-op; subtask (b)
-//!   will plug in handlers for `connect` / `disconnect` / `configure`).
+//! - default: emit a valid `hello` and then drain stdin until EOF. The drain
+//!   loop is intentionally a no-op so future message handlers can slot in
+//!   without restructuring the binary.
 //! - `--no-hello`: never emit `hello`. Used to exercise the Bridge's
 //!   handshake timeout path.
 //! - `--bad-version`: emit `hello` with an SDK major that the Bridge
@@ -26,9 +26,9 @@ use std::process::ExitCode;
 const FLAG_NO_HELLO: &str = "--no-hello";
 
 /// CLI flag that emits a `hello` whose `sdk_version` reports a major that the
-/// Bridge will treat as incompatible. The exact value lives next to the
-/// Bridge's compatibility check so the two stay coupled by intent: see
-/// `BAD_SDK_VERSION` in `crates/midori-runtime/src/driver_proc.rs`.
+/// Bridge will treat as incompatible. The major must fall outside the
+/// Bridge's accepted-major set (defined as `ACCEPTED_SDK_MAJORS` in the
+/// runtime crate's `driver_proc` module) for the `IncompatibleSdk` test to fire.
 const FLAG_BAD_VERSION: &str = "--bad-version";
 
 /// SDK version reported by the default fixture path. Held as a constant so
@@ -80,17 +80,15 @@ fn exec_start(flags: &[String]) -> ExitCode {
         }
     }
 
-    // Stdin BufRead scaffold loop. Subtask (b) will replace the no-op body
-    // with `match` arms for `hello_ack` / `connect` / `disconnect` /
-    // `configure`. Today the loop just drains stdin until EOF, which is the
-    // signal the parent uses to terminate the child gracefully.
+    // Drain stdin until EOF. The loop body is a deliberate no-op: the parent
+    // closes stdin when it wants the child gone, and the BufRead structure
+    // is the slot a future change can fill with a message dispatcher
+    // without reshaping the binary.
     let stdin = std::io::stdin();
     let reader = BufReader::new(stdin.lock());
     for line in reader.lines() {
         match line {
-            Ok(_line) => {
-                // Subtask (b) hook point: dispatch on parsed message type.
-            }
+            Ok(_line) => {}
             Err(err) => {
                 eprintln!("midori-driver-dummy: stdin read error: {err}");
                 return ExitCode::FAILURE;

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -6,6 +6,10 @@ description = "CLI and pipeline orchestrator for the Midori signal bridge"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/mew-ton/midori"
 
+[lib]
+name = "midori_runtime"
+path = "src/lib.rs"
+
 [[bin]]
 name = "midori"
 path = "src/main.rs"

--- a/crates/midori-runtime/src/driver_proc.rs
+++ b/crates/midori-runtime/src/driver_proc.rs
@@ -25,10 +25,10 @@
 //!
 //! # Scope
 //!
-//! Only handshake completion is implemented here. Lifecycle management
+//! This module handles spawn + handshake only. Lifecycle management
 //! (graceful shutdown, log forwarding from the post-handshake stdout stream,
-//! SIGTERM / SIGKILL escalation) is the responsibility of the next subtask
-//! and intentionally absent from this module.
+//! SIGTERM / SIGKILL escalation) lives elsewhere and is intentionally not
+//! part of this module's surface.
 
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
@@ -72,22 +72,18 @@ struct HelloAckMessage<'a> {
 /// Outcome of a `spawn_driver` call.
 ///
 /// On the success path the handle owns the child process plus its stdin
-/// writer; the post-handshake stdout reader thread is intentionally not
-/// exposed yet (subtask (b) will wire log forwarding through it). Dropping
-/// the handle closes stdin, which the dummy fixture treats as the signal to
-/// exit its `BufRead` loop.
+/// writer. Dropping the handle closes stdin, which the dummy fixture treats
+/// as the signal to exit its `BufRead` loop.
 #[derive(Debug)]
 pub struct DriverHandle {
     /// Driver name as supplied to [`spawn_driver`]. Carried for diagnostics.
     pub name: String,
     /// Resolved binary path, useful for log lines and crash reports.
     pub path: PathBuf,
-    /// Profile blob forwarded to the driver. Held for later use by subtask
-    /// (b) when `connect` / `configure` flows are wired in.
-    pub profile: serde_json::Value,
     /// SDK version the driver advertised in its `hello`.
     pub sdk_version: String,
     child: Child,
+    #[allow(dead_code)]
     stdin: ChildStdin,
 }
 
@@ -96,12 +92,6 @@ impl DriverHandle {
     #[must_use]
     pub fn child(&self) -> &Child {
         &self.child
-    }
-
-    /// Mutable borrow of the child stdin pipe so subtask (b) can write
-    /// follow-up control commands without taking the pipe.
-    pub fn stdin_mut(&mut self) -> &mut ChildStdin {
-        &mut self.stdin
     }
 }
 
@@ -126,6 +116,8 @@ pub enum SpawnError {
         reason: String,
     },
     /// Writing the `hello_ack` line to the driver's stdin failed.
+    /// Realistic only if the child crashed between emitting `hello` and the
+    /// Bridge's ack write — a real cross-process boundary that can fail.
     HelloAckWrite(std::io::Error),
 }
 
@@ -177,14 +169,15 @@ impl std::error::Error for SpawnError {
 ///
 /// `name` is the driver identifier (used for diagnostics and later for
 /// dispatching events); `profile` is the configuration blob the runtime
-/// will hand to the driver after the handshake (subtask (b) uses it).
+/// will eventually forward to the driver — handshake itself does not consume
+/// it, so the parameter is held only at the API boundary.
 ///
 /// On the failure path the child process is reaped before this function
 /// returns — callers do not need to clean up zombies on `Err(_)`.
 pub fn spawn_driver(
     name: impl Into<String>,
     path: impl Into<PathBuf>,
-    profile: serde_json::Value,
+    profile: &serde_json::Value,
 ) -> Result<DriverHandle, SpawnError> {
     spawn_driver_with_timeout(name, path, profile, HANDSHAKE_TIMEOUT)
 }
@@ -195,9 +188,10 @@ pub fn spawn_driver(
 pub fn spawn_driver_with_timeout(
     name: impl Into<String>,
     path: impl Into<PathBuf>,
-    profile: serde_json::Value,
+    profile: &serde_json::Value,
     handshake_timeout: Duration,
 ) -> Result<DriverHandle, SpawnError> {
+    let _ = profile;
     let name = name.into();
     let path = path.into();
 
@@ -237,10 +231,9 @@ pub fn spawn_driver_with_timeout(
                 let _ = tx.send(Err(err));
             }
         }
-        // Hand the BufReader back via thread join so subtask (b) can resume
-        // reading subsequent stdout lines (log forwarding) once the
-        // join-API for that path is designed. For now the reader is
-        // dropped, which closes the read half cleanly.
+        // Drop the reader once the first line is captured: closing the read
+        // half of the pipe is the cleanest signal to a future log-forwarding
+        // path that the handshake stage is done.
         drop(reader);
     });
 
@@ -296,11 +289,10 @@ pub fn spawn_driver_with_timeout(
     }
 
     if let Compatibility::Incompatible { reason } = compat {
-        // Give the driver a brief window to observe the negative ack and
-        // exit cleanly. If it doesn't, escalate to kill so the parent does
-        // not block. Subtask (b) replaces this with the SIGTERM/SIGKILL
-        // ladder agreed for the lifecycle module.
-        wait_for_exit_or_kill(&mut child, Duration::from_millis(200));
+        // The negative ack has been written; closing the child immediately
+        // keeps the bridge non-blocking. Graceful exit on the driver side
+        // is a lifecycle concern handled outside this module.
+        kill_and_reap(&mut child);
         return Err(SpawnError::IncompatibleSdk {
             driver_version: hello.sdk_version,
             reason,
@@ -310,7 +302,6 @@ pub fn spawn_driver_with_timeout(
     Ok(DriverHandle {
         name,
         path,
-        profile,
         sdk_version: hello.sdk_version,
         child,
         stdin,
@@ -388,29 +379,6 @@ fn write_hello_ack(stdin: &mut ChildStdin, ack: &HelloAckMessage<'_>) -> std::io
 fn kill_and_reap(child: &mut Child) {
     let _ = child.kill();
     let _ = child.wait();
-}
-
-/// Poll for the child to exit; if it still hasn't after `grace`, kill it.
-/// Used on the `IncompatibleSdk` path so the driver gets a chance to log
-/// the negative ack and exit on its own before the Bridge force-closes it.
-fn wait_for_exit_or_kill(child: &mut Child, grace: Duration) {
-    let deadline = std::time::Instant::now() + grace;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return,
-            Ok(None) => {
-                if std::time::Instant::now() >= deadline {
-                    kill_and_reap(child);
-                    return;
-                }
-                thread::sleep(Duration::from_millis(10));
-            }
-            Err(_) => {
-                kill_and_reap(child);
-                return;
-            }
-        }
-    }
 }
 
 /// Synthesize a `serde_json::Error` for the "valid JSON but wrong tag" case

--- a/crates/midori-runtime/src/driver_proc.rs
+++ b/crates/midori-runtime/src/driver_proc.rs
@@ -1,0 +1,424 @@
+//! Driver subprocess supervisor: spawn a driver binary, complete the JSON
+//! Lines `hello` / `hello_ack` handshake, and hand back a [`DriverHandle`].
+//!
+//! # Protocol
+//!
+//! The wire format is `design/10-driver-plugin.md`「バージョン互換性」:
+//!
+//! ```jsonc
+//! // Driver → Bridge stdout (first line)
+//! {"type": "hello", "sdk_version": "1.0.0"}
+//!
+//! // Bridge → Driver stdin (first line)
+//! {"type": "hello_ack", "compatible": true}
+//! // or
+//! {"type": "hello_ack", "compatible": false, "reason": "sdk 1.0.0 is too old, require >=1.2.0"}
+//! ```
+//!
+//! # Concurrency model
+//!
+//! The handshake is implemented with synchronous primitives — `std::process`
+//! for the child, a worker thread that reads the first stdout line into a
+//! `std::sync::mpsc` channel, and `Receiver::recv_timeout` for the bound on
+//! handshake duration. The runtime crate does not depend on tokio, and the
+//! handshake is short-lived enough that a thread-per-spawn model is fine.
+//!
+//! # Scope
+//!
+//! Only handshake completion is implemented here. Lifecycle management
+//! (graceful shutdown, log forwarding from the post-handshake stdout stream,
+//! SIGTERM / SIGKILL escalation) is the responsibility of the next subtask
+//! and intentionally absent from this module.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// Default upper bound on how long [`spawn_driver`] waits for the driver to
+/// emit its `hello` line. Drivers are expected to write `hello` synchronously
+/// at the top of `main()`, so 5 seconds is multiple orders of magnitude
+/// beyond the realistic budget. Tests use [`spawn_driver_with_timeout`] with
+/// a much shorter value to keep the suite fast.
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// SDK majors the Bridge currently understands. The compatibility check
+/// accepts any `hello.sdk_version` parseable as `MAJOR.MINOR.PATCH` whose
+/// `MAJOR` is listed here. Bumping the SDK's binary layout extends this list
+/// (or replaces it) — see `design/10-driver-plugin.md`「バージョン互換性」 for
+/// the policy: layout changes happen on semver-major bumps only.
+const ACCEPTED_SDK_MAJORS: &[u32] = &[0, 1];
+
+/// JSON-tagged `hello` message read from the driver's stdout.
+#[derive(Debug, serde::Deserialize)]
+struct HelloMessage {
+    #[serde(rename = "type")]
+    message_type: String,
+    sdk_version: String,
+}
+
+/// JSON-tagged `hello_ack` message written to the driver's stdin.
+#[derive(Debug, serde::Serialize)]
+struct HelloAckMessage<'a> {
+    #[serde(rename = "type")]
+    message_type: &'a str,
+    compatible: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'a str>,
+}
+
+/// Outcome of a `spawn_driver` call.
+///
+/// On the success path the handle owns the child process plus its stdin
+/// writer; the post-handshake stdout reader thread is intentionally not
+/// exposed yet (subtask (b) will wire log forwarding through it). Dropping
+/// the handle closes stdin, which the dummy fixture treats as the signal to
+/// exit its `BufRead` loop.
+#[derive(Debug)]
+pub struct DriverHandle {
+    /// Driver name as supplied to [`spawn_driver`]. Carried for diagnostics.
+    pub name: String,
+    /// Resolved binary path, useful for log lines and crash reports.
+    pub path: PathBuf,
+    /// Profile blob forwarded to the driver. Held for later use by subtask
+    /// (b) when `connect` / `configure` flows are wired in.
+    pub profile: serde_json::Value,
+    /// SDK version the driver advertised in its `hello`.
+    pub sdk_version: String,
+    child: Child,
+    stdin: ChildStdin,
+}
+
+impl DriverHandle {
+    /// Borrow the child process handle (for `id()` and similar inspection).
+    #[must_use]
+    pub fn child(&self) -> &Child {
+        &self.child
+    }
+
+    /// Mutable borrow of the child stdin pipe so subtask (b) can write
+    /// follow-up control commands without taking the pipe.
+    pub fn stdin_mut(&mut self) -> &mut ChildStdin {
+        &mut self.stdin
+    }
+}
+
+/// Errors returned by [`spawn_driver`] / [`spawn_driver_with_timeout`].
+#[derive(Debug)]
+pub enum SpawnError {
+    /// `Command::spawn` itself failed (binary missing, permission denied, …).
+    Spawn(std::io::Error),
+    /// The driver process started but did not emit `hello` within the
+    /// configured timeout. The child is killed before this is returned.
+    HandshakeTimeout,
+    /// The driver closed stdout (and/or exited) without ever emitting
+    /// `hello`. This is the EOF-before-handshake path.
+    HandshakeMissing,
+    /// A line was received but failed to parse as a `hello` message.
+    HandshakeMalformed(serde_json::Error),
+    /// The driver advertised an SDK version the Bridge does not accept.
+    /// Before this is returned, the Bridge writes `hello_ack { compatible:
+    /// false }` so the driver can shut down cleanly with a logged reason.
+    IncompatibleSdk {
+        driver_version: String,
+        reason: String,
+    },
+    /// Writing the `hello_ack` line to the driver's stdin failed.
+    HelloAckWrite(std::io::Error),
+}
+
+impl std::fmt::Display for SpawnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(err) => write!(f, "driver プロセスの spawn に失敗しました: {err}"),
+            Self::HandshakeTimeout => write!(
+                f,
+                "driver が {} 秒以内に hello を送信しませんでした",
+                HANDSHAKE_TIMEOUT.as_secs()
+            ),
+            Self::HandshakeMissing => {
+                f.write_str("driver が hello を送信せずに stdout を閉じました")
+            }
+            Self::HandshakeMalformed(err) => {
+                write!(
+                    f,
+                    "driver の hello を JSON として解釈できませんでした: {err}"
+                )
+            }
+            Self::IncompatibleSdk {
+                driver_version,
+                reason,
+            } => write!(
+                f,
+                "driver の SDK バージョン `{driver_version}` は Bridge と非互換です: {reason}"
+            ),
+            Self::HelloAckWrite(err) => write!(
+                f,
+                "driver stdin への hello_ack 書き込みに失敗しました: {err}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SpawnError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Spawn(err) | Self::HelloAckWrite(err) => Some(err),
+            Self::HandshakeMalformed(err) => Some(err),
+            Self::HandshakeTimeout | Self::HandshakeMissing | Self::IncompatibleSdk { .. } => None,
+        }
+    }
+}
+
+/// Spawn a driver binary at `path`, complete the version handshake, and
+/// return a [`DriverHandle`] tied to the live child.
+///
+/// `name` is the driver identifier (used for diagnostics and later for
+/// dispatching events); `profile` is the configuration blob the runtime
+/// will hand to the driver after the handshake (subtask (b) uses it).
+///
+/// On the failure path the child process is reaped before this function
+/// returns — callers do not need to clean up zombies on `Err(_)`.
+pub fn spawn_driver(
+    name: impl Into<String>,
+    path: impl Into<PathBuf>,
+    profile: serde_json::Value,
+) -> Result<DriverHandle, SpawnError> {
+    spawn_driver_with_timeout(name, path, profile, HANDSHAKE_TIMEOUT)
+}
+
+/// [`spawn_driver`] with an explicit handshake timeout. Tests use a short
+/// timeout (typically 200ms) to keep the suite fast; production callers
+/// should keep using the default via [`spawn_driver`].
+pub fn spawn_driver_with_timeout(
+    name: impl Into<String>,
+    path: impl Into<PathBuf>,
+    profile: serde_json::Value,
+    handshake_timeout: Duration,
+) -> Result<DriverHandle, SpawnError> {
+    let name = name.into();
+    let path = path.into();
+
+    let mut child = Command::new(&path)
+        .arg("start")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(SpawnError::Spawn)?;
+
+    // Take pipes immediately so we can hand them to threads without holding
+    // an outstanding `&mut child` borrow during the handshake.
+    let stdout = child
+        .stdout
+        .take()
+        .expect("Stdio::piped() guarantees stdout is Some");
+    let mut stdin = child
+        .stdin
+        .take()
+        .expect("Stdio::piped() guarantees stdin is Some");
+
+    // Read the first stdout line on a worker thread. Channel-disconnect
+    // (sender dropped without sending) maps to EOF before hello.
+    let (tx, rx) = mpsc::channel::<std::io::Result<String>>();
+    let reader_handle = thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                // Sender drops on return; the Bridge sees Disconnected.
+            }
+            Ok(_) => {
+                let _ = tx.send(Ok(line));
+            }
+            Err(err) => {
+                let _ = tx.send(Err(err));
+            }
+        }
+        // Hand the BufReader back via thread join so subtask (b) can resume
+        // reading subsequent stdout lines (log forwarding) once the
+        // join-API for that path is designed. For now the reader is
+        // dropped, which closes the read half cleanly.
+        drop(reader);
+    });
+
+    let hello_line = match rx.recv_timeout(handshake_timeout) {
+        Ok(Ok(line)) => line,
+        Ok(Err(io_err)) => {
+            kill_and_reap(&mut child);
+            // Reap the worker thread so its drop runs on this thread
+            // rather than detaching.
+            let _ = reader_handle.join();
+            return Err(SpawnError::Spawn(io_err));
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            kill_and_reap(&mut child);
+            let _ = reader_handle.join();
+            return Err(SpawnError::HandshakeTimeout);
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            kill_and_reap(&mut child);
+            let _ = reader_handle.join();
+            return Err(SpawnError::HandshakeMissing);
+        }
+    };
+
+    let _ = reader_handle.join();
+
+    let hello: HelloMessage = match serde_json::from_str(hello_line.trim_end()) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            kill_and_reap(&mut child);
+            return Err(SpawnError::HandshakeMalformed(err));
+        }
+    };
+
+    if hello.message_type != "hello" {
+        kill_and_reap(&mut child);
+        return Err(SpawnError::HandshakeMalformed(json_type_error(&format!(
+            "expected `type=\"hello\"`, got `type={:?}`",
+            hello.message_type
+        ))));
+    }
+
+    let compat = is_sdk_compatible(&hello.sdk_version);
+    let ack = HelloAckMessage {
+        message_type: "hello_ack",
+        compatible: compat.is_compatible(),
+        reason: compat.reason(),
+    };
+
+    if let Err(err) = write_hello_ack(&mut stdin, &ack) {
+        kill_and_reap(&mut child);
+        return Err(SpawnError::HelloAckWrite(err));
+    }
+
+    if let Compatibility::Incompatible { reason } = compat {
+        // Give the driver a brief window to observe the negative ack and
+        // exit cleanly. If it doesn't, escalate to kill so the parent does
+        // not block. Subtask (b) replaces this with the SIGTERM/SIGKILL
+        // ladder agreed for the lifecycle module.
+        wait_for_exit_or_kill(&mut child, Duration::from_millis(200));
+        return Err(SpawnError::IncompatibleSdk {
+            driver_version: hello.sdk_version,
+            reason,
+        });
+    }
+
+    Ok(DriverHandle {
+        name,
+        path,
+        profile,
+        sdk_version: hello.sdk_version,
+        child,
+        stdin,
+    })
+}
+
+/// Result of [`is_sdk_compatible`]. Carried as a small enum so the caller
+/// can build the `hello_ack` reason field and the `IncompatibleSdk` error
+/// from the same source of truth.
+enum Compatibility {
+    Compatible,
+    Incompatible { reason: String },
+}
+
+impl Compatibility {
+    fn is_compatible(&self) -> bool {
+        matches!(self, Self::Compatible)
+    }
+
+    fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Compatible => None,
+            Self::Incompatible { reason } => Some(reason.as_str()),
+        }
+    }
+}
+
+/// Decide whether the Bridge accepts `version` as a peer SDK.
+///
+/// The accepted set is `MAJOR.MINOR.PATCH` triples whose `MAJOR` is listed
+/// in [`ACCEPTED_SDK_MAJORS`]. Anything that fails to parse — empty string,
+/// non-numeric segments, fewer than three segments — is rejected with a
+/// reason describing the failure mode so the driver-side log makes the
+/// mismatch obvious.
+fn is_sdk_compatible(version: &str) -> Compatibility {
+    let mut parts = version.split('.');
+    let Some(major_str) = parts.next() else {
+        return Compatibility::Incompatible {
+            reason: format!("sdk_version `{version}` is empty"),
+        };
+    };
+    let Ok(major) = major_str.parse::<u32>() else {
+        return Compatibility::Incompatible {
+            reason: format!("sdk_version `{version}` has non-numeric major component"),
+        };
+    };
+    // Require the remaining `MINOR.PATCH` segments to exist, even if we don't
+    // gate on their values — the protocol contract is "MAJOR.MINOR.PATCH".
+    if parts.next().is_none() || parts.next().is_none() {
+        return Compatibility::Incompatible {
+            reason: format!("sdk_version `{version}` is not in MAJOR.MINOR.PATCH form"),
+        };
+    }
+    if !ACCEPTED_SDK_MAJORS.contains(&major) {
+        return Compatibility::Incompatible {
+            reason: format!(
+                "sdk_version `{version}` advertises major {major}, Bridge accepts {ACCEPTED_SDK_MAJORS:?}"
+            ),
+        };
+    }
+    Compatibility::Compatible
+}
+
+/// Encode and send a `hello_ack` line on `stdin`.
+fn write_hello_ack(stdin: &mut ChildStdin, ack: &HelloAckMessage<'_>) -> std::io::Result<()> {
+    serde_json::to_writer(&mut *stdin, ack)?;
+    stdin.write_all(b"\n")?;
+    stdin.flush()
+}
+
+/// Kill the child and wait for it so callers do not leak zombies on the
+/// error paths. Errors during kill / wait are intentionally swallowed: the
+/// outer `Err(SpawnError::…)` already carries the user-visible cause and
+/// the cleanup is best-effort.
+fn kill_and_reap(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Poll for the child to exit; if it still hasn't after `grace`, kill it.
+/// Used on the `IncompatibleSdk` path so the driver gets a chance to log
+/// the negative ack and exit on its own before the Bridge force-closes it.
+fn wait_for_exit_or_kill(child: &mut Child, grace: Duration) {
+    let deadline = std::time::Instant::now() + grace;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    kill_and_reap(child);
+                    return;
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(_) => {
+                kill_and_reap(child);
+                return;
+            }
+        }
+    }
+}
+
+/// Synthesize a `serde_json::Error` for the "valid JSON but wrong tag" case
+/// so [`SpawnError::HandshakeMalformed`] can carry the diagnostic without a
+/// dedicated variant.
+fn json_type_error(message: &str) -> serde_json::Error {
+    // serde_json does not expose `Error::custom` publicly; round-trip
+    // through `serde::de::Error` via a deserializer that produces our text.
+    use serde::de::Error as _;
+    serde_json::Error::custom(message)
+}

--- a/crates/midori-runtime/src/driver_proc.rs
+++ b/crates/midori-runtime/src/driver_proc.rs
@@ -101,8 +101,11 @@ pub enum SpawnError {
     /// `Command::spawn` itself failed (binary missing, permission denied, …).
     Spawn(std::io::Error),
     /// The driver process started but did not emit `hello` within the
-    /// configured timeout. The child is killed before this is returned.
-    HandshakeTimeout,
+    /// supplied timeout. Carries the actual budget that elapsed so the
+    /// `Display` impl can report the value the caller passed in (which
+    /// differs from [`HANDSHAKE_TIMEOUT`] in tests). The child is killed
+    /// before this is returned.
+    HandshakeTimeout(Duration),
     /// The driver closed stdout (and/or exited) without ever emitting
     /// `hello`. This is the EOF-before-handshake path.
     HandshakeMissing,
@@ -125,10 +128,10 @@ impl std::fmt::Display for SpawnError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Spawn(err) => write!(f, "driver プロセスの spawn に失敗しました: {err}"),
-            Self::HandshakeTimeout => write!(
+            Self::HandshakeTimeout(elapsed) => write!(
                 f,
-                "driver が {} 秒以内に hello を送信しませんでした",
-                HANDSHAKE_TIMEOUT.as_secs()
+                "driver が {:.3} 秒以内に hello を送信しませんでした",
+                elapsed.as_secs_f64()
             ),
             Self::HandshakeMissing => {
                 f.write_str("driver が hello を送信せずに stdout を閉じました")
@@ -159,7 +162,9 @@ impl std::error::Error for SpawnError {
         match self {
             Self::Spawn(err) | Self::HelloAckWrite(err) => Some(err),
             Self::HandshakeMalformed(err) => Some(err),
-            Self::HandshakeTimeout | Self::HandshakeMissing | Self::IncompatibleSdk { .. } => None,
+            Self::HandshakeTimeout(_) | Self::HandshakeMissing | Self::IncompatibleSdk { .. } => {
+                None
+            }
         }
     }
 }
@@ -249,7 +254,7 @@ pub fn spawn_driver_with_timeout(
         Err(mpsc::RecvTimeoutError::Timeout) => {
             kill_and_reap(&mut child);
             let _ = reader_handle.join();
-            return Err(SpawnError::HandshakeTimeout);
+            return Err(SpawnError::HandshakeTimeout(handshake_timeout));
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
             kill_and_reap(&mut child);

--- a/crates/midori-runtime/src/lib.rs
+++ b/crates/midori-runtime/src/lib.rs
@@ -1,0 +1,10 @@
+//! Library surface of the Midori Bridge runtime.
+//!
+//! The runtime ships primarily as the `midori` binary (`src/main.rs`), but
+//! certain subsystems are exposed here so integration tests and downstream
+//! consumers can drive them directly without going through argv.
+//!
+//! Today only the driver process supervisor is exposed. The CLI dispatch
+//! layer remains binary-private until there is a concrete need to expose it.
+
+pub mod driver_proc;

--- a/crates/midori-runtime/tests/driver_spawn.rs
+++ b/crates/midori-runtime/tests/driver_spawn.rs
@@ -122,10 +122,15 @@ fn it_should_complete_handshake_against_dummy_driver() {
 fn it_should_return_handshake_timeout_when_driver_does_not_emit_hello() {
     let case = CASE_TIMEOUT;
     let err = spawn(&case).expect_err("--no-hello must surface as a timeout");
-    assert!(
-        matches!(err, SpawnError::HandshakeTimeout),
-        "expected HandshakeTimeout, got {err:?}"
-    );
+    match err {
+        SpawnError::HandshakeTimeout(elapsed) => {
+            assert_eq!(
+                elapsed, case.timeout,
+                "HandshakeTimeout must echo the caller-supplied timeout, got {elapsed:?}"
+            );
+        }
+        other => panic!("expected HandshakeTimeout, got {other:?}"),
+    }
 }
 
 #[cfg(unix)]

--- a/crates/midori-runtime/tests/driver_spawn.rs
+++ b/crates/midori-runtime/tests/driver_spawn.rs
@@ -17,12 +17,11 @@ use midori_runtime::driver_proc::{spawn_driver_with_timeout, SpawnError, HANDSHA
 ///
 /// Cargo's `CARGO_BIN_EXE_<name>` env var is only set for binaries in the
 /// same package as the test, so this resolver walks the workspace `target/`
-/// tree the test's own `current_exe()` lives under and locates the
-/// sibling `midori-driver-dummy` artifact. Cargo always builds a workspace
-/// binary in the same profile dir as the integration test that depends on
-/// it transitively (the test crate's `[lib]` re-exports trigger a rebuild),
-/// but to be safe the resolver also issues an explicit `cargo build` for
-/// the binary when it isn't already present.
+/// tree the test's own `current_exe()` lives under and locates the sibling
+/// `midori-driver-dummy` artifact. The dummy crate is not a build-time
+/// dependency of this test crate, so the resolver issues an explicit
+/// `cargo build` when the artifact is missing rather than relying on
+/// cargo's incidental ordering.
 fn dummy_bin_path() -> &'static std::path::Path {
     static CELL: OnceLock<PathBuf> = OnceLock::new();
     CELL.get_or_init(|| {
@@ -112,13 +111,13 @@ fn it_should_complete_handshake_against_dummy_driver() {
         "driver must report a non-empty SDK version on the success path"
     );
     // Dropping the handle drops `ChildStdin` first, which closes the write
-    // half of the pipe. The dummy's BufRead loop terminates on the
-    // resulting EOF. The `Child` is not waited on here — that's subtask
-    // (b)'s lifecycle responsibility — but the dummy exiting promptly on
-    // stdin EOF is what makes (b) able to wait without hanging.
+    // half of the pipe. The dummy's BufRead loop terminates on the resulting
+    // EOF. The `Child` itself is not awaited here; lifecycle handling lives
+    // outside this module.
     drop(handle);
 }
 
+#[cfg(unix)]
 #[test]
 fn it_should_return_handshake_timeout_when_driver_does_not_emit_hello() {
     let case = CASE_TIMEOUT;
@@ -129,6 +128,7 @@ fn it_should_return_handshake_timeout_when_driver_does_not_emit_hello() {
     );
 }
 
+#[cfg(unix)]
 #[test]
 fn it_should_return_incompatible_sdk_when_driver_advertises_unknown_version() {
     let case = CASE_INCOMPAT;
@@ -158,17 +158,16 @@ fn it_should_return_incompatible_sdk_when_driver_advertises_unknown_version() {
 /// embedded as a wrapper script.
 ///
 /// Since `Command::new(path)` only takes one arg list and `spawn_driver`
-/// already injects `start`, we materialise the wrapper as a small shell
-/// script per call when extra flags are needed. On platforms without
-/// `/bin/sh` this would need adjustment; the runtime is currently tested
-/// on Linux only via CI.
+/// already injects `start`, the helper materialises a small shell script
+/// per call when extra flags are needed. The shell-script path is unix-only;
+/// fixture-flag-using cases are gated with `#[cfg(unix)]` accordingly.
 fn spawn(case: &SpawnCase) -> Result<midori_runtime::driver_proc::DriverHandle, SpawnError> {
     let bin_path = if case.fixture_args.is_empty() {
         dummy_bin_path().to_path_buf()
     } else {
         wrap_with_flags(case.name, case.fixture_args)
     };
-    spawn_driver_with_timeout(case.name, bin_path, serde_json::json!({}), case.timeout)
+    spawn_driver_with_timeout(case.name, bin_path, &serde_json::json!({}), case.timeout)
 }
 
 /// Materialise a tiny shell wrapper that invokes the dummy binary with the

--- a/crates/midori-runtime/tests/driver_spawn.rs
+++ b/crates/midori-runtime/tests/driver_spawn.rs
@@ -28,13 +28,38 @@ fn fixture_bin_path(bin_name: &'static str) -> &'static std::path::Path {
             .parent()
             .and_then(|p| p.parent())
             .expect("integration test exe must live under target/<profile>/deps/");
+        // The directory name immediately above `deps/` is the cargo profile
+        // the test was compiled under: `target/<profile>/deps/<test-bin>`.
+        // We pass it back to `cargo build` so the fixture lands in the same
+        // profile dir the resolver is searching in. `--profile dev` is the
+        // canonical spelling for the directory that cargo names `debug`.
+        let profile_name = profile_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .expect("profile directory name must be UTF-8");
         let candidate = profile_dir.join(bin_filename(bin_name));
         if !candidate.exists() {
+            let cargo_profile = if profile_name == "debug" {
+                "dev"
+            } else {
+                profile_name
+            };
             let status = std::process::Command::new(env!("CARGO"))
-                .args(["build", "-p", "midori-driver-dummy", "--bin", bin_name])
+                .args([
+                    "build",
+                    "-p",
+                    "midori-driver-dummy",
+                    "--bin",
+                    bin_name,
+                    "--profile",
+                    cargo_profile,
+                ])
                 .status()
                 .expect("invoke cargo build for fixture");
-            assert!(status.success(), "cargo build of {bin_name} failed");
+            assert!(
+                status.success(),
+                "cargo build of {bin_name} (profile {cargo_profile}) failed"
+            );
         }
         assert!(
             candidate.exists(),

--- a/crates/midori-runtime/tests/driver_spawn.rs
+++ b/crates/midori-runtime/tests/driver_spawn.rs
@@ -1,11 +1,11 @@
 //! Integration tests for the Bridge-side driver spawn / handshake flow.
 //!
-//! Each test runs `midori-driver-dummy` with one of three CLI flag shapes
-//! (default / `--no-hello` / `--bad-version`) and asserts the matching
-//! `spawn_driver` outcome. Cargo's `CARGO_BIN_EXE_<name>` env var only
-//! covers binaries declared in the same package as the test, so the
-//! fixture path is resolved at runtime by walking the workspace `target/`
-//! tree the test executable itself lives in.
+//! The fixture comes as three sibling binaries built from the same source
+//! (`crates/midori-driver-dummy/`). Each binary's behavior is selected at
+//! build time via `CARGO_BIN_NAME`, so the test hands `spawn_driver` an
+//! exact path per case and never has to materialise a wrapper script
+//! at runtime — wrappers race against parallel tests under Linux fork-exec
+//! semantics (ETXTBSY).
 
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -13,40 +13,28 @@ use std::time::Duration;
 
 use midori_runtime::driver_proc::{spawn_driver_with_timeout, SpawnError, HANDSHAKE_TIMEOUT};
 
-/// Resolved path to the `midori-driver-dummy` fixture binary.
+/// Resolved path to a fixture binary by name.
 ///
-/// Cargo's `CARGO_BIN_EXE_<name>` env var is only set for binaries in the
-/// same package as the test, so this resolver walks the workspace `target/`
-/// tree the test's own `current_exe()` lives under and locates the sibling
-/// `midori-driver-dummy` artifact. The dummy crate is not a build-time
-/// dependency of this test crate, so the resolver issues an explicit
-/// `cargo build` when the artifact is missing rather than relying on
-/// cargo's incidental ordering.
-fn dummy_bin_path() -> &'static std::path::Path {
-    static CELL: OnceLock<PathBuf> = OnceLock::new();
-    CELL.get_or_init(|| {
+/// Cargo's `CARGO_BIN_EXE_<name>` env var is only set for binaries declared
+/// in the same package as the test, so the resolver walks the workspace
+/// `target/<profile>/` directory the test executable itself lives under.
+/// If the artifact is missing (e.g. `cargo test -p midori-runtime` without
+/// `--workspace`) the resolver builds it explicitly. Each binary is cached
+/// in its own `OnceLock` so the build is amortised across tests.
+fn fixture_bin_path(bin_name: &'static str) -> &'static std::path::Path {
+    fn resolve(bin_name: &str) -> PathBuf {
         let test_exe = std::env::current_exe().expect("current_exe");
-        // Integration test executables live at
-        // `<workspace>/target/<profile>/deps/<test-name>-<hash>`; walk up
-        // two levels to reach the profile dir.
         let profile_dir = test_exe
             .parent()
             .and_then(|p| p.parent())
             .expect("integration test exe must live under target/<profile>/deps/");
-        let candidate = profile_dir.join(bin_filename("midori-driver-dummy"));
+        let candidate = profile_dir.join(bin_filename(bin_name));
         if !candidate.exists() {
-            // Force a build of the dummy binary into the same profile so
-            // the test does not silently fall back to a stale or missing
-            // artifact. Failure here is a hard test failure — there is no
-            // graceful fallback that preserves the meaning of the suite.
             let status = std::process::Command::new(env!("CARGO"))
-                .args(["build", "-p", "midori-driver-dummy"])
+                .args(["build", "-p", "midori-driver-dummy", "--bin", bin_name])
                 .status()
                 .expect("invoke cargo build for fixture");
-            assert!(
-                status.success(),
-                "cargo build of midori-driver-dummy failed"
-            );
+            assert!(status.success(), "cargo build of {bin_name} failed");
         }
         assert!(
             candidate.exists(),
@@ -54,7 +42,23 @@ fn dummy_bin_path() -> &'static std::path::Path {
             candidate.display()
         );
         candidate
-    })
+    }
+
+    match bin_name {
+        "midori-driver-dummy" => {
+            static CELL: OnceLock<PathBuf> = OnceLock::new();
+            CELL.get_or_init(|| resolve(bin_name))
+        }
+        "midori-driver-dummy-no-hello" => {
+            static CELL: OnceLock<PathBuf> = OnceLock::new();
+            CELL.get_or_init(|| resolve(bin_name))
+        }
+        "midori-driver-dummy-bad-version" => {
+            static CELL: OnceLock<PathBuf> = OnceLock::new();
+            CELL.get_or_init(|| resolve(bin_name))
+        }
+        other => panic!("unknown fixture binary requested: {other}"),
+    }
 }
 
 #[cfg(windows)]
@@ -67,19 +71,19 @@ fn bin_filename(stem: &str) -> String {
     stem.to_owned()
 }
 
-/// Table-driven layout: each row pins one fixture flag set to one expected
+/// Table-driven layout: each row pins one fixture binary to one expected
 /// outcome class. The actual assertions live in the per-row helpers because
 /// `SpawnError` is non-`Eq` and matching on its variants is the cleanest
 /// way to assert without overspecifying inner fields.
 struct SpawnCase {
     name: &'static str,
-    fixture_args: &'static [&'static str],
+    fixture_bin: &'static str,
     timeout: Duration,
 }
 
 const CASE_SUCCESS: SpawnCase = SpawnCase {
     name: "dummy-success",
-    fixture_args: &[],
+    fixture_bin: "midori-driver-dummy",
     // Production timeout is fine for the success path; the dummy emits hello
     // synchronously so the wait is effectively instantaneous.
     timeout: HANDSHAKE_TIMEOUT,
@@ -87,7 +91,7 @@ const CASE_SUCCESS: SpawnCase = SpawnCase {
 
 const CASE_TIMEOUT: SpawnCase = SpawnCase {
     name: "dummy-timeout",
-    fixture_args: &["--no-hello"],
+    fixture_bin: "midori-driver-dummy-no-hello",
     // Short enough that the suite stays fast, long enough that a slow CI
     // runner does not race the dummy's stdin-read setup.
     timeout: Duration::from_millis(200),
@@ -95,7 +99,7 @@ const CASE_TIMEOUT: SpawnCase = SpawnCase {
 
 const CASE_INCOMPAT: SpawnCase = SpawnCase {
     name: "dummy-incompat",
-    fixture_args: &["--bad-version"],
+    fixture_bin: "midori-driver-dummy-bad-version",
     timeout: HANDSHAKE_TIMEOUT,
 };
 
@@ -117,11 +121,10 @@ fn it_should_complete_handshake_against_dummy_driver() {
     drop(handle);
 }
 
-#[cfg(unix)]
 #[test]
 fn it_should_return_handshake_timeout_when_driver_does_not_emit_hello() {
     let case = CASE_TIMEOUT;
-    let err = spawn(&case).expect_err("--no-hello must surface as a timeout");
+    let err = spawn(&case).expect_err("no-hello fixture must surface as a timeout");
     match err {
         SpawnError::HandshakeTimeout(elapsed) => {
             assert_eq!(
@@ -133,11 +136,10 @@ fn it_should_return_handshake_timeout_when_driver_does_not_emit_hello() {
     }
 }
 
-#[cfg(unix)]
 #[test]
 fn it_should_return_incompatible_sdk_when_driver_advertises_unknown_version() {
     let case = CASE_INCOMPAT;
-    let err = spawn(&case).expect_err("--bad-version must surface as IncompatibleSdk");
+    let err = spawn(&case).expect_err("bad-version fixture must surface as IncompatibleSdk");
     match err {
         SpawnError::IncompatibleSdk {
             driver_version,
@@ -156,78 +158,10 @@ fn it_should_return_incompatible_sdk_when_driver_advertises_unknown_version() {
     }
 }
 
-/// Build a `SpawnError`-returning call from a [`SpawnCase`]. The fixture
-/// arguments are appended after the implicit `start` subcommand by the
-/// dummy binary's own argv parser; `spawn_driver` itself always passes
-/// `start`, and additional flags ride along via the binary path's args
-/// embedded as a wrapper script.
-///
-/// Since `Command::new(path)` only takes one arg list and `spawn_driver`
-/// already injects `start`, the helper materialises a small shell script
-/// per call when extra flags are needed. The shell-script path is unix-only;
-/// fixture-flag-using cases are gated with `#[cfg(unix)]` accordingly.
+/// Build a `SpawnError`-returning call from a [`SpawnCase`]. Each case
+/// resolves to a pre-built binary; no wrapper script or runtime fixture
+/// argument injection is needed.
 fn spawn(case: &SpawnCase) -> Result<midori_runtime::driver_proc::DriverHandle, SpawnError> {
-    let bin_path = if case.fixture_args.is_empty() {
-        dummy_bin_path().to_path_buf()
-    } else {
-        wrap_with_flags(case.name, case.fixture_args)
-    };
+    let bin_path = fixture_bin_path(case.fixture_bin).to_path_buf();
     spawn_driver_with_timeout(case.name, bin_path, &serde_json::json!({}), case.timeout)
-}
-
-/// Materialise a tiny shell wrapper that invokes the dummy binary with the
-/// supplied extra flags after the implicit `start` arg the Bridge always
-/// injects. The wrapper lives under the system temp directory and is
-/// kept around for the lifetime of the test process — small enough to
-/// not warrant explicit cleanup.
-#[cfg(unix)]
-fn wrap_with_flags(tag: &str, extra_args: &[&str]) -> std::path::PathBuf {
-    use std::io::Write as _;
-    use std::os::unix::fs::PermissionsExt as _;
-
-    let dir = std::env::temp_dir().join(format!("midori-driver-spawn-test-{tag}"));
-    std::fs::create_dir_all(&dir).expect("mkdir wrapper dir");
-    let script_path = dir.join("dummy-wrapper.sh");
-    let mut script = String::new();
-    script.push_str("#!/bin/sh\n");
-    script.push_str("exec ");
-    let dummy_path = dummy_bin_path()
-        .to_str()
-        .expect("dummy bin path must be UTF-8");
-    script.push_str(&shell_quote(dummy_path));
-    script.push_str(" \"$@\"");
-    for arg in extra_args {
-        script.push(' ');
-        script.push_str(&shell_quote(arg));
-    }
-    script.push('\n');
-    let mut f = std::fs::File::create(&script_path).expect("create wrapper");
-    f.write_all(script.as_bytes()).expect("write wrapper");
-    drop(f);
-    let mut perms = std::fs::metadata(&script_path)
-        .expect("stat wrapper")
-        .permissions();
-    perms.set_mode(0o755);
-    std::fs::set_permissions(&script_path, perms).expect("chmod wrapper");
-    script_path
-}
-
-#[cfg(not(unix))]
-fn wrap_with_flags(_tag: &str, _extra_args: &[&str]) -> std::path::PathBuf {
-    panic!("driver_spawn integration tests currently require a unix shell")
-}
-
-#[cfg(unix)]
-fn shell_quote(s: &str) -> String {
-    let mut out = String::with_capacity(s.len() + 2);
-    out.push('\'');
-    for ch in s.chars() {
-        if ch == '\'' {
-            out.push_str(r"'\''");
-        } else {
-            out.push(ch);
-        }
-    }
-    out.push('\'');
-    out
 }

--- a/crates/midori-runtime/tests/driver_spawn.rs
+++ b/crates/midori-runtime/tests/driver_spawn.rs
@@ -1,0 +1,229 @@
+//! Integration tests for the Bridge-side driver spawn / handshake flow.
+//!
+//! Each test runs `midori-driver-dummy` with one of three CLI flag shapes
+//! (default / `--no-hello` / `--bad-version`) and asserts the matching
+//! `spawn_driver` outcome. Cargo's `CARGO_BIN_EXE_<name>` env var only
+//! covers binaries declared in the same package as the test, so the
+//! fixture path is resolved at runtime by walking the workspace `target/`
+//! tree the test executable itself lives in.
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use midori_runtime::driver_proc::{spawn_driver_with_timeout, SpawnError, HANDSHAKE_TIMEOUT};
+
+/// Resolved path to the `midori-driver-dummy` fixture binary.
+///
+/// Cargo's `CARGO_BIN_EXE_<name>` env var is only set for binaries in the
+/// same package as the test, so this resolver walks the workspace `target/`
+/// tree the test's own `current_exe()` lives under and locates the
+/// sibling `midori-driver-dummy` artifact. Cargo always builds a workspace
+/// binary in the same profile dir as the integration test that depends on
+/// it transitively (the test crate's `[lib]` re-exports trigger a rebuild),
+/// but to be safe the resolver also issues an explicit `cargo build` for
+/// the binary when it isn't already present.
+fn dummy_bin_path() -> &'static std::path::Path {
+    static CELL: OnceLock<PathBuf> = OnceLock::new();
+    CELL.get_or_init(|| {
+        let test_exe = std::env::current_exe().expect("current_exe");
+        // Integration test executables live at
+        // `<workspace>/target/<profile>/deps/<test-name>-<hash>`; walk up
+        // two levels to reach the profile dir.
+        let profile_dir = test_exe
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("integration test exe must live under target/<profile>/deps/");
+        let candidate = profile_dir.join(bin_filename("midori-driver-dummy"));
+        if !candidate.exists() {
+            // Force a build of the dummy binary into the same profile so
+            // the test does not silently fall back to a stale or missing
+            // artifact. Failure here is a hard test failure — there is no
+            // graceful fallback that preserves the meaning of the suite.
+            let status = std::process::Command::new(env!("CARGO"))
+                .args(["build", "-p", "midori-driver-dummy"])
+                .status()
+                .expect("invoke cargo build for fixture");
+            assert!(
+                status.success(),
+                "cargo build of midori-driver-dummy failed"
+            );
+        }
+        assert!(
+            candidate.exists(),
+            "fixture binary not found at {}",
+            candidate.display()
+        );
+        candidate
+    })
+}
+
+#[cfg(windows)]
+fn bin_filename(stem: &str) -> String {
+    format!("{stem}.exe")
+}
+
+#[cfg(not(windows))]
+fn bin_filename(stem: &str) -> String {
+    stem.to_owned()
+}
+
+/// Table-driven layout: each row pins one fixture flag set to one expected
+/// outcome class. The actual assertions live in the per-row helpers because
+/// `SpawnError` is non-`Eq` and matching on its variants is the cleanest
+/// way to assert without overspecifying inner fields.
+struct SpawnCase {
+    name: &'static str,
+    fixture_args: &'static [&'static str],
+    timeout: Duration,
+}
+
+const CASE_SUCCESS: SpawnCase = SpawnCase {
+    name: "dummy-success",
+    fixture_args: &[],
+    // Production timeout is fine for the success path; the dummy emits hello
+    // synchronously so the wait is effectively instantaneous.
+    timeout: HANDSHAKE_TIMEOUT,
+};
+
+const CASE_TIMEOUT: SpawnCase = SpawnCase {
+    name: "dummy-timeout",
+    fixture_args: &["--no-hello"],
+    // Short enough that the suite stays fast, long enough that a slow CI
+    // runner does not race the dummy's stdin-read setup.
+    timeout: Duration::from_millis(200),
+};
+
+const CASE_INCOMPAT: SpawnCase = SpawnCase {
+    name: "dummy-incompat",
+    fixture_args: &["--bad-version"],
+    timeout: HANDSHAKE_TIMEOUT,
+};
+
+#[test]
+fn it_should_complete_handshake_against_dummy_driver() {
+    let case = CASE_SUCCESS;
+    let handle = spawn(&case).unwrap_or_else(|err| {
+        panic!("expected success, got {err:?}");
+    });
+    assert_eq!(handle.name, case.name);
+    assert!(
+        !handle.sdk_version.is_empty(),
+        "driver must report a non-empty SDK version on the success path"
+    );
+    // Dropping the handle drops `ChildStdin` first, which closes the write
+    // half of the pipe. The dummy's BufRead loop terminates on the
+    // resulting EOF. The `Child` is not waited on here — that's subtask
+    // (b)'s lifecycle responsibility — but the dummy exiting promptly on
+    // stdin EOF is what makes (b) able to wait without hanging.
+    drop(handle);
+}
+
+#[test]
+fn it_should_return_handshake_timeout_when_driver_does_not_emit_hello() {
+    let case = CASE_TIMEOUT;
+    let err = spawn(&case).expect_err("--no-hello must surface as a timeout");
+    assert!(
+        matches!(err, SpawnError::HandshakeTimeout),
+        "expected HandshakeTimeout, got {err:?}"
+    );
+}
+
+#[test]
+fn it_should_return_incompatible_sdk_when_driver_advertises_unknown_version() {
+    let case = CASE_INCOMPAT;
+    let err = spawn(&case).expect_err("--bad-version must surface as IncompatibleSdk");
+    match err {
+        SpawnError::IncompatibleSdk {
+            driver_version,
+            reason,
+        } => {
+            assert!(
+                driver_version.starts_with("99."),
+                "driver_version should echo the advertised value, got {driver_version}"
+            );
+            assert!(
+                reason.contains("major"),
+                "reason should describe the major-mismatch, got {reason}"
+            );
+        }
+        other => panic!("expected IncompatibleSdk, got {other:?}"),
+    }
+}
+
+/// Build a `SpawnError`-returning call from a [`SpawnCase`]. The fixture
+/// arguments are appended after the implicit `start` subcommand by the
+/// dummy binary's own argv parser; `spawn_driver` itself always passes
+/// `start`, and additional flags ride along via the binary path's args
+/// embedded as a wrapper script.
+///
+/// Since `Command::new(path)` only takes one arg list and `spawn_driver`
+/// already injects `start`, we materialise the wrapper as a small shell
+/// script per call when extra flags are needed. On platforms without
+/// `/bin/sh` this would need adjustment; the runtime is currently tested
+/// on Linux only via CI.
+fn spawn(case: &SpawnCase) -> Result<midori_runtime::driver_proc::DriverHandle, SpawnError> {
+    let bin_path = if case.fixture_args.is_empty() {
+        dummy_bin_path().to_path_buf()
+    } else {
+        wrap_with_flags(case.name, case.fixture_args)
+    };
+    spawn_driver_with_timeout(case.name, bin_path, serde_json::json!({}), case.timeout)
+}
+
+/// Materialise a tiny shell wrapper that invokes the dummy binary with the
+/// supplied extra flags after the implicit `start` arg the Bridge always
+/// injects. The wrapper lives under the system temp directory and is
+/// kept around for the lifetime of the test process — small enough to
+/// not warrant explicit cleanup.
+#[cfg(unix)]
+fn wrap_with_flags(tag: &str, extra_args: &[&str]) -> std::path::PathBuf {
+    use std::io::Write as _;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = std::env::temp_dir().join(format!("midori-driver-spawn-test-{tag}"));
+    std::fs::create_dir_all(&dir).expect("mkdir wrapper dir");
+    let script_path = dir.join("dummy-wrapper.sh");
+    let mut script = String::new();
+    script.push_str("#!/bin/sh\n");
+    script.push_str("exec ");
+    let dummy_path = dummy_bin_path()
+        .to_str()
+        .expect("dummy bin path must be UTF-8");
+    script.push_str(&shell_quote(dummy_path));
+    script.push_str(" \"$@\"");
+    for arg in extra_args {
+        script.push(' ');
+        script.push_str(&shell_quote(arg));
+    }
+    script.push('\n');
+    let mut f = std::fs::File::create(&script_path).expect("create wrapper");
+    f.write_all(script.as_bytes()).expect("write wrapper");
+    drop(f);
+    let mut perms = std::fs::metadata(&script_path)
+        .expect("stat wrapper")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script_path, perms).expect("chmod wrapper");
+    script_path
+}
+
+#[cfg(not(unix))]
+fn wrap_with_flags(_tag: &str, _extra_args: &[&str]) -> std::path::PathBuf {
+    panic!("driver_spawn integration tests currently require a unix shell")
+}
+
+#[cfg(unix)]
+fn shell_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str(r"'\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}


### PR DESCRIPTION
## Summary

- Adds `spawn_driver` / `DriverHandle` / `SpawnError` to `midori-runtime::driver_proc`, completing the hello / hello_ack JSON Lines handshake against a driver subprocess and returning a live handle that owns the child plus its stdin pipe.
- Introduces the `midori-driver-dummy` workspace crate as a test fixture with `--no-hello` and `--bad-version` flags so the spawn flow can be exercised deterministically across success / timeout / incompatible-SDK regimes.
- Implementation stays sync (`std::process` + worker thread + `mpsc::recv_timeout`); no tokio dependency added.

## Scope boundary

Lifecycle management (graceful shutdown, log forwarding from post-handshake stdout, SIGTERM/SIGKILL escalation) is intentionally deferred to subtask (b). The dummy driver's stdin `BufRead` loop body is a no-op scaffold that subtask (b) will fill in with `connect` / `disconnect` / `configure` handlers.

## Acceptance Criteria

- [x] `spawn_driver(name, path, profile)` returns `DriverHandle` on success
- [x] Driver `hello` interpreted from stdout, SDK compatibility decided, `hello_ack { compatible: bool }` written to stdin
- [x] `hello_ack { compatible: false, reason }` sent before returning `SpawnError::IncompatibleSdk`
- [x] `HANDSHAKE_TIMEOUT = Duration::from_secs(5)` constant; overrun → `SpawnError::HandshakeTimeout`
- [x] EOF on stdout before `hello` → `SpawnError::HandshakeMissing`
- [x] `crates/midori-driver-dummy/` exists with `start` subcommand parser, valid hello emission, and a stdin `BufRead` loop scaffold for subtask (b)
- [x] 3 unit tests (success / HandshakeTimeout / IncompatibleSdk)

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo deny check`

Closes MEW-64.
Part of #58.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ドライバー子プロセスの起動・監督とJSONベースのハンドシェイクによるSDK互換性判定を追加しました。
  * ランタイムからドライバー監督機能が利用可能になりました（公開モジュールの追加）。

* **Tests**
  * 起動成功、ハンドシェイクタイムアウト、SDK非互換を検証する統合テストを追加しました。

* **Chores**
  * テスト用のダミードライバ（複数バイナリのフィクスチャ）をワークスペースに追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->