### PR TITLE
feat(driver-osc): スケルトンに最小ハンドシェイクを実装 (MEW-28)

### DIFF
--- a/crates/midori-driver-osc/src/main.rs
+++ b/crates/midori-driver-osc/src/main.rs
@@ -1,7 +1,59 @@
-fn main() {}
+//! Official OSC driver binary for the Midori signal bridge.
+//!
+//! This is a skeleton: it wires the SDK's CLI scaffold (`<driver> list` /
+//! `<driver> start`) to a `Driver` implementation that completes the
+//! handshake and idles. The OSC protocol itself, device enumeration, and
+//! actual signal forwarding are deliberately deferred to follow-up work
+//! and live behind no-op handlers here.
+//!
+//! # What this binary currently does
+//!
+//! - `list`: prints an empty device array (`[]`). Device enumeration is
+//!   intentionally not implemented yet — the bridge treats an empty list
+//!   as "this driver is wired up but has no devices to offer right now",
+//!   which is the correct state for a skeleton.
+//! - `start`: emits the SDK `hello` message, waits for `hello_ack`, then
+//!   accepts and silently drops any control commands (`connect`,
+//!   `configure`, `disconnect`) until stdin EOF or SIGTERM/SIGINT.
+//!
+//! Returning `Ok(())` from every command handler keeps the bridge's
+//! lifecycle tests against this driver passing: the bridge sees a clean
+//! handshake, can issue commands without errors, and observes a graceful
+//! exit on shutdown. When real OSC support lands, the handler bodies are
+//! the place to dispatch into the protocol implementation.
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {}
+use std::process::ExitCode;
+
+use midori_sdk::{ControlCommand, DeviceEntry, Driver, DriverError};
+
+/// Skeleton driver state. Holds no resources today; future OSC work will
+/// add a UDP socket handle, a worker thread, and an SPSC `Producer` here.
+#[derive(Default)]
+struct OscDriver;
+
+impl Driver for OscDriver {
+    fn list_devices(&mut self) -> Vec<DeviceEntry> {
+        // Device discovery (enumerating reachable OSC endpoints) is out of
+        // scope for the skeleton. Returning an empty list is the documented
+        // way to say "no devices available" without erroring out.
+        Vec::new()
+    }
+
+    fn handle_command(&mut self, _command: ControlCommand) -> Result<(), DriverError> {
+        // Accept and drop. Returning Ok keeps the SDK's command loop alive
+        // so the bridge can drive the full lifecycle (connect → configure →
+        // disconnect) against this skeleton without surfacing spurious
+        // protocol errors.
+        Ok(())
+    }
+
+    fn shutdown(&mut self) -> Result<(), DriverError> {
+        // No resources to release yet. Real implementations will tear down
+        // the OSC socket and join worker threads here.
+        Ok(())
+    }
+}
+
+fn main() -> ExitCode {
+    midori_sdk::driver::run(OscDriver)
 }

--- a/crates/midori-driver-osc/src/main.rs
+++ b/crates/midori-driver-osc/src/main.rs
@@ -28,7 +28,6 @@ use midori_sdk::{ControlCommand, DeviceEntry, Driver, DriverError};
 
 /// Skeleton driver state. Holds no resources today; future OSC work will
 /// add a UDP socket handle, a worker thread, and an SPSC `Producer` here.
-#[derive(Default)]
 struct OscDriver;
 
 impl Driver for OscDriver {


### PR DESCRIPTION
## 概要

公式 OSC ドライバの Cargo crate スケルトンに、ランタイムから起動された際にハンドシェイクを完了して待機状態に入る最小実装を入れる。OSC プロトコル本体・デバイス列挙・接続処理は本 PR のスコープ外。

Closes MEW-28
Linear: https://linear.app/mewton/issue/MEW-28/bootstrap-official-osc-driver-crate-skeleton

## 変更点

- `crates/midori-driver-osc/src/main.rs` を `fn main() {}` から `midori_sdk::driver::run` 呼び出しに置き換え
- `Driver` トレイトを最小実装する `OscDriver` 構造体を追加
  - `list_devices`: 空の `Vec` を返す（デバイス列挙はスコープ外）
  - `handle_command`: 受領して `Ok(())`（コマンドループを生かしておくため）
  - `shutdown`: `Ok(())`（解放すべき資源がまだない）

これにより以下の AC を満たす：

- [x] `crates/midori-driver-osc/` が Cargo workspace に追加されている（既達成）
- [x] `midori-sdk` を依存として持ち、ビルドが通る
- [x] ランタイムから起動されるとハンドシェイクを完了して待機状態になる

## 動作確認

| サブコマンド | 入力 | 期待挙動 | 結果 |
|---|---|---|---|
| `list` | なし | `[]` を出力して exit 0 | OK |
| `start` | `hello_ack` → `connect` → `disconnect` を流す | `hello` を 1 行目に出力、コマンドを順に消費し、stdin EOF で exit 0 | OK |
| 引数なし | — | usage を stderr に出して exit 1 | OK |

## 設計メモ

- `midori-sdk` 側に `Driver` トレイトと `run()` ヘルパー（ハンドシェイク・シグナルハンドリング・stdin リーダースレッド込み）が既に揃っているので、ドライバ側は最小実装のみで AC を満たせる
- 実際の OSC 実装が入った段階で、`OscDriver` フィールドに UDP socket / worker thread / `Producer` などを持たせ、`handle_command` 内でディスパッチする予定（コメントに明記）
- midi ドライバには触っていない（`defer-implementing-midi-driver-to-user` skill 準拠）

## DoD

- [x] `cargo build -p midori-driver-osc` 成功
- [x] `cargo clippy --workspace --all-targets -- -D warnings` 警告ゼロ
- [x] `cargo fmt --check` パス
- [x] `cargo test --workspace` 全件パス
- [x] PR は draft で作成
- [ ] ローカルレビュー（`/code-review:code-review` + `/coderabbit:review`）→ これから実施
- [ ] Linear MEW-28 を In Review に遷移 → ローカルレビュー完了後

## Test plan

- [ ] CI green
- [ ] `/code-review:code-review` 完走
- [ ] `/coderabbit:review` 完走
- [ ] user による最終レビュー

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * OSCドライバーが実装され、利用可能になりました。ドライバーはデバイスの検出、コマンド処理、およびシステムのシャットダウン機能に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->