### PR TITLE
feat(runtime): wire driver lifecycle commands and stdout log forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +322,7 @@ name = "midori-driver-dummy"
 version = "0.1.0"
 dependencies = [
  "serde_json",
+ "signal-hook",
 ]
 
 [[package]]
@@ -339,6 +346,7 @@ dependencies = [
  "clap",
  "dirs",
  "midori-core",
+ "nix",
  "rmpv",
  "serde",
  "serde_json",
@@ -355,6 +363,18 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]

--- a/crates/midori-driver-dummy/Cargo.toml
+++ b/crates/midori-driver-dummy/Cargo.toml
@@ -50,8 +50,8 @@ serde_json = "1"
 
 # Sync signal handler used by the SIGTERM fixtures. signal-hook is already
 # in the workspace lock via `midori-sdk` so no new transitive surface is
-# introduced. Only the Unix targets actually install the handler — Windows
-# parent-side signal handling is out of scope for the parent issue.
+# introduced. Windows lacks POSIX signals so the dependency is unix-only;
+# Windows fixtures fall back to stdin-EOF for shutdown.
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.4"
 

--- a/crates/midori-driver-dummy/Cargo.toml
+++ b/crates/midori-driver-dummy/Cargo.toml
@@ -25,8 +25,35 @@ path = "src/main.rs"
 name = "midori-driver-dummy-bad-version"
 path = "src/main.rs"
 
+# Lifecycle / log-forwarding fixtures. Each variant is a separate binary
+# so the integration test resolves an exact pre-built path — same rationale
+# as the handshake fixtures above.
+
+[[bin]]
+name = "midori-driver-dummy-noisy-stdout"
+path = "src/main.rs"
+
+[[bin]]
+name = "midori-driver-dummy-sigterm-graceful"
+path = "src/main.rs"
+
+[[bin]]
+name = "midori-driver-dummy-sigterm-ignore"
+path = "src/main.rs"
+
+[[bin]]
+name = "midori-driver-dummy-exit-error"
+path = "src/main.rs"
+
 [dependencies]
 serde_json = "1"
+
+# Sync signal handler used by the SIGTERM fixtures. signal-hook is already
+# in the workspace lock via `midori-sdk` so no new transitive surface is
+# introduced. Only the Unix targets actually install the handler — Windows
+# parent-side signal handling is out of scope for the parent issue.
+[target.'cfg(unix)'.dependencies]
+signal-hook = "0.4"
 
 [lints]
 workspace = true

--- a/crates/midori-driver-dummy/src/main.rs
+++ b/crates/midori-driver-dummy/src/main.rs
@@ -27,8 +27,11 @@
 //!   SIGTERM handler that ignores the signal entirely. Forces the bridge's
 //!   SIGKILL escalation path. Also ignores stdin EOF so the only way out
 //!   is the SIGKILL the bridge sends after its grace period.
-//! - `midori-driver-dummy-exit-error`: emit `hello`, then exit with status
-//!   1 immediately. Exercises the bridge's abnormal-exit logging.
+//! - `midori-driver-dummy-exit-error`: emit `hello`, read one line from
+//!   stdin to synchronize on the bridge's `hello_ack` write (so the
+//!   subsequent exit does not race the ack and surface as `BrokenPipe`),
+//!   then exit with status 1. Exercises the bridge's abnormal-exit
+//!   logging.
 //!
 //! Selecting fixture mode by binary name (rather than by CLI flag) lets the
 //! integration test hand `spawn_driver` an exact, pre-built binary path —
