### PR TITLE
fix(runtime): MAJOR.MINOR.PATCH の各 segment を厳密に検証する

### DIFF
--- a/crates/midori-runtime/src/driver_proc/handshake.rs
+++ b/crates/midori-runtime/src/driver_proc/handshake.rs
@@ -114,28 +114,84 @@ impl Compatibility {
 
 /// Decide whether the Bridge accepts `version` as a peer SDK.
 ///
-/// The accepted set is `MAJOR.MINOR.PATCH` triples whose `MAJOR` is listed
-/// in [`ACCEPTED_SDK_MAJORS`]. Anything that fails to parse — empty string,
-/// non-numeric segments, fewer than three segments — is rejected with a
-/// reason describing the failure mode so the driver-side log makes the
-/// mismatch obvious.
+/// The accepted set is `MAJOR.MINOR.PATCH` triples of bare base-10 `u32`
+/// integers whose `MAJOR` is listed in [`ACCEPTED_SDK_MAJORS`]. Each segment
+/// is parsed with [`u32::from_str`], which rejects empty strings, leading
+/// `-` (no negative `u32`) and surrounding whitespace; we additionally
+/// reject a leading `+` sign so the protocol stays a strict subset of
+/// `SemVer`'s MAJOR.MINOR.PATCH grammar (`SemVer` numeric identifiers are
+/// unsigned and do not carry a sign character).
+///
+/// Pre-release / build metadata (`1.0.0-rc.1`, `1.0.0+build.7`) are out of
+/// scope: such inputs fail the per-segment numeric parse and are reported
+/// the same way as any other malformed segment.
+///
+/// The `Incompatible` reason names which segment failed and how, so the
+/// driver-side log makes the mismatch obvious without the reader having to
+/// reproduce the parse locally.
 pub(super) fn is_sdk_compatible(version: &str) -> Compatibility {
+    if version.is_empty() {
+        return Compatibility::Incompatible {
+            reason: format!("sdk_version `{version}` is empty"),
+        };
+    }
     let mut parts = version.split('.');
     let Some(major_str) = parts.next() else {
+        // `str::split` always yields at least one element, so this is
+        // unreachable in practice; keep the arm to make the iterator
+        // contract explicit at the call site.
         return Compatibility::Incompatible {
             reason: format!("sdk_version `{version}` is empty"),
         };
     };
-    let Ok(major) = major_str.parse::<u32>() else {
-        return Compatibility::Incompatible {
-            reason: format!("sdk_version `{version}` has non-numeric major component"),
-        };
-    };
-    // Require the remaining `MINOR.PATCH` segments to exist, even if we don't
-    // gate on their values — the protocol contract is "MAJOR.MINOR.PATCH".
-    if parts.next().is_none() || parts.next().is_none() {
+    let Some(minor_str) = parts.next() else {
         return Compatibility::Incompatible {
             reason: format!("sdk_version `{version}` is not in MAJOR.MINOR.PATCH form"),
+        };
+    };
+    let Some(patch_str) = parts.next() else {
+        return Compatibility::Incompatible {
+            reason: format!("sdk_version `{version}` is not in MAJOR.MINOR.PATCH form"),
+        };
+    };
+    if parts.next().is_some() {
+        return Compatibility::Incompatible {
+            reason: format!(
+                "sdk_version `{version}` carries a trailing segment past MAJOR.MINOR.PATCH"
+            ),
+        };
+    }
+    // Each segment is parsed with `u32::from_str` (which rejects empty
+    // strings, surrounding whitespace, and a leading `-`); the explicit
+    // `starts_with('+')` guard then strips the only sign character that
+    // `from_str` would otherwise accept, keeping the accepted shape at
+    // exactly "one or more ASCII digits" per `SemVer` numeric identifiers.
+    if major_str.starts_with('+') {
+        return Compatibility::Incompatible {
+            reason: format!(
+                "sdk_version `{version}` has non-numeric major component `{major_str}`"
+            ),
+        };
+    }
+    let Ok(major) = major_str.parse::<u32>() else {
+        return Compatibility::Incompatible {
+            reason: format!(
+                "sdk_version `{version}` has non-numeric major component `{major_str}`"
+            ),
+        };
+    };
+    if minor_str.starts_with('+') || minor_str.parse::<u32>().is_err() {
+        return Compatibility::Incompatible {
+            reason: format!(
+                "sdk_version `{version}` has non-numeric minor component `{minor_str}`"
+            ),
+        };
+    }
+    if patch_str.starts_with('+') || patch_str.parse::<u32>().is_err() {
+        return Compatibility::Incompatible {
+            reason: format!(
+                "sdk_version `{version}` has non-numeric patch component `{patch_str}`"
+            ),
         };
     }
     if !ACCEPTED_SDK_MAJORS.contains(&major) {
@@ -166,4 +222,93 @@ pub(super) fn json_type_error(message: &str) -> serde_json::Error {
     // through `serde::de::Error` via a deserializer that produces our text.
     use serde::de::Error as _;
     serde_json::Error::custom(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_sdk_compatible, Compatibility};
+
+    /// Table-driven coverage of the MAJOR.MINOR.PATCH parser. The expected
+    /// shape is paired with a fragment of the rejection reason so the test
+    /// fails loudly if a future edit changes which segment a malformed
+    /// input is blamed on (for example, accidentally reporting a 4-segment
+    /// version as "non-numeric patch" instead of "trailing segment").
+    enum Expected {
+        Compatible,
+        /// The rejection reason must contain this substring. The fragments
+        /// are chosen to be specific to one rejection branch so a swap
+        /// between branches is detectable.
+        IncompatibleContains(&'static str),
+    }
+
+    #[test]
+    fn it_should_validate_sdk_version_segments() {
+        let cases: &[(&str, Expected)] = &[
+            // Accepted: both currently-allowed majors.
+            ("1.0.0", Expected::Compatible),
+            ("0.1.0", Expected::Compatible),
+            // Rejected: major outside the accepted set, but well-formed.
+            (
+                "99.0.0",
+                Expected::IncompatibleContains("advertises major 99"),
+            ),
+            // Rejected: non-numeric minor and patch.
+            (
+                "1.foo.bar",
+                Expected::IncompatibleContains("non-numeric minor"),
+            ),
+            // Rejected: empty minor segment between two dots.
+            ("1..3", Expected::IncompatibleContains("non-numeric minor")),
+            // Rejected: trailing segment past MAJOR.MINOR.PATCH.
+            (
+                "1.2.3.4",
+                Expected::IncompatibleContains("trailing segment"),
+            ),
+            // Rejected: empty input.
+            ("", Expected::IncompatibleContains("is empty")),
+            // Rejected: leading whitespace — `u32::from_str` does not trim.
+            (
+                " 1.0.0",
+                Expected::IncompatibleContains("non-numeric major"),
+            ),
+            // Rejected: leading minus sign — `u32` is unsigned.
+            (
+                "-1.0.0",
+                Expected::IncompatibleContains("non-numeric major"),
+            ),
+            // Rejected: leading plus sign — explicitly stripped before parse
+            // so the accepted shape stays "ASCII digits only".
+            (
+                "+1.0.0",
+                Expected::IncompatibleContains("non-numeric major"),
+            ),
+            // Rejected: too few segments (regression guard for the existing
+            // "must have at least three" path).
+            ("1.0", Expected::IncompatibleContains("MAJOR.MINOR.PATCH")),
+        ];
+
+        for (input, expected) in cases {
+            let result = is_sdk_compatible(input);
+            match (expected, &result) {
+                (Expected::Compatible, Compatibility::Compatible) => {}
+                (
+                    Expected::IncompatibleContains(needle),
+                    Compatibility::Incompatible { reason },
+                ) => {
+                    assert!(
+                        reason.contains(needle),
+                        "input {input:?}: expected reason to contain {needle:?}, got {reason:?}"
+                    );
+                }
+                (Expected::Compatible, Compatibility::Incompatible { reason }) => {
+                    panic!("input {input:?}: expected Compatible, got Incompatible({reason:?})");
+                }
+                (Expected::IncompatibleContains(needle), Compatibility::Compatible) => {
+                    panic!(
+                        "input {input:?}: expected Incompatible containing {needle:?}, got Compatible"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/crates/midori-runtime/src/driver_proc/handshake.rs
+++ b/crates/midori-runtime/src/driver_proc/handshake.rs
@@ -163,10 +163,13 @@ pub(super) fn is_sdk_compatible(version: &str) -> Compatibility {
     }
     // Each segment is parsed with `u32::from_str` (which rejects empty
     // strings, surrounding whitespace, and a leading `-`); the explicit
-    // `starts_with('+')` guard then strips the only sign character that
-    // `from_str` would otherwise accept, keeping the accepted shape at
-    // exactly "one or more ASCII digits" per `SemVer` numeric identifiers.
-    if major_str.starts_with('+') {
+    // `starts_with('+')` guard strips the only sign character that
+    // `from_str` would otherwise accept, and the `len > 1 && starts '0'`
+    // guard rejects multi-digit numbers padded with `0` (e.g. `01`).
+    // Together the three checks pin the accepted shape to `SemVer`'s
+    // numeric identifier grammar — "0 OR a non-zero digit followed by
+    // digits".
+    if major_str.starts_with('+') || (major_str.len() > 1 && major_str.starts_with('0')) {
         return Compatibility::Incompatible {
             reason: format!(
                 "sdk_version `{version}` has non-numeric major component `{major_str}`"
@@ -180,14 +183,20 @@ pub(super) fn is_sdk_compatible(version: &str) -> Compatibility {
             ),
         };
     };
-    if minor_str.starts_with('+') || minor_str.parse::<u32>().is_err() {
+    if minor_str.starts_with('+')
+        || (minor_str.len() > 1 && minor_str.starts_with('0'))
+        || minor_str.parse::<u32>().is_err()
+    {
         return Compatibility::Incompatible {
             reason: format!(
                 "sdk_version `{version}` has non-numeric minor component `{minor_str}`"
             ),
         };
     }
-    if patch_str.starts_with('+') || patch_str.parse::<u32>().is_err() {
+    if patch_str.starts_with('+')
+        || (patch_str.len() > 1 && patch_str.starts_with('0'))
+        || patch_str.parse::<u32>().is_err()
+    {
         return Compatibility::Incompatible {
             reason: format!(
                 "sdk_version `{version}` has non-numeric patch component `{patch_str}`"
@@ -285,6 +294,20 @@ mod tests {
             // Rejected: too few segments (regression guard for the existing
             // "must have at least three" path).
             ("1.0", Expected::IncompatibleContains("MAJOR.MINOR.PATCH")),
+            // Rejected: `SemVer` numeric identifiers forbid leading zeros on
+            // multi-digit numbers (`01` is not the same identifier as `1`).
+            (
+                "01.0.0",
+                Expected::IncompatibleContains("non-numeric major"),
+            ),
+            (
+                "1.02.0",
+                Expected::IncompatibleContains("non-numeric minor"),
+            ),
+            (
+                "1.0.03",
+                Expected::IncompatibleContains("non-numeric patch"),
+            ),
         ];
 
         for (input, expected) in cases {


### PR DESCRIPTION
## Summary

`is_sdk_compatible` の検証を強化し、SemVer 仕様に準拠した strict な MAJOR.MINOR.PATCH 三段構造のみを Compatible として受理するようにした。

これまでは major のみ `u32::from_str` で parse し、minor / patch は「セグメントが存在するか」しかチェックしていなかったため、以下の malformed な sdk_version が誤って compatible 判定を通過していた:

- `1.foo.bar` — minor / patch が非数値
- `1..3` — minor が空文字
- `1.2.3.4` — segment が 4 つ以上
- ` 1.0.0` — 数値前後の空白
- `+1.0.0` / `-1.0.0` — 符号付き数値
- `01.0.0` — leading zero (SemVer 仕様 §2 違反)

## 変更点

- `crates/midori-runtime/src/driver_proc/handshake.rs`
  - `is_sdk_compatible` で 3 segment 構造を厳格にチェック (4+ segment は "trailing segment" として reject)
  - 各 segment に対して `u32::from_str` で parse + `+` 符号 reject + leading zero reject
  - 失敗理由 (reason) は失敗したセグメントを名指して、driver 側ログから不一致箇所を特定しやすく
  - `#[cfg(test)] mod tests` に table-driven test を追加 (Compatible 2 ケース / Incompatible 12 ケース)

## Out of Scope

- pre-release / build metadata (`1.0.0-rc.1` 等) は doc コメントで明示的に out of scope と記載
- `ACCEPTED_SDK_MAJORS` の値変更や `Compatibility` enum 構造変更はなし
- `crates/midori-driver-dummy/` の `BAD_SDK_VERSION` および既存テストは現状維持

## Test plan

- [x] `cargo build`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (既存テスト 7 件 + 追加 1 件すべて pass)
- [x] `cargo fmt --check`
- [x] `coderabbit review --agent -t committed --base main` (findings: 0)

## DoD

- [x] AC をすべて満たす
- [x] テストを追加 (table-driven 12 ケース)
- [x] PR 本文に Issue 番号を含む (`Closes MEW-67`)
- [x] lint エラーゼロ
- [ ] レビュー pass (この PR の draft 状態を ready 切替後に CodeRabbit auto-review で確認)

Closes MEW-67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * SDK バージョン互換性チェックの検証ルールを強化しました。
  * SDK バージョン検証失敗時のエラーメッセージをより詳細にしました。

* **テスト**
  * SDK バージョン互換性検証のテストカバレッジを拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->