### PR TITLE
chore(claude): add trivial-scope cleanup policy

### DIFF
--- a/.claude/skills/route-task-management-through-soloscrum/SKILL.md
+++ b/.claude/skills/route-task-management-through-soloscrum/SKILL.md
@@ -47,3 +47,19 @@ If the intent is ambiguous (e.g. "整理して" — could be `/refine` or `/brea
 ## Edge case: Linear-side mechanical updates
 
 After the user merges a PR, transitioning the corresponding Linear Issue to Done is a **mechanical follow-through** of the soloscrum `/review` flow, not an ad hoc decision. This kind of post-merge sync is allowed without re-invoking a soloscrum command. The same applies to GitHub Issue auto-close via `Closes #N`.
+
+## Trivial-scope label during /refine
+
+`/refine` includes assessing whether the Issue meets CLAUDE.md's trivial-scope criteria. If it does, apply the `trivial-scope` label after creating the Issue (Linear MCP `mcp__linear-server__save_issue` with the label, or `gh issue edit --add-label trivial-scope`).
+
+Priority is computed on substance regardless of the label — the label is a separate signal used for parallel cleanup pickup, not a priority bump.
+
+## Parallel cleanup at /develop
+
+When invoking `/develop` for a primary Issue, scan the backlog for `trivial-scope`-labeled Issues. Dispatch up to two of them to parallel git worktrees as independent draft PRs alongside the primary task. Each follows the standard `/develop` flow (branch → implement → push → draft → local review → ready).
+
+Skip the parallel pickup if:
+
+- The user explicitly asks to focus on the primary Issue alone
+- A trivial-scope candidate conflicts with the primary work's file changes
+- Backlog has zero `trivial-scope` candidates

--- a/.claude/skills/run-local-code-review-before-marking-ready/SKILL.md
+++ b/.claude/skills/run-local-code-review-before-marking-ready/SKILL.md
@@ -51,3 +51,12 @@ Running both before `gh pr ready` keeps the GitHub-side CodeRabbit auto-review c
 - ❌ Wait for GitHub-side CodeRabbit to surface findings on a ready PR (defeats the purpose of the draft window).
 - ❌ Pause for user go-ahead before `gh pr ready` when reviewers are green and the fix stayed in scope.
 - ✅ Both reviewers complete with 0 actionable findings (or all addressed) → `gh pr ready` autonomously.
+
+## Pre-existing bugs surfaced during review
+
+Local reviewers (especially CodeRabbit) sometimes flag real bugs on lines that the current PR did not modify. These are out of the current PR's scope.
+
+- File the finding via `/refine` as a follow-up Issue.
+- If the bug meets the trivial-scope criteria defined in CLAUDE.md, apply the `trivial-scope` label so the fix is picked up automatically at the next `/develop` (via parallel worktree).
+- Do NOT fix inline. Inline-fixing pre-existing bugs in scope-narrow PRs fragments review and erodes the audit trail.
+- Reply to the reviewer comment confirming the deferral and linking the new Issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,22 @@ The aim of every change — design doc, implementation, refactor, task design �
 - When implementing, perform refactors needed for consistency *now*, not later. Deferred inconsistencies compound into cognitive load.
 - Comments and docs must stand alone (skills: `write-self-contained-comments`, `doc-context-free`). External references (PR / Issue numbers, conversation history) belong only in transient markers like TODO/FIXME.
 
+## Trivial-scope cleanup
+
+Pre-existing 1-line / mechanical bugs surfaced during PR review are not fixed in-place — they go through `/refine` as follow-up Issues. To absorb these without inflating individual PRs, we use a label-based parallel pickup.
+
+**Trivial-scope criteria** (all must hold):
+
+- SP ≤ 1
+- Decision-free: single correct answer (typo, broken cross-reference, dead comment, doc claim that contradicts adjacent code)
+- No behavior change in non-test code, or a one-line behavior fix that is mechanically obvious
+- No new error variant, dep, function, or module added
+- Edits one source file, plus modest corresponding test changes (a few lines or one new test). Large test rewrites disqualify.
+
+**Marking**: Issues meeting these criteria get the `trivial-scope` label during `/refine`. The label does not affect priority — priority stays computed on substance.
+
+**Parallel pickup at `/develop`**: when `/develop` starts on a primary Issue, up to two `trivial-scope`-labeled Issues from backlog are dispatched to parallel git worktrees as independent draft PRs (cap N=2 to keep user review handoff manageable). The user can opt-out per `/develop` invocation if review bandwidth is constrained.
+
 ## Judgeability
 
 Every change that lands must remain judgeable by at least one party still in the loop — the user, or an automated review mechanism (`/code-review:code-review`, CodeRabbit, `soloscrum-review`). The failure mode is *code that exists but no one can evaluate*.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file defines how Claude collaborates on this repository. Skills handle per-
 The aim of every change — design doc, implementation, refactor, task design — is to leave the system more internally consistent than it was found. Inconsistency is the primary debt being paid down.
 
 - When editing design docs, exhaustively verify the change introduces no contradictions with other parts of the design (skill: `find-contradiction`). Surface every contradiction; never paper over.
-- When implementing, perform refactors needed for consistency *now*, not later. Deferred inconsistencies compound into cognitive load.
+- When implementing, perform refactors needed for consistency *within the scope you are touching* now, not later. Deferred inconsistencies inside that scope compound into cognitive load. (Pre-existing bugs on lines or files outside the current scope are governed by `## Trivial-scope cleanup` below, not by this rule.)
 - Comments and docs must stand alone (skills: `write-self-contained-comments`, `doc-context-free`). External references (PR / Issue numbers, conversation history) belong only in transient markers like TODO/FIXME.
 
 ## Trivial-scope cleanup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Pre-existing 1-line / mechanical bugs surfaced during PR review are not fixed in
 
 - SP ≤ 1
 - Decision-free: single correct answer (typo, broken cross-reference, dead comment, doc claim that contradicts adjacent code)
-- No behavior change in non-test code, or a one-line behavior fix that is mechanically obvious
+- No behavior change in non-test code (even one-line fixes are excluded — choosing the correct new behavior requires judgment)
 - No new error variant, dep, function, or module added
 - Edits one source file, plus modest corresponding test changes (a few lines or one new test). Large test rewrites disqualify.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ The aim of every change — design doc, implementation, refactor, task design �
 
 ## Trivial-scope cleanup
 
-Pre-existing 1-line / mechanical bugs surfaced during PR review are not fixed in-place — they go through `/refine` as follow-up Issues. To absorb these without inflating individual PRs, we use a label-based parallel pickup.
+Pre-existing mechanical bugs surfaced during PR review are not fixed in-place — they go through `/refine` as follow-up Issues. To absorb these without inflating individual PRs, we use a label-based parallel pickup.
 
 **Trivial-scope criteria** (all must hold):
 


### PR DESCRIPTION
## Summary

Adds a label-based mechanism to absorb pre-existing trivial bugs surfaced during PR review without inflating individual PRs.

- **CLAUDE.md** gains a `Trivial-scope cleanup` section with the criteria, label, and parallel pickup policy.
- **`run-local-code-review-before-marking-ready` skill** notes that pre-existing bugs go through `/refine` + label, never inline.
- **`route-task-management-through-soloscrum` skill** notes the `/refine` label-application step and the `/develop` parallel pickup.

## Why

Pre-existing bugs surfaced during review (e.g. broken cross-references, dead comments, doc claims that contradict adjacent code) used to either be: (a) deferred to a follow-up Issue + later /develop cycle (slow), or (b) inline-fixed in the current PR (scope creep, review fragmentation). Neither is great.

The new policy: defer to `/refine` with a `trivial-scope` label, then at the next `/develop` invocation up to two trivial-scope-labeled Issues are dispatched in parallel git worktrees as independent draft PRs alongside the primary task. Main PR stays scope-clean; trivial fixes still land quickly.

## Trivial-scope criteria

All must hold:

- SP ≤ 1
- Decision-free (single correct answer)
- No behavior change in non-test code, or a one-line behavior fix that is mechanically obvious
- No new error variant, dep, function, or module added
- One source file edit plus modest corresponding test changes (a few lines or one new test). Large test rewrites disqualify.

Priority is unaffected — the label is a separate signal for parallel pickup, not a priority bump.

## Test plan

- [x] CLAUDE.md renders the new section before \`Judgeability\` (manual)
- [x] \`trivial-scope\` label created on GitHub and Linear (color \`#C5DEF5\`)
- [x] MEW-67 (is_sdk_compatible validation tightening) labeled retroactively as the first qualifying candidate (its scope: single file \`handshake.rs\` + table-driven test additions, decision-free, SP 1)
- [ ] Future \`/refine\` runs apply the label when criteria match (validated on next /refine cycle)
- [ ] Future \`/develop\` runs pick up trivial-scope candidates in parallel worktrees (validated on next /develop cycle)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 運用ガイダンスを拡充し、/refineでの「trivial-scope」判定とラベル付与の振る舞い（優先度には影響しないこと）を明記
  * /develop実行時の「並列クリーンアップ」動作を定義（最大2件を並列ドラフトPRとして送出、スキップ条件を明示）
  * マージ後の機械的更新の注意点を周辺章に統合
  * コードレビューで既存バグが発見された場合の手順（/refineでフォローアップIssue作成、インライン修正は行わずレビュアーへ返信で保留を連絡）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->