@@ -195,10 +198,18 @@ fn run_sigterm_graceful() -> ExitCode {
     }
     #[cfg(unix)]
     {
+        // Drain stdin in the background so the bridge's pre-shutdown
+        // control writes (connect / configure / disconnect) cannot fill
+        // the OS pipe buffer and stall the parent on its way to `Drop`.
+        // The drain thread is detached: when the main thread returns
+        // `ExitCode::SUCCESS`, process exit tears it down regardless of
+        // its current state.
+        std::thread::spawn(|| {
+            let _ = drain_stdin_until_eof();
+        });
         // Poll the flag in a tight-but-bounded loop. The bridge's `Drop`
         // sends SIGTERM, this fixture flips the flag, the next iteration
-        // exits cleanly. Stdin is intentionally not consumed — the test
-        // checks the SIGTERM path, not the stdin-EOF path.
+        // exits cleanly.
         while !shutdown.load(Ordering::SeqCst) {
             std::thread::sleep(SIGTERM_POLL_INTERVAL);
         }

--- a/crates/midori-driver-dummy/src/main.rs
+++ b/crates/midori-driver-dummy/src/main.rs
@@ -1,19 +1,34 @@
-//! Test fixture driver binary used by Bridge spawn / handshake tests.
+//! Test fixture driver binary used by Bridge spawn / handshake / lifecycle
+//! tests.
 //!
 //! This binary speaks the driver-side half of the JSON Lines control protocol
 //! described in `design/10-driver-plugin.md`「通信アーキテクチャ」「バージョン互換性」.
-//! Three compiled binaries share this source file, each selecting a fixture
-//! mode via the build-time `CARGO_BIN_NAME`:
+//! Multiple compiled binaries share this source file, each selecting a
+//! fixture mode via the build-time `CARGO_BIN_NAME`:
 //!
-//! - `midori-driver-dummy`: emit a valid `hello` and drain stdin until EOF.
-//!   The drain loop is a deliberate no-op so a future change can slot a
-//!   message dispatcher in without restructuring the binary.
-//! - `midori-driver-dummy-no-hello`: never emit `hello`. Used to exercise
-//!   the Bridge's handshake-timeout path.
+//! Handshake fixtures:
+//! - `midori-driver-dummy`: emit a valid `hello`, accept any control
+//!   messages on stdin (each is acknowledged on stderr as a no-op), and
+//!   exit on stdin EOF.
+//! - `midori-driver-dummy-no-hello`: never emit `hello`. Exercises the
+//!   Bridge's handshake-timeout path.
 //! - `midori-driver-dummy-bad-version`: emit a `hello` whose `sdk_version`
-//!   reports a major outside the Bridge's accepted-major set (defined as
-//!   `ACCEPTED_SDK_MAJORS` in the runtime crate's `driver_proc` module).
-//!   Used to exercise the `IncompatibleSdk` path.
+//!   reports a major outside the Bridge's accepted-major set. Exercises
+//!   the `IncompatibleSdk` path.
+//!
+//! Lifecycle / log-forwarding fixtures:
+//! - `midori-driver-dummy-noisy-stdout`: emit `hello`, then write a
+//!   non-JSON line to stdout, then idle until stdin EOF / SIGTERM.
+//!   Exercises the bridge's "non-JSON stdout → log forwarder" path.
+//! - `midori-driver-dummy-sigterm-graceful`: emit `hello`, install a
+//!   SIGTERM handler that sets a shutdown flag, and poll the flag in the
+//!   stdin loop so SIGTERM produces a clean exit.
+//! - `midori-driver-dummy-sigterm-ignore`: emit `hello`, install a
+//!   SIGTERM handler that ignores the signal entirely. Forces the bridge's
+//!   SIGKILL escalation path. Also ignores stdin EOF so the only way out
+//!   is the SIGKILL the bridge sends after its grace period.
+//! - `midori-driver-dummy-exit-error`: emit `hello`, then exit with status
+//!   1 immediately. Exercises the bridge's abnormal-exit logging.
 //!
 //! Selecting fixture mode by binary name (rather than by CLI flag) lets the
 //! integration test hand `spawn_driver` an exact, pre-built binary path —
@@ -26,15 +41,24 @@
 
 use std::io::{BufRead, BufReader, Write};
 use std::process::ExitCode;
+#[cfg(unix)]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(unix)]
+use std::sync::Arc;
+use std::time::Duration;
 
 /// Fixture mode resolved from the binary's compiled-in name. The runtime
 /// fall-through to `Success` is just for forward-compatibility — every
-/// binary actually shipped here matches one of the three known names.
+/// binary actually shipped here matches one of the known names.
 #[derive(Debug, Clone, Copy)]
 enum FixtureMode {
     Success,
     NoHello,
     BadVersion,
+    NoisyStdout,
+    SigtermGraceful,
+    SigtermIgnore,
+    ExitError,
 }
 
 const fn fixture_mode_for(bin_name: &str) -> FixtureMode {
@@ -43,6 +67,14 @@ const fn fixture_mode_for(bin_name: &str) -> FixtureMode {
         FixtureMode::NoHello
     } else if matches_const(bytes, b"midori-driver-dummy-bad-version") {
         FixtureMode::BadVersion
+    } else if matches_const(bytes, b"midori-driver-dummy-noisy-stdout") {
+        FixtureMode::NoisyStdout
+    } else if matches_const(bytes, b"midori-driver-dummy-sigterm-graceful") {
+        FixtureMode::SigtermGraceful
+    } else if matches_const(bytes, b"midori-driver-dummy-sigterm-ignore") {
+        FixtureMode::SigtermIgnore
+    } else if matches_const(bytes, b"midori-driver-dummy-exit-error") {
+        FixtureMode::ExitError
     } else {
         FixtureMode::Success
     }
@@ -73,6 +105,11 @@ const DEFAULT_SDK_VERSION: &str = "0.1.0";
 /// `hello_ack { compatible: false }` and surfaces `IncompatibleSdk`.
 const BAD_SDK_VERSION: &str = "99.0.0";
 
+/// Polling interval used by the SIGTERM-graceful fixture's stdin loop. Short
+/// enough that the test does not have to budget seconds of wall-clock to
+/// observe a clean exit; long enough that the loop is not a busy-wait.
+const SIGTERM_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
 fn main() -> ExitCode {
     let mut args = std::env::args();
     let _bin = args.next();
@@ -92,27 +129,132 @@ fn main() -> ExitCode {
 
 fn exec_start() -> ExitCode {
     match FIXTURE {
-        FixtureMode::Success => {
-            if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
-                eprintln!("midori-driver-dummy: failed to write hello: {err}");
-                return ExitCode::FAILURE;
-            }
+        FixtureMode::Success => run_success(),
+        FixtureMode::NoHello => run_no_hello(),
+        FixtureMode::BadVersion => run_bad_version(),
+        FixtureMode::NoisyStdout => run_noisy_stdout(),
+        FixtureMode::SigtermGraceful => run_sigterm_graceful(),
+        FixtureMode::SigtermIgnore => run_sigterm_ignore(),
+        FixtureMode::ExitError => run_exit_error(),
+    }
+}
+
+fn run_success() -> ExitCode {
+    if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
+        eprintln!("midori-driver-dummy: failed to write hello: {err}");
+        return ExitCode::FAILURE;
+    }
+    drain_stdin_until_eof()
+}
+
+fn run_no_hello() -> ExitCode {
+    // Skip hello emission; the test relies on the Bridge timing out.
+    // Idle on stdin so we do not exit before the bridge's timeout fires.
+    drain_stdin_until_eof()
+}
+
+fn run_bad_version() -> ExitCode {
+    if let Err(err) = emit_hello_line(BAD_SDK_VERSION) {
+        eprintln!("midori-driver-dummy: failed to write hello: {err}");
+        return ExitCode::FAILURE;
+    }
+    drain_stdin_until_eof()
+}
+
+fn run_noisy_stdout() -> ExitCode {
+    if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
+        eprintln!("midori-driver-dummy: failed to write hello: {err}");
+        return ExitCode::FAILURE;
+    }
+    // Emit a line that is **not** valid JSON. The bridge's log forwarder
+    // wraps this into a `type=log layer=driver/<name>` entry.
+    if let Err(err) = emit_raw_stdout_line("midori-driver-dummy: noisy debug line") {
+        eprintln!("midori-driver-dummy: failed to write noisy line: {err}");
+        return ExitCode::FAILURE;
+    }
+    drain_stdin_until_eof()
+}
+
+fn run_sigterm_graceful() -> ExitCode {
+    if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
+        eprintln!("midori-driver-dummy: failed to write hello: {err}");
+        return ExitCode::FAILURE;
+    }
+    #[cfg(unix)]
+    {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        if let Err(err) = install_sigterm_flag(&shutdown) {
+            eprintln!("midori-driver-dummy: failed to install SIGTERM handler: {err}");
+            return ExitCode::FAILURE;
         }
-        FixtureMode::NoHello => {
-            // Skip hello emission; the test relies on the Bridge timing out.
+        // Poll the flag in a tight-but-bounded loop. The bridge's `Drop`
+        // sends SIGTERM, this fixture flips the flag, the next iteration
+        // exits cleanly. Stdin is intentionally not consumed — the test
+        // checks the SIGTERM path, not the stdin-EOF path.
+        while !shutdown.load(Ordering::SeqCst) {
+            std::thread::sleep(SIGTERM_POLL_INTERVAL);
         }
-        FixtureMode::BadVersion => {
-            if let Err(err) = emit_hello_line(BAD_SDK_VERSION) {
-                eprintln!("midori-driver-dummy: failed to write hello: {err}");
-                return ExitCode::FAILURE;
-            }
+        ExitCode::SUCCESS
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows: just drain stdin. The bridge's SIGKILL fallback (via
+        // `Child::kill()` → `TerminateProcess`) is the test's expectation
+        // there; the parent issue treats Windows lifecycle as out of scope.
+        drain_stdin_until_eof()
+    }
+}
+
+fn run_sigterm_ignore() -> ExitCode {
+    if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
+        eprintln!("midori-driver-dummy: failed to write hello: {err}");
+        return ExitCode::FAILURE;
+    }
+    #[cfg(unix)]
+    {
+        if let Err(err) = install_sigterm_ignore() {
+            eprintln!("midori-driver-dummy: failed to ignore SIGTERM: {err}");
+            return ExitCode::FAILURE;
+        }
+        // Sleep forever. Stdin EOF is also ignored — the bridge must use
+        // SIGKILL to terminate. SIGKILL bypasses signal handlers and Rust's
+        // process exits with the default signal-termination status.
+        loop {
+            std::thread::sleep(Duration::from_mins(1));
         }
     }
+    #[cfg(not(unix))]
+    {
+        loop {
+            std::thread::sleep(Duration::from_mins(1));
+        }
+    }
+}
 
-    // Drain stdin until EOF. The loop body is a deliberate no-op: the parent
-    // closes stdin when it wants the child gone, and the BufRead structure
-    // is the slot a future change can fill with a message dispatcher
-    // without reshaping the binary.
+fn run_exit_error() -> ExitCode {
+    if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
+        eprintln!("midori-driver-dummy: failed to write hello: {err}");
+        return ExitCode::FAILURE;
+    }
+    // Wait for the bridge's hello_ack on stdin before exiting. Without this
+    // wait, the child would frequently exit before the bridge finishes
+    // writing hello_ack, surfacing as `HelloAckWrite(BrokenPipe)` on the
+    // bridge side and masking the abnormal-exit code path under test.
+    // Reading exactly one line is enough — we do not interpret the ack
+    // content, only synchronize on its arrival.
+    let stdin = std::io::stdin();
+    let mut handle = stdin.lock();
+    let mut line = String::new();
+    let _ = handle.read_line(&mut line);
+    drop(handle);
+    ExitCode::from(1)
+}
+
+/// Drain stdin until EOF. The loop body is a deliberate no-op: the parent
+/// closes stdin when it wants the child gone, and the `BufRead` structure
+/// is the slot a future change can fill with a message dispatcher
+/// without reshaping the binary.
+fn drain_stdin_until_eof() -> ExitCode {
     let stdin = std::io::stdin();
     let reader = BufReader::new(stdin.lock());
     for line in reader.lines() {
@@ -127,6 +269,32 @@ fn exec_start() -> ExitCode {
     ExitCode::SUCCESS
 }
 
+#[cfg(unix)]
+fn install_sigterm_flag(flag: &Arc<AtomicBool>) -> std::io::Result<()> {
+    use signal_hook::consts::SIGTERM;
+    signal_hook::flag::register(SIGTERM, Arc::clone(flag))?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn install_sigterm_ignore() -> std::io::Result<()> {
+    use signal_hook::consts::SIGTERM;
+    // signal-hook's safe `flag::register` API replaces the default action
+    // (terminate) with a "set this AtomicBool" handler. We register a flag
+    // we never read, which is equivalent to ignoring SIGTERM from the
+    // kernel's perspective: the signal arrives, the handler runs, the
+    // handler returns, and the process keeps going. The bridge then has
+    // to escalate to SIGKILL after its grace period.
+    //
+    // Going through `signal_hook::flag::register` (rather than the
+    // closure-taking `signal_hook_registry::register` which is `unsafe`)
+    // keeps this fixture compatible with the workspace's
+    // `unsafe_code = "forbid"` lint.
+    let sink = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(SIGTERM, sink)?;
+    Ok(())
+}
+
 fn emit_hello_line(sdk_version: &str) -> std::io::Result<()> {
     let stdout = std::io::stdout();
     let mut out = stdout.lock();
@@ -135,6 +303,14 @@ fn emit_hello_line(sdk_version: &str) -> std::io::Result<()> {
         "sdk_version": sdk_version,
     });
     serde_json::to_writer(&mut out, &payload)?;
+    out.write_all(b"\n")?;
+    out.flush()
+}
+
+fn emit_raw_stdout_line(line: &str) -> std::io::Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    out.write_all(line.as_bytes())?;
     out.write_all(b"\n")?;
     out.flush()
 }

--- a/crates/midori-driver-dummy/src/main.rs
+++ b/crates/midori-driver-dummy/src/main.rs
@@ -21,8 +21,9 @@
 //!   non-JSON line to stdout, then idle until stdin EOF / SIGTERM.
 //!   Exercises the bridge's "non-JSON stdout → log forwarder" path.
 //! - `midori-driver-dummy-sigterm-graceful`: emit `hello`, install a
-//!   SIGTERM handler that sets a shutdown flag, and poll the flag in the
-//!   stdin loop so SIGTERM produces a clean exit.
+//!   SIGTERM handler that sets a shutdown flag, then poll the flag on
+//!   the main thread while a background thread drains stdin so the
+//!   bridge's pre-shutdown control writes never stall the parent.
 //! - `midori-driver-dummy-sigterm-ignore`: emit `hello`, install a
 //!   SIGTERM handler that ignores the signal entirely. Forces the bridge's
 //!   SIGKILL escalation path. Also ignores stdin EOF so the only way out

--- a/crates/midori-driver-dummy/src/main.rs
+++ b/crates/midori-driver-dummy/src/main.rs
@@ -7,9 +7,9 @@
 //! fixture mode via the build-time `CARGO_BIN_NAME`:
 //!
 //! Handshake fixtures:
-//! - `midori-driver-dummy`: emit a valid `hello`, accept any control
-//!   messages on stdin (each is acknowledged on stderr as a no-op), and
-//!   exit on stdin EOF.
+//! - `midori-driver-dummy`: emit a valid `hello`, silently discard any
+//!   control messages on stdin, and exit on stdin EOF. The body of the
+//!   stdin loop is a deliberate no-op slot for future handler dispatch.
 //! - `midori-driver-dummy-no-hello`: never emit `hello`. Exercises the
 //!   Bridge's handshake-timeout path.
 //! - `midori-driver-dummy-bad-version`: emit a `hello` whose `sdk_version`
@@ -198,9 +198,9 @@ fn run_sigterm_graceful() -> ExitCode {
     }
     #[cfg(not(unix))]
     {
-        // Windows: just drain stdin. The bridge's SIGKILL fallback (via
-        // `Child::kill()` → `TerminateProcess`) is the test's expectation
-        // there; the parent issue treats Windows lifecycle as out of scope.
+        // Windows lacks SIGTERM; the bridge falls back to closing stdin and
+        // letting the kernel reap the child. Drain stdin until EOF so the
+        // fixture exits when the parent decides to shut it down.
         drain_stdin_until_eof()
     }
 }

--- a/crates/midori-driver-dummy/src/main.rs
+++ b/crates/midori-driver-dummy/src/main.rs
@@ -176,17 +176,25 @@ fn run_noisy_stdout() -> ExitCode {
 }
 
 fn run_sigterm_graceful() -> ExitCode {
+    // Install the handler BEFORE emitting hello: the bridge cannot send
+    // SIGTERM until it has read hello, so registering first guarantees the
+    // signal arrives at an installed handler regardless of how slow the
+    // CI runner is between handshake completion and the test's `drop`.
+    #[cfg(unix)]
+    let shutdown = {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        if let Err(err) = install_sigterm_flag(&shutdown) {
+            eprintln!("midori-driver-dummy: failed to install SIGTERM handler: {err}");
+            return ExitCode::FAILURE;
+        }
+        shutdown
+    };
     if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
         eprintln!("midori-driver-dummy: failed to write hello: {err}");
         return ExitCode::FAILURE;
     }
     #[cfg(unix)]
     {
-        let shutdown = Arc::new(AtomicBool::new(false));
-        if let Err(err) = install_sigterm_flag(&shutdown) {
-            eprintln!("midori-driver-dummy: failed to install SIGTERM handler: {err}");
-            return ExitCode::FAILURE;
-        }
         // Poll the flag in a tight-but-bounded loop. The bridge's `Drop`
         // sends SIGTERM, this fixture flips the flag, the next iteration
         // exits cleanly. Stdin is intentionally not consumed — the test
@@ -206,16 +214,23 @@ fn run_sigterm_graceful() -> ExitCode {
 }
 
 fn run_sigterm_ignore() -> ExitCode {
-    if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
-        eprintln!("midori-driver-dummy: failed to write hello: {err}");
-        return ExitCode::FAILURE;
-    }
+    // Same install-before-hello ordering as `run_sigterm_graceful`: the
+    // race between hello emission and handler registration would otherwise
+    // let SIGTERM hit a still-default-action process and end the test
+    // before the SIGKILL escalation path runs.
     #[cfg(unix)]
     {
         if let Err(err) = install_sigterm_ignore() {
             eprintln!("midori-driver-dummy: failed to ignore SIGTERM: {err}");
             return ExitCode::FAILURE;
         }
+    }
+    if let Err(err) = emit_hello_line(DEFAULT_SDK_VERSION) {
+        eprintln!("midori-driver-dummy: failed to write hello: {err}");
+        return ExitCode::FAILURE;
+    }
+    #[cfg(unix)]
+    {
         // Sleep forever. Stdin EOF is also ignored — the bridge must use
         // SIGKILL to terminate. SIGKILL bypasses signal handlers and Rust's
         // process exits with the default signal-termination status.

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -23,6 +23,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
 
+# Safe Unix syscall wrappers. Used by `driver_proc` to send SIGTERM to a
+# child process without an `unsafe { libc::kill }` block — the workspace
+# forbids `unsafe_code` (see `Cargo.toml` workspace lints).
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.30", default-features = false, features = ["signal"] }
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/crates/midori-runtime/src/driver_proc.rs
+++ b/crates/midori-runtime/src/driver_proc.rs
@@ -136,7 +136,7 @@ impl Default for SpawnOptions {
 /// background threads that:
 /// - own the child process and `wait()` for it on a dedicated thread
 ///   (the "watcher"), flipping a shared liveness flag when the child exits;
-/// - drain the post-handshake stdout stream and forward each non-JSON line
+/// - drain the post-handshake stdout stream and forward each line
 ///   into the bridge logger (the "log forwarder").
 ///
 /// Dropping the handle closes stdin, sends SIGTERM, polls the liveness
@@ -252,16 +252,18 @@ impl Drop for DriverHandle {
 
         terminate_with_grace(&self.alive, self.child_pid, self.shutdown_grace);
 
-        // Join background threads so their drop runs synchronously rather
-        // than detaching. The watcher's `child.wait()` is what actually
-        // reaps the kernel-level corpse, so joining it is what guarantees
-        // the child is gone before this `Drop` returns. Any join error is
-        // swallowed — the threads only ever panic on logger writer errors
-        // which the logger itself already swallows.
-        if let Some(handle) = self.log_forwarder.take() {
+        // Join the watcher first: its `child.wait()` is what reaps the kernel
+        // corpse, so once the watcher returns the child stdout pipe is
+        // guaranteed to have closed. The log-forwarder, which blocks on
+        // `read_line` against that pipe, can then unblock immediately on EOF
+        // — joining it second avoids an arbitrary wait while the child is
+        // still in the kernel's signal-delivery window. Join errors are
+        // swallowed because the inner threads only panic on logger writer
+        // errors, which the logger already absorbs.
+        if let Some(handle) = self.watcher.take() {
             let _ = handle.join();
         }
-        if let Some(handle) = self.watcher.take() {
+        if let Some(handle) = self.log_forwarder.take() {
             let _ = handle.join();
         }
     }
@@ -273,10 +275,10 @@ pub enum SpawnError {
     /// `Command::spawn` itself failed (binary missing, permission denied, …).
     Spawn(std::io::Error),
     /// The driver process started but did not emit `hello` within the
-    /// supplied timeout. Carries the actual budget that elapsed so the
-    /// `Display` impl can report the value the caller passed in (which
-    /// differs from [`HANDSHAKE_TIMEOUT`] in tests). The child is killed
-    /// before this is returned.
+    /// supplied timeout. Carries the configured budget so the `Display` impl
+    /// can echo the value the caller passed in (tests use a much shorter
+    /// timeout than [`HANDSHAKE_TIMEOUT`]). The child is killed before this
+    /// is returned.
     HandshakeTimeout(Duration),
     /// The driver closed stdout (and/or exited) without ever emitting
     /// `hello`. This is the EOF-before-handshake path.
@@ -671,11 +673,11 @@ fn send_sigterm(pid: u32) {
 
 #[cfg(not(unix))]
 fn send_sigterm(_pid: u32) {
-    // Windows lifecycle handling is out of scope for the parent issue.
-    // `send_sigkill` below also no-ops, so a Windows build of this code
-    // path effectively relies on the child exiting via stdin EOF. Wiring
-    // `TerminateProcess` is deferred until a later issue actually targets
-    // Windows.
+    // Windows lacks POSIX signals; the equivalent shutdown path requires
+    // `TerminateProcess`, which has different semantics (no graceful window).
+    // Until the lifecycle module is taught to switch between models, this
+    // build target relies on the child exiting via stdin EOF, and
+    // `send_sigkill` below is also a no-op.
 }
 
 /// Send `SIGKILL` to `pid`. Best-effort — ESRCH is ignored.

--- a/crates/midori-runtime/src/driver_proc.rs
+++ b/crates/midori-runtime/src/driver_proc.rs
@@ -3,7 +3,8 @@
 //!
 //! # Protocol
 //!
-//! The wire format is `design/10-driver-plugin.md`「バージョン互換性」:
+//! The wire format is `design/10-driver-plugin.md`「バージョン互換性」「通信
+//! アーキテクチャ」:
 //!
 //! ```jsonc
 //! // Driver → Bridge stdout (first line)
@@ -13,7 +14,19 @@
 //! {"type": "hello_ack", "compatible": true}
 //! // or
 //! {"type": "hello_ack", "compatible": false, "reason": "sdk 1.0.0 is too old, require >=1.2.0"}
+//!
+//! // Bridge → Driver stdin (post-handshake control messages)
+//! {"type": "connect",    "device": "...", "config": {...}}
+//! {"type": "disconnect", "device": "..."}
+//! {"type": "configure",  "payload": {...}}
 //! ```
+//!
+//! Control messages are fire-and-forget: the bridge does not wait on a
+//! response. Driver-originated stdout lines after `hello` are JSON Lines
+//! containing events / state, and any line that fails to parse as JSON is
+//! treated as a debug log line and forwarded to the bridge logger under the
+//! `driver/<name>` layer (spec line 150: "stdout の行が有効な JSON でなけれ
+//! ばデバッグログとしてイベントログに転送する").
 //!
 //! # Concurrency model
 //!
@@ -23,26 +36,47 @@
 //! handshake duration. The runtime crate does not depend on tokio, and the
 //! handshake is short-lived enough that a thread-per-spawn model is fine.
 //!
-//! # Scope
+//! After the handshake, ownership of the stdout `BufReader` transfers into a
+//! long-lived "log forwarder" thread that drains the rest of the stream into
+//! [`crate::logging`]. A second long-lived "watcher" thread calls
+//! `child.wait()` to detect abnormal exits, flipping a shared
+//! `Arc<AtomicBool>` that backs [`DriverHandle::is_alive`].
 //!
-//! This module handles spawn + handshake only. Lifecycle management
-//! (graceful shutdown, log forwarding from the post-handshake stdout stream,
-//! SIGTERM / SIGKILL escalation) lives elsewhere and is intentionally not
-//! part of this module's surface.
+//! # Lifecycle / shutdown
+//!
+//! [`DriverHandle`] owns the child process. Its [`Drop`] impl performs the
+//! "SIGTERM → grace period → SIGKILL" escalation required by
+//! `design/10-driver-plugin.md`「Bridge によるライフサイクル管理」:
+//!
+//! 1. Send `SIGTERM` (Unix only — Windows lifecycle is out of scope).
+//! 2. Poll `child.try_wait()` until the grace period elapses.
+//! 3. If the child has not exited, escalate to `child.kill()` (SIGKILL on
+//!    Unix) and `wait()` the corpse so the caller does not leak a zombie.
+//!
+//! Tests construct handles via [`spawn_driver_with_options`] with a short
+//! grace period to keep the suite fast.
 
 use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
-use std::process::{Child, ChildStdin, Command, Stdio};
-use std::sync::mpsc;
-use std::thread;
-use std::time::Duration;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{mpsc, Arc};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 /// Default upper bound on how long [`spawn_driver`] waits for the driver to
 /// emit its `hello` line. Drivers are expected to write `hello` synchronously
 /// at the top of `main()`, so 5 seconds is multiple orders of magnitude
-/// beyond the realistic budget. Tests use [`spawn_driver_with_timeout`] with
+/// beyond the realistic budget. Tests use [`spawn_driver_with_options`] with
 /// a much shorter value to keep the suite fast.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default grace period between SIGTERM and SIGKILL when [`DriverHandle`] is
+/// dropped. The driver SDK installs a SIGTERM handler that flips a shutdown
+/// flag and exits its main loop on the next iteration; 3 seconds is well
+/// above the realistic exit budget while still putting an outer bound on
+/// how long a misbehaving driver can stall bridge shutdown.
+pub const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_secs(3);
 
 /// SDK majors the Bridge currently understands. The compatibility check
 /// accepts any `hello.sdk_version` parseable as `MAJOR.MINOR.PATCH` whose
@@ -50,6 +84,12 @@ pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 /// (or replaces it) — see `design/10-driver-plugin.md`「バージョン互換性」 for
 /// the policy: layout changes happen on semver-major bumps only.
 const ACCEPTED_SDK_MAJORS: &[u32] = &[0, 1];
+
+/// Poll interval used while waiting for the child to exit during the SIGTERM
+/// → SIGKILL escalation window. Small enough that the worst-case overshoot
+/// of the grace deadline is negligible (50 ms on a 3 s grace), large enough
+/// that the busy-wait does not chew CPU.
+const SHUTDOWN_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// JSON-tagged `hello` message read from the driver's stdout.
 #[derive(Debug, serde::Deserialize)]
@@ -69,33 +109,165 @@ struct HelloAckMessage<'a> {
     reason: Option<&'a str>,
 }
 
+/// Tunable options for [`spawn_driver_with_options`]. Held as a struct so
+/// adding more fields (e.g. environment, working directory) does not blow
+/// up the function signature — see `limit-function-arguments`.
+#[derive(Debug, Clone)]
+pub struct SpawnOptions {
+    /// Maximum time to wait for the driver's `hello` line before giving up.
+    pub handshake_timeout: Duration,
+    /// Time the [`DriverHandle::drop`] escalation waits between SIGTERM and
+    /// SIGKILL.
+    pub shutdown_grace: Duration,
+}
+
+impl Default for SpawnOptions {
+    fn default() -> Self {
+        Self {
+            handshake_timeout: HANDSHAKE_TIMEOUT,
+            shutdown_grace: DEFAULT_SHUTDOWN_GRACE,
+        }
+    }
+}
+
 /// Outcome of a `spawn_driver` call.
 ///
-/// On the success path the handle owns the child process plus its stdin
-/// writer. Dropping the handle closes stdin, which the dummy fixture treats
-/// as the signal to exit its `BufRead` loop.
+/// On the success path the handle owns the driver's stdin writer plus
+/// background threads that:
+/// - own the child process and `wait()` for it on a dedicated thread
+///   (the "watcher"), flipping a shared liveness flag when the child exits;
+/// - drain the post-handshake stdout stream and forward each non-JSON line
+///   into the bridge logger (the "log forwarder").
+///
+/// Dropping the handle closes stdin, sends SIGTERM, polls the liveness
+/// flag for the configured grace period, and finally escalates to SIGKILL
+/// before joining both background threads.
 #[derive(Debug)]
 pub struct DriverHandle {
-    /// Driver name as supplied to [`spawn_driver`]. Carried for diagnostics.
+    /// Driver name as supplied to [`spawn_driver`]. Carried for diagnostics
+    /// and used as the `driver/<name>` layer string for forwarded log lines.
     pub name: String,
     /// Resolved binary path, useful for log lines and crash reports.
     pub path: PathBuf,
     /// SDK version the driver advertised in its `hello`.
     pub sdk_version: String,
-    child: Child,
-    #[allow(dead_code)]
-    stdin: ChildStdin,
+    /// PID captured at spawn time, used by [`Drop`] to send SIGTERM /
+    /// SIGKILL via `nix` rather than going through `Child::kill` (which
+    /// would require shared mutable access to the `Child` the watcher
+    /// thread already owns).
+    child_pid: u32,
+    stdin: Option<ChildStdin>,
+    /// Shared liveness flag. The watcher flips this to `false` when the
+    /// child exits (graceful or abnormal). Exposed via [`Self::is_alive`]
+    /// so callers can detect "this driver is gone, drop my handle", and
+    /// used by [`Drop`] to detect a clean exit during the grace window.
+    alive: Arc<AtomicBool>,
+    /// Set by [`Drop`] before it sends SIGTERM, so the watcher thread can
+    /// distinguish "we asked for this exit" (normal shutdown — do not
+    /// surface as an error) from "the driver crashed on its own" (abnormal
+    /// — log to bridge error).
+    shutdown_initiated: Arc<AtomicBool>,
+    /// Time to wait between SIGTERM and SIGKILL during [`Drop`].
+    shutdown_grace: Duration,
+    /// Background threads spawned at handshake completion. Joined on drop.
+    log_forwarder: Option<JoinHandle<()>>,
+    watcher: Option<JoinHandle<()>>,
 }
 
 impl DriverHandle {
-    /// Borrow the child process handle (for `id()` and similar inspection).
+    /// Borrow the driver name. Useful as the `driver/<name>` layer string.
     #[must_use]
-    pub fn child(&self) -> &Child {
-        &self.child
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Whether the driver subprocess is still believed to be alive.
+    ///
+    /// The watcher thread sets this to `false` when `child.wait()` returns,
+    /// so a `false` reading is authoritative ("the kernel reaped the child").
+    /// A `true` reading is best-effort — the child could exit between the
+    /// load and the next call.
+    #[must_use]
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::SeqCst)
+    }
+
+    /// Send a `connect` control message to the driver.
+    ///
+    /// `device` identifies the connection target (e.g. a MIDI port name);
+    /// `config` is the driver-defined connection blob. Both are forwarded
+    /// verbatim — the bridge does not interpret `config`. No response is
+    /// awaited; control messages are fire-and-forget per the spec.
+    pub fn connect(&mut self, device: &str, config: &serde_json::Value) -> std::io::Result<()> {
+        self.write_control(&serde_json::json!({
+            "type": "connect",
+            "device": device,
+            "config": config,
+        }))
+    }
+
+    /// Send a `disconnect` control message for `device`.
+    pub fn disconnect(&mut self, device: &str) -> std::io::Result<()> {
+        self.write_control(&serde_json::json!({
+            "type": "disconnect",
+            "device": device,
+        }))
+    }
+
+    /// Send a `configure` control message carrying an opaque payload.
+    pub fn configure(&mut self, payload: &serde_json::Value) -> std::io::Result<()> {
+        self.write_control(&serde_json::json!({
+            "type": "configure",
+            "payload": payload,
+        }))
+    }
+
+    fn write_control(&mut self, value: &serde_json::Value) -> std::io::Result<()> {
+        let stdin = self.stdin.as_mut().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "driver stdin is no longer available",
+            )
+        })?;
+        serde_json::to_writer(&mut *stdin, value)?;
+        stdin.write_all(b"\n")?;
+        stdin.flush()
     }
 }
 
-/// Errors returned by [`spawn_driver`] / [`spawn_driver_with_timeout`].
+impl Drop for DriverHandle {
+    fn drop(&mut self) {
+        // Mark shutdown as bridge-initiated so the watcher does not log a
+        // SIGTERM-induced exit as "abnormal". The store happens before
+        // stdin is closed (and therefore before any signal is sent) so
+        // there is no window where the watcher could observe the child's
+        // exit without the flag set.
+        self.shutdown_initiated.store(true, Ordering::SeqCst);
+
+        // Close stdin first. The SDK's main loop falls out on EOF, so for
+        // well-behaved drivers this alone is enough to trigger a clean exit
+        // without ever raising SIGTERM. The escalation below is the safety
+        // net for drivers that ignore stdin EOF.
+        drop(self.stdin.take());
+
+        terminate_with_grace(&self.alive, self.child_pid, self.shutdown_grace);
+
+        // Join background threads so their drop runs synchronously rather
+        // than detaching. The watcher's `child.wait()` is what actually
+        // reaps the kernel-level corpse, so joining it is what guarantees
+        // the child is gone before this `Drop` returns. Any join error is
+        // swallowed — the threads only ever panic on logger writer errors
+        // which the logger itself already swallows.
+        if let Some(handle) = self.log_forwarder.take() {
+            let _ = handle.join();
+        }
+        if let Some(handle) = self.watcher.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Errors returned by [`spawn_driver`] / [`spawn_driver_with_options`].
 #[derive(Debug)]
 pub enum SpawnError {
     /// `Command::spawn` itself failed (binary missing, permission denied, …).
@@ -172,10 +344,11 @@ impl std::error::Error for SpawnError {
 /// Spawn a driver binary at `path`, complete the version handshake, and
 /// return a [`DriverHandle`] tied to the live child.
 ///
-/// `name` is the driver identifier (used for diagnostics and later for
-/// dispatching events); `profile` is the configuration blob the runtime
-/// will eventually forward to the driver — handshake itself does not consume
-/// it, so the parameter is held only at the API boundary.
+/// `name` is the driver identifier (used for diagnostics and as the
+/// `driver/<name>` layer string for forwarded log lines); `profile` is the
+/// configuration blob the runtime will eventually forward to the driver —
+/// handshake itself does not consume it, so the parameter is held only at
+/// the API boundary.
 ///
 /// On the failure path the child process is reaped before this function
 /// returns — callers do not need to clean up zombies on `Err(_)`.
@@ -184,17 +357,18 @@ pub fn spawn_driver(
     path: impl Into<PathBuf>,
     profile: &serde_json::Value,
 ) -> Result<DriverHandle, SpawnError> {
-    spawn_driver_with_timeout(name, path, profile, HANDSHAKE_TIMEOUT)
+    spawn_driver_with_options(name, path, profile, &SpawnOptions::default())
 }
 
-/// [`spawn_driver`] with an explicit handshake timeout. Tests use a short
-/// timeout (typically 200ms) to keep the suite fast; production callers
-/// should keep using the default via [`spawn_driver`].
-pub fn spawn_driver_with_timeout(
+/// [`spawn_driver`] with explicit handshake timeout / shutdown-grace tuning.
+/// Tests use a short timeout (typically 200 ms) and a short grace (typically
+/// 200 ms) to keep the suite fast; production callers should keep using the
+/// defaults via [`spawn_driver`].
+pub fn spawn_driver_with_options(
     name: impl Into<String>,
     path: impl Into<PathBuf>,
     profile: &serde_json::Value,
-    handshake_timeout: Duration,
+    options: &SpawnOptions,
 ) -> Result<DriverHandle, SpawnError> {
     let _ = profile;
     let name = name.into();
@@ -219,51 +393,8 @@ pub fn spawn_driver_with_timeout(
         .take()
         .expect("Stdio::piped() guarantees stdin is Some");
 
-    // Read the first stdout line on a worker thread. Channel-disconnect
-    // (sender dropped without sending) maps to EOF before hello.
-    let (tx, rx) = mpsc::channel::<std::io::Result<String>>();
-    let reader_handle = thread::spawn(move || {
-        let mut reader = BufReader::new(stdout);
-        let mut line = String::new();
-        match reader.read_line(&mut line) {
-            Ok(0) => {
-                // Sender drops on return; the Bridge sees Disconnected.
-            }
-            Ok(_) => {
-                let _ = tx.send(Ok(line));
-            }
-            Err(err) => {
-                let _ = tx.send(Err(err));
-            }
-        }
-        // Drop the reader once the first line is captured: closing the read
-        // half of the pipe is the cleanest signal to a future log-forwarding
-        // path that the handshake stage is done.
-        drop(reader);
-    });
-
-    let hello_line = match rx.recv_timeout(handshake_timeout) {
-        Ok(Ok(line)) => line,
-        Ok(Err(io_err)) => {
-            kill_and_reap(&mut child);
-            // Reap the worker thread so its drop runs on this thread
-            // rather than detaching.
-            let _ = reader_handle.join();
-            return Err(SpawnError::Spawn(io_err));
-        }
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            kill_and_reap(&mut child);
-            let _ = reader_handle.join();
-            return Err(SpawnError::HandshakeTimeout(handshake_timeout));
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            kill_and_reap(&mut child);
-            let _ = reader_handle.join();
-            return Err(SpawnError::HandshakeMissing);
-        }
-    };
-
-    let _ = reader_handle.join();
+    let (hello_line, stdout_reader) =
+        read_hello_line(stdout, options.handshake_timeout, &mut child)?;
 
     let hello: HelloMessage = match serde_json::from_str(hello_line.trim_end()) {
         Ok(parsed) => parsed,
@@ -304,13 +435,262 @@ pub fn spawn_driver_with_timeout(
         });
     }
 
+    // Hand the live child off to background workers and build the handle.
+    let child_pid = child.id();
+    let alive = Arc::new(AtomicBool::new(true));
+    let shutdown_initiated = Arc::new(AtomicBool::new(false));
+
+    let log_forwarder = spawn_log_forwarder(name.clone(), stdout_reader);
+    let watcher = spawn_exit_watcher(
+        name.clone(),
+        child,
+        Arc::clone(&alive),
+        Arc::clone(&shutdown_initiated),
+    );
+
     Ok(DriverHandle {
         name,
         path,
         sdk_version: hello.sdk_version,
-        child,
-        stdin,
+        child_pid,
+        stdin: Some(stdin),
+        alive,
+        shutdown_initiated,
+        shutdown_grace: options.shutdown_grace,
+        log_forwarder: Some(log_forwarder),
+        watcher: Some(watcher),
     })
+}
+
+/// Internal channel payload used during handshake so the worker thread can
+/// hand its `BufReader<ChildStdout>` back when it returns the first line.
+/// Transferring ownership lets the post-handshake log forwarder pick up
+/// reading from byte 0 of the next line without re-opening stdout.
+enum HandshakeReadOutcome {
+    Line {
+        line: String,
+        reader: BufReader<ChildStdout>,
+    },
+    Err(std::io::Error),
+}
+
+/// Read the driver's first stdout line under a wall-clock timeout, handing
+/// the reader back to the caller so the post-handshake forwarder can keep
+/// reading from byte 0 of line 2.
+///
+/// On the error paths the child is killed and reaped before returning so
+/// the worker thread's `read_line` unblocks (otherwise `join` would deadlock
+/// against the read still waiting on the live pipe).
+fn read_hello_line(
+    stdout: ChildStdout,
+    timeout: Duration,
+    child: &mut Child,
+) -> Result<(String, BufReader<ChildStdout>), SpawnError> {
+    let (tx, rx) = mpsc::channel::<HandshakeReadOutcome>();
+    let reader_handle = thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => {
+                // Sender drops on return; the receiver sees Disconnected.
+            }
+            Ok(_) => {
+                let _ = tx.send(HandshakeReadOutcome::Line { line, reader });
+            }
+            Err(err) => {
+                let _ = tx.send(HandshakeReadOutcome::Err(err));
+            }
+        }
+    });
+
+    let result = match rx.recv_timeout(timeout) {
+        Ok(HandshakeReadOutcome::Line { line, reader }) => Ok((line, reader)),
+        Ok(HandshakeReadOutcome::Err(io_err)) => {
+            kill_and_reap(child);
+            Err(SpawnError::Spawn(io_err))
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            kill_and_reap(child);
+            Err(SpawnError::HandshakeTimeout(timeout))
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            kill_and_reap(child);
+            Err(SpawnError::HandshakeMissing)
+        }
+    };
+    let _ = reader_handle.join();
+    result
+}
+
+/// Convert a non-JSON driver stdout line into the structured fields the
+/// bridge logger expects. Pure function: no IO, no globals — the integration
+/// test path verifies the call site is wired, and this unit-tests the
+/// translation without needing a process boundary.
+#[must_use]
+pub fn non_json_line_to_log_event(driver_name: &str, line: &str) -> LogEvent {
+    LogEvent {
+        layer: format!("driver/{driver_name}"),
+        device: None,
+        message: line.trim_end_matches(['\r', '\n']).to_owned(),
+    }
+}
+
+/// Output of [`non_json_line_to_log_event`]. Matches the field set the
+/// `crate::logging::info` entrypoint takes.
+#[derive(Debug, PartialEq, Eq)]
+pub struct LogEvent {
+    pub layer: String,
+    pub device: Option<String>,
+    pub message: String,
+}
+
+/// Drive the post-handshake stdout reader on its own thread, forwarding
+/// each line into the bridge logger. Today every line is treated as a log
+/// line — driver→bridge JSON control messages do not exist yet. When they
+/// do, the dispatch will branch here.
+fn spawn_log_forwarder(driver_name: String, mut reader: BufReader<ChildStdout>) -> JoinHandle<()> {
+    thread::spawn(move || {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => return, // EOF: child closed stdout
+                Ok(_) => {
+                    let event = non_json_line_to_log_event(&driver_name, &line);
+                    crate::logging::info(&event.layer, event.device.as_deref(), &event.message);
+                }
+                Err(_err) => {
+                    // Read errors mean the pipe is gone; the watcher will
+                    // observe the child exit and flip `alive`. Bail.
+                    return;
+                }
+            }
+        }
+    })
+}
+
+/// Wait on the child process from a dedicated thread so the bridge learns
+/// about abnormal exits without blocking foreground work, and so the
+/// [`Drop`]-side SIGTERM / SIGKILL escalation can synchronize against the
+/// child's reap purely through the `alive` flag and the eventual thread
+/// join. The watcher fully owns the `Child` for the duration of its life;
+/// no other code ever calls `wait()` on it.
+fn spawn_exit_watcher(
+    driver_name: String,
+    mut child: Child,
+    alive: Arc<AtomicBool>,
+    shutdown_initiated: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        let status = child.wait();
+        alive.store(false, Ordering::SeqCst);
+
+        // If the bridge initiated the shutdown (i.e. `Drop` ran and sent
+        // SIGTERM / SIGKILL), the resulting exit is **expected** even when
+        // it manifests as a non-zero status (signal-terminated processes
+        // report `ExitStatus::success() == false` on Unix). Suppressing
+        // the abnormal-exit log on this path keeps "normal driver
+        // shutdown" out of the bridge error stream.
+        if shutdown_initiated.load(Ordering::SeqCst) {
+            return;
+        }
+
+        match status {
+            Ok(status) if status.success() => {
+                // Graceful exit: nothing to log; the handle owner will
+                // observe `is_alive() == false` if it cares.
+            }
+            Ok(status) => {
+                crate::logging::error(
+                    "bridge",
+                    Some(&driver_name),
+                    format_args!("driver subprocess exited abnormally: {status}"),
+                );
+            }
+            Err(err) => {
+                crate::logging::error(
+                    "bridge",
+                    Some(&driver_name),
+                    format_args!("driver subprocess wait() failed: {err}"),
+                );
+            }
+        }
+    })
+}
+
+/// SIGTERM → grace → SIGKILL escalation. Synchronizes with the watcher
+/// thread purely through the shared `alive` flag: the watcher sets it to
+/// `false` after `child.wait()` returns, so polling it tells us when the
+/// child has been reaped without us having to share the `Child` itself.
+fn terminate_with_grace(alive: &AtomicBool, child_pid: u32, grace: Duration) {
+    // Fast path: child already gone (graceful exit triggered by stdin EOF
+    // closing the SDK loop, or pre-existing crash). Nothing to do.
+    if !alive.load(Ordering::SeqCst) {
+        return;
+    }
+
+    // Step 1: send SIGTERM. Best-effort; ESRCH (child raced to exit
+    // between the load above and the kill below) is ignored inside
+    // `send_sigterm`.
+    send_sigterm(child_pid);
+
+    // Step 2: poll the watcher's `alive` flag. The watcher sets it to
+    // `false` after `child.wait()` returns, so a `false` reading means the
+    // kernel has reaped the child and there is no SIGKILL work to do.
+    let deadline = Instant::now() + grace;
+    while alive.load(Ordering::SeqCst) {
+        if Instant::now() >= deadline {
+            // Step 3: SIGKILL escalation. Sending the signal via the cached
+            // PID is sufficient — the watcher is parked in `child.wait()`
+            // and will return as soon as the kernel delivers the SIGKILL.
+            // The watcher then flips `alive` and exits, and the caller's
+            // `Drop` joins it next, which synchronizes the reap.
+            send_sigkill(child_pid);
+            return;
+        }
+        thread::sleep(SHUTDOWN_POLL_INTERVAL);
+    }
+}
+
+/// Send `SIGTERM` to `pid`. Best-effort: errors are intentionally ignored
+/// (the most common error is ESRCH = the child already exited).
+#[cfg(unix)]
+fn send_sigterm(pid: u32) {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+    // `pid` came from `Child::id()` which returns a `u32` representing a
+    // POSIX `pid_t`. PIDs are positive and well below `i32::MAX` on every
+    // supported Unix kernel (Linux caps at `kernel.pid_max`, default 32768
+    // / 4 194 304; macOS at 99 998), so the bit-pattern reinterpretation
+    // via `cast_signed` is faithful — we just have to pick a signed
+    // version explicitly so clippy's `cast_possible_wrap` lint stops
+    // flagging the conversion. The workspace forbids `unsafe_code` so we
+    // go through `nix`'s safe wrapper rather than `libc::kill`.
+    let _ = kill(Pid::from_raw(pid.cast_signed()), Signal::SIGTERM);
+}
+
+#[cfg(not(unix))]
+fn send_sigterm(_pid: u32) {
+    // Windows lifecycle handling is out of scope for the parent issue.
+    // `send_sigkill` below also no-ops, so a Windows build of this code
+    // path effectively relies on the child exiting via stdin EOF. Wiring
+    // `TerminateProcess` is deferred until a later issue actually targets
+    // Windows.
+}
+
+/// Send `SIGKILL` to `pid`. Best-effort — ESRCH is ignored.
+#[cfg(unix)]
+fn send_sigkill(pid: u32) {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+    // Same `pid_t` reasoning as `send_sigterm` — see that function for
+    // the cast / `unsafe_code = "forbid"` rationale.
+    let _ = kill(Pid::from_raw(pid.cast_signed()), Signal::SIGKILL);
+}
+
+#[cfg(not(unix))]
+fn send_sigkill(_pid: u32) {
+    // See `send_sigterm` for the Windows scope note.
 }
 
 /// Result of [`is_sdk_compatible`]. Carried as a small enum so the caller
@@ -394,4 +774,35 @@ fn json_type_error(message: &str) -> serde_json::Error {
     // through `serde::de::Error` via a deserializer that produces our text.
     use serde::de::Error as _;
     serde_json::Error::custom(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_should_strip_trailing_newline_when_converting_non_json_line() {
+        let event = non_json_line_to_log_event("dummy", "hello world\n");
+        assert_eq!(event.layer, "driver/dummy");
+        assert_eq!(event.device, None);
+        assert_eq!(event.message, "hello world");
+    }
+
+    #[test]
+    fn it_should_strip_trailing_crlf_when_converting_non_json_line() {
+        let event = non_json_line_to_log_event("midi", "boom\r\n");
+        assert_eq!(event.message, "boom");
+    }
+
+    #[test]
+    fn it_should_preserve_internal_whitespace_when_converting_non_json_line() {
+        let event = non_json_line_to_log_event("osc", "  spaced  message  ");
+        assert_eq!(event.message, "  spaced  message  ");
+    }
+
+    #[test]
+    fn it_should_use_driver_layer_prefix_in_log_event() {
+        let event = non_json_line_to_log_event("my-driver", "x");
+        assert_eq!(event.layer, "driver/my-driver");
+    }
 }

--- a/crates/midori-runtime/src/lib.rs
+++ b/crates/midori-runtime/src/lib.rs
@@ -4,7 +4,17 @@
 //! certain subsystems are exposed here so integration tests and downstream
 //! consumers can drive them directly without going through argv.
 //!
-//! Today only the driver process supervisor is exposed. The CLI dispatch
-//! layer remains binary-private until there is a concrete need to expose it.
+//! Exposed:
+//!
+//! - [`driver_proc`]: driver subprocess supervisor (spawn / handshake /
+//!   lifecycle).
+//! - [`logging`]: bridge logger entrypoints. Re-exported so `driver_proc`'s
+//!   stdout-forwarding path can hand non-JSON driver lines to the same
+//!   logger the CLI uses, and so integration tests can observe the layer
+//!   string used for forwarded lines.
+//!
+//! The CLI dispatch layer remains binary-private until there is a concrete
+//! need to expose it.
 
 pub mod driver_proc;
+pub mod logging;

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -1,7 +1,6 @@
 mod error;
 mod events_pipeline;
 mod events_schema;
-mod logging;
 mod plugin_resolver;
 mod profile;
 mod ring_handshake;
@@ -13,9 +12,10 @@ use clap::{Parser, Subcommand};
 
 use crate::error::CliError;
 use crate::events_pipeline::{check_driver_schema, DriverSchemaOutcome};
-use crate::logging::{LogFormat, LogLevel};
 use crate::plugin_resolver::{resolve_drivers, ResolvedDrivers};
 use crate::profile::{collect_driver_names, load_from_path as load_profile};
+use midori_runtime::logging;
+use midori_runtime::logging::{LogFormat, LogLevel};
 
 #[derive(Parser, Debug)]
 #[command(

--- a/crates/midori-runtime/tests/driver_spawn.rs
+++ b/crates/midori-runtime/tests/driver_spawn.rs
@@ -215,12 +215,14 @@ fn lifecycle_options() -> SpawnOptions {
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn it_should_complete_full_lifecycle_against_sigterm_graceful_dummy() {
     // spawn → connect → disconnect → configure → drop. The
     // SIGTERM-graceful fixture flips its shutdown flag on SIGTERM so Drop's
     // grace period is enough to observe a clean exit before the SIGKILL
-    // escalation triggers.
+    // escalation triggers. Windows lacks SIGTERM and the bridge's
+    // signal-send path is a no-op there, so this test is unix-only.
     let bin = fixture_bin_path("midori-driver-dummy-sigterm-graceful").to_path_buf();
     let mut handle =
         spawn_driver_with_options("dummy", bin, &serde_json::json!({}), &lifecycle_options())
@@ -274,13 +276,16 @@ fn it_should_record_abnormal_exit_when_driver_exits_with_non_zero_status() {
     drop(handle);
 }
 
+#[cfg(unix)]
 #[test]
 fn it_should_escalate_to_sigkill_when_sigterm_is_ignored() {
     // The fixture installs a SIGTERM handler that does nothing, and ignores
     // stdin EOF. The bridge's Drop must escalate to SIGKILL after the grace
     // period elapses. Wall-clock budget: at most `grace + a generous slack`
     // — we measure the elapsed time across `drop(handle)` and assert it
-    // stays below ~1 second on a 300ms grace.
+    // stays below ~1 second on a 300ms grace. Windows lacks both SIGTERM
+    // and SIGKILL semantics, and the fixture's Windows fallback loops
+    // forever instead of installing handlers — so this is unix-only.
     let bin = fixture_bin_path("midori-driver-dummy-sigterm-ignore").to_path_buf();
     let handle = spawn_driver_with_options(
         "dummy-ignore",

--- a/crates/midori-runtime/tests/driver_spawn.rs
+++ b/crates/midori-runtime/tests/driver_spawn.rs
@@ -1,6 +1,7 @@
-//! Integration tests for the Bridge-side driver spawn / handshake flow.
+//! Integration tests for the Bridge-side driver spawn / handshake / lifecycle
+//! flow.
 //!
-//! The fixture comes as three sibling binaries built from the same source
+//! The fixture comes as multiple sibling binaries built from the same source
 //! (`crates/midori-driver-dummy/`). Each binary's behavior is selected at
 //! build time via `CARGO_BIN_NAME`, so the test hands `spawn_driver` an
 //! exact path per case and never has to materialise a wrapper script
@@ -9,9 +10,11 @@
 
 use std::path::PathBuf;
 use std::sync::OnceLock;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
-use midori_runtime::driver_proc::{spawn_driver_with_timeout, SpawnError, HANDSHAKE_TIMEOUT};
+use midori_runtime::driver_proc::{
+    spawn_driver_with_options, DriverHandle, SpawnError, SpawnOptions, HANDSHAKE_TIMEOUT,
+};
 
 /// Resolved path to a fixture binary by name.
 ///
@@ -69,19 +72,21 @@ fn fixture_bin_path(bin_name: &'static str) -> &'static std::path::Path {
         candidate
     }
 
+    macro_rules! cached {
+        ($name:literal) => {{
+            static CELL: OnceLock<PathBuf> = OnceLock::new();
+            CELL.get_or_init(|| resolve($name))
+        }};
+    }
+
     match bin_name {
-        "midori-driver-dummy" => {
-            static CELL: OnceLock<PathBuf> = OnceLock::new();
-            CELL.get_or_init(|| resolve(bin_name))
-        }
-        "midori-driver-dummy-no-hello" => {
-            static CELL: OnceLock<PathBuf> = OnceLock::new();
-            CELL.get_or_init(|| resolve(bin_name))
-        }
-        "midori-driver-dummy-bad-version" => {
-            static CELL: OnceLock<PathBuf> = OnceLock::new();
-            CELL.get_or_init(|| resolve(bin_name))
-        }
+        "midori-driver-dummy" => cached!("midori-driver-dummy"),
+        "midori-driver-dummy-no-hello" => cached!("midori-driver-dummy-no-hello"),
+        "midori-driver-dummy-bad-version" => cached!("midori-driver-dummy-bad-version"),
+        "midori-driver-dummy-noisy-stdout" => cached!("midori-driver-dummy-noisy-stdout"),
+        "midori-driver-dummy-sigterm-graceful" => cached!("midori-driver-dummy-sigterm-graceful"),
+        "midori-driver-dummy-sigterm-ignore" => cached!("midori-driver-dummy-sigterm-ignore"),
+        "midori-driver-dummy-exit-error" => cached!("midori-driver-dummy-exit-error"),
         other => panic!("unknown fixture binary requested: {other}"),
     }
 }
@@ -97,13 +102,23 @@ fn bin_filename(stem: &str) -> String {
 }
 
 /// Table-driven layout: each row pins one fixture binary to one expected
-/// outcome class. The actual assertions live in the per-row helpers because
-/// `SpawnError` is non-`Eq` and matching on its variants is the cleanest
-/// way to assert without overspecifying inner fields.
+/// handshake outcome class. The actual assertions live in the per-row
+/// helpers because `SpawnError` is non-`Eq` and matching on its variants
+/// is the cleanest way to assert without overspecifying inner fields.
 struct SpawnCase {
     name: &'static str,
     fixture_bin: &'static str,
-    timeout: Duration,
+    options: SpawnOptions,
+}
+
+const fn options_with_timeout(timeout: Duration) -> SpawnOptions {
+    SpawnOptions {
+        handshake_timeout: timeout,
+        // Tests that exercise the handshake path do not hold the resulting
+        // handle long, so the shutdown grace value is irrelevant — we use
+        // the production default for parity with `spawn_driver`.
+        shutdown_grace: Duration::from_secs(3),
+    }
 }
 
 const CASE_SUCCESS: SpawnCase = SpawnCase {
@@ -111,7 +126,7 @@ const CASE_SUCCESS: SpawnCase = SpawnCase {
     fixture_bin: "midori-driver-dummy",
     // Production timeout is fine for the success path; the dummy emits hello
     // synchronously so the wait is effectively instantaneous.
-    timeout: HANDSHAKE_TIMEOUT,
+    options: options_with_timeout(HANDSHAKE_TIMEOUT),
 };
 
 const CASE_TIMEOUT: SpawnCase = SpawnCase {
@@ -119,13 +134,13 @@ const CASE_TIMEOUT: SpawnCase = SpawnCase {
     fixture_bin: "midori-driver-dummy-no-hello",
     // Short enough that the suite stays fast, long enough that a slow CI
     // runner does not race the dummy's stdin-read setup.
-    timeout: Duration::from_millis(200),
+    options: options_with_timeout(Duration::from_millis(200)),
 };
 
 const CASE_INCOMPAT: SpawnCase = SpawnCase {
     name: "dummy-incompat",
     fixture_bin: "midori-driver-dummy-bad-version",
-    timeout: HANDSHAKE_TIMEOUT,
+    options: options_with_timeout(HANDSHAKE_TIMEOUT),
 };
 
 #[test]
@@ -141,8 +156,7 @@ fn it_should_complete_handshake_against_dummy_driver() {
     );
     // Dropping the handle drops `ChildStdin` first, which closes the write
     // half of the pipe. The dummy's BufRead loop terminates on the resulting
-    // EOF. The `Child` itself is not awaited here; lifecycle handling lives
-    // outside this module.
+    // EOF, so the SIGTERM escalation in `Drop` finds the child already gone.
     drop(handle);
 }
 
@@ -153,7 +167,7 @@ fn it_should_return_handshake_timeout_when_driver_does_not_emit_hello() {
     match err {
         SpawnError::HandshakeTimeout(elapsed) => {
             assert_eq!(
-                elapsed, case.timeout,
+                elapsed, case.options.handshake_timeout,
                 "HandshakeTimeout must echo the caller-supplied timeout, got {elapsed:?}"
             );
         }
@@ -183,10 +197,138 @@ fn it_should_return_incompatible_sdk_when_driver_advertises_unknown_version() {
     }
 }
 
+// ------------------------------------------------------------------
+// Lifecycle tests: control messages, log forwarding, abnormal exit,
+// SIGTERM → grace → SIGKILL escalation.
+// ------------------------------------------------------------------
+
+/// Shorter shutdown grace used by lifecycle tests so the SIGKILL-escalation
+/// case finishes inside a reasonable test budget. The value is large enough
+/// that the SIGTERM-graceful fixture's poll loop (20ms) runs at least a
+/// handful of times under load before the deadline fires.
+const TEST_SHUTDOWN_GRACE: Duration = Duration::from_millis(300);
+
+fn lifecycle_options() -> SpawnOptions {
+    SpawnOptions {
+        handshake_timeout: HANDSHAKE_TIMEOUT,
+        shutdown_grace: TEST_SHUTDOWN_GRACE,
+    }
+}
+
+#[test]
+fn it_should_complete_full_lifecycle_against_sigterm_graceful_dummy() {
+    // spawn → connect → disconnect → configure → drop. The
+    // SIGTERM-graceful fixture flips its shutdown flag on SIGTERM so Drop's
+    // grace period is enough to observe a clean exit before the SIGKILL
+    // escalation triggers.
+    let bin = fixture_bin_path("midori-driver-dummy-sigterm-graceful").to_path_buf();
+    let mut handle =
+        spawn_driver_with_options("dummy", bin, &serde_json::json!({}), &lifecycle_options())
+            .expect("handshake against sigterm-graceful fixture");
+
+    handle
+        .connect("port-a", &serde_json::json!({"latency_ms": 1}))
+        .expect("connect write succeeds while child stdin is open");
+    handle
+        .configure(&serde_json::json!({"sample_rate": 48_000}))
+        .expect("configure write succeeds");
+    handle
+        .disconnect("port-a")
+        .expect("disconnect write succeeds");
+    assert!(
+        handle.is_alive(),
+        "child should still be alive between control writes"
+    );
+
+    let started = Instant::now();
+    drop(handle);
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < TEST_SHUTDOWN_GRACE * 4,
+        "graceful drop should finish well within escalation budget, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn it_should_record_abnormal_exit_when_driver_exits_with_non_zero_status() {
+    let bin = fixture_bin_path("midori-driver-dummy-exit-error").to_path_buf();
+    let handle = spawn_driver_with_options(
+        "dummy-exit",
+        bin,
+        &serde_json::json!({}),
+        &lifecycle_options(),
+    )
+    .expect("handshake completes before the child exits");
+
+    // Watcher thread races the child's exit. Poll `is_alive` for up to a
+    // second; this is a generous bound because spawn → exit is microseconds
+    // on the dummy.
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while handle.is_alive() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        !handle.is_alive(),
+        "watcher should mark the handle dead after the child's non-zero exit"
+    );
+    drop(handle);
+}
+
+#[test]
+fn it_should_escalate_to_sigkill_when_sigterm_is_ignored() {
+    // The fixture installs a SIGTERM handler that does nothing, and ignores
+    // stdin EOF. The bridge's Drop must escalate to SIGKILL after the grace
+    // period elapses. Wall-clock budget: at most `grace + a generous slack`
+    // — we measure the elapsed time across `drop(handle)` and assert it
+    // stays below ~1 second on a 300ms grace.
+    let bin = fixture_bin_path("midori-driver-dummy-sigterm-ignore").to_path_buf();
+    let handle = spawn_driver_with_options(
+        "dummy-ignore",
+        bin,
+        &serde_json::json!({}),
+        &lifecycle_options(),
+    )
+    .expect("handshake against sigterm-ignore fixture");
+
+    let started = Instant::now();
+    drop(handle);
+    let elapsed = started.elapsed();
+    // Lower bound: the grace period must have actually elapsed because the
+    // fixture cannot exit any earlier than that.
+    assert!(
+        elapsed >= TEST_SHUTDOWN_GRACE,
+        "SIGKILL escalation should not fire before grace period, took {elapsed:?}"
+    );
+    // Upper bound: the SIGKILL path completes shortly after the grace
+    // deadline. Wide budget to absorb scheduler jitter on busy CI runners.
+    assert!(
+        elapsed < TEST_SHUTDOWN_GRACE + Duration::from_secs(2),
+        "SIGKILL escalation should finish soon after grace period, took {elapsed:?}"
+    );
+}
+
+#[test]
+fn it_should_spawn_noisy_stdout_fixture_without_hanging() {
+    // The bridge-internal log-forwarder thread is wired to crate::logging,
+    // which writes to the real `io::stdout()`. Capturing that without
+    // refactoring the logging sink is out of scope, so this is a smoke
+    // test: the fixture emits a non-JSON line, the forwarder consumes it,
+    // and Drop completes. A regression that re-uses the handshake reader
+    // (or fails to start the forwarder) would manifest as a hang here.
+    let bin = fixture_bin_path("midori-driver-dummy-noisy-stdout").to_path_buf();
+    let handle =
+        spawn_driver_with_options("noisy", bin, &serde_json::json!({}), &lifecycle_options())
+            .expect("handshake against noisy-stdout fixture");
+    // Give the forwarder thread a beat to consume the emitted line. This is
+    // not load-bearing for correctness but makes the test's intent explicit.
+    std::thread::sleep(Duration::from_millis(50));
+    drop(handle);
+}
+
 /// Build a `SpawnError`-returning call from a [`SpawnCase`]. Each case
 /// resolves to a pre-built binary; no wrapper script or runtime fixture
 /// argument injection is needed.
-fn spawn(case: &SpawnCase) -> Result<midori_runtime::driver_proc::DriverHandle, SpawnError> {
+fn spawn(case: &SpawnCase) -> Result<DriverHandle, SpawnError> {
     let bin_path = fixture_bin_path(case.fixture_bin).to_path_buf();
-    spawn_driver_with_timeout(case.name, bin_path, &serde_json::json!({}), case.timeout)
+    spawn_driver_with_options(case.name, bin_path, &serde_json::json!({}), &case.options)
 }


### PR DESCRIPTION
## Summary

- Extend `DriverHandle` with `connect` / `disconnect` / `configure`: each writes a `\n`-terminated JSON Line to driver stdin (no response handling).
- Forward post-handshake driver stdout lines to `crate::logging::info(\"driver/<name>\", None, line)`. Conversion is a pure function (`non_json_line_to_log_event`) for unit-testability; the integration smoke test confirms the call site.
- Watch the child on a dedicated thread; flip `is_alive() = false` on exit and emit `bridge` error log only for genuinely abnormal exits (a `shutdown_initiated` flag suppresses errors when Drop initiated the shutdown).
- `Drop` impl: close stdin → SIGTERM → poll `alive` for `shutdown_grace` → SIGKILL escalation → join watcher / log-forwarder threads. `shutdown_grace` is injectable via `SpawnOptions` so tests run on a tight (300 ms) budget.
- Four new dummy fixture binaries (`-noisy-stdout`, `-sigterm-graceful`, `-sigterm-ignore`, `-exit-error`) following the per-bin-mode pattern from MEW-64 to avoid wrapper ETXTBSY races.
- Workspace forbids `unsafe_code`, so SIGTERM / SIGKILL go through `nix` (Unix-only dep) instead of `libc::kill`. The dummy uses `signal-hook` (already in the workspace via `midori-sdk`) for handler registration.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 7 driver_spawn integration tests pass (handshake-success / -timeout / -incompatible plus new lifecycle / abnormal-exit / SIGKILL-escalation / noisy-stdout-smoke), 4 new `non_json_line_to_log_event` unit tests, all existing tests still green.
- [x] `cargo deny check` — advisories / bans / licenses / sources all OK.
- [x] No tokio added (verified via `grep -rn '\btokio\b' crates/`; only the existing comment in `driver_proc.rs` mentions it as a non-dependency).

## DoD

- [x] AC1 — control writes (`connect` / `disconnect` / `configure`) emit JSON Lines to stdin with no response handling
- [x] AC2 — non-JSON stdout lines convert to `{type:log, layer:driver/<name>, level:info, message:<verbatim>}` via the bridge logger
- [x] AC3 — abnormal exit writes a bridge error log; `is_alive()` flips to `false` (the minimal "registry" interpretation, no global supervisor)
- [x] AC4 — `Drop` performs SIGTERM → 3 s grace → SIGKILL on Unix; Windows is parent-issue out-of-scope
- [x] AC5 — dummy variants: control messages are read in the existing stdin loop (no-op in MEW-65 — handler dispatch table is the next subtask's seam); non-JSON-emit binary; SIGTERM-graceful and SIGTERM-ignore binaries
- [x] AC6 — full-lifecycle integration test (`it_should_complete_full_lifecycle_against_sigterm_graceful_dummy`)
- [x] AC7 — non-JSON conversion unit tests (4 cases: `\\n` strip, `\\r\\n` strip, internal-whitespace preserve, layer prefix)
- [x] AC8 — abnormal-exit integration test (`it_should_record_abnormal_exit_when_driver_exits_with_non_zero_status`)
- [x] AC9 — SIGKILL-escalation integration test with 300 ms grace + 2 s upper bound

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ドライバー監督を強化し、SIGTERM→グレースピリオド→SIGKILLの段階的シャットダウンを実装
  * 非JSON出力のドライバーログを公開ロギング経由でフォワード可能に
  * 起動・シャットダウン挙動を指定できる公開オプション（タイムアウト／グレース期間）を追加
  * ライブラリのロギング機能を公開エントリとして再エクスポートし、CLIがそれを利用

* **テスト**
  * ノイジー出力、SIGTERM（グレース／無視）、異常終了など多数のダミーフィクスチャとライフサイクル検証を追加

* **リファクタリング**
  * 生成・ハンドシェイク・監督フローを再構成し、ログ転送と終了監視を常駐化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->