### PR TITLE
feat(runtime): wire shm ring ingest into inline event pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "midori-core"
 version = "0.3.0"
 dependencies = [
@@ -345,8 +363,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dirs",
+ "memmap2",
  "midori-core",
  "nix",
+ "os_pipe",
  "rmpv",
  "serde",
  "serde_json",
@@ -375,6 +395,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -403,6 +424,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "prettyplease"

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -23,14 +23,44 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
 
-# Safe Unix syscall wrappers. Used by `driver_proc` to send SIGTERM to a
-# child process without an `unsafe { libc::kill }` block — the workspace
-# forbids `unsafe_code` (see `Cargo.toml` workspace lints).
+# Safe Unix syscall wrappers. `driver_proc` uses `signal` for SIGTERM, the
+# inline ring consumer uses `mman` (mmap/munmap) and `memfd` (memfd_create)
+# to allocate per-driver shared memory, and the fd-passing helper uses
+# `socket` for SCM_RIGHTS sendmsg/recvmsg. The mmap calls themselves are
+# `unsafe` by definition (the kernel can map memory the compiler cannot
+# reason about); see the per-crate `unsafe_code = "deny"` lint override
+# below for the policy rationale.
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.30", default-features = false, features = ["signal"] }
+nix = { version = "0.30", default-features = false, features = ["signal", "mman", "fs", "socket", "uio"] }
+# Safe(-ish) wrapper around `mmap`. The `map_mut` constructor is `unsafe`
+# because the kernel-backed memory can be mutated outside the compiler's
+# aliasing model; the returned `MmapMut` itself exposes a `&mut [u8]`-like
+# interface that is otherwise pure-safe Rust.
+memmap2 = "0.9"
 
 [dev-dependencies]
 tempfile = "3"
+# Cross-platform safe wrapper for `pipe(2)`. Used by the SCM_RIGHTS round-trip
+# test to construct a pair of file descriptors whose semantics are easy to
+# observe (write to one end, read on the other) without needing an `unsafe`
+# block in the test code itself.
+os_pipe = "1"
 
-[lints]
-workspace = true
+# NOTE: We intentionally do **not** inherit `lints.workspace = true` here.
+# The workspace lint table sets `unsafe_code = "forbid"`, which prevents this
+# crate from opting into the `unsafe` blocks required for OS-level shm work
+# (memfd_create + mmap, SCM_RIGHTS over UNIX domain sockets) in the driver
+# ↔ bridge inline ring ingest path. cargo rejects per-crate overrides while
+# inheriting the workspace lint table, so we re-declare every workspace lint
+# explicitly here and downgrade only `unsafe_code` to `deny`. Keep this list
+# in sync with `Cargo.toml`'s `[workspace.lints]` block when it changes.
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+all         = { level = "warn", priority = -1 }
+pedantic    = { level = "warn", priority = -1 }
+correctness = { level = "deny", priority = -1 }
+module_name_repetitions = "allow"
+missing_errors_doc      = "allow"
+missing_panics_doc      = "allow"

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -23,13 +23,19 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
 
-# Safe Unix syscall wrappers. `driver_proc` uses `signal` for SIGTERM, the
-# inline ring consumer uses `mman` (mmap/munmap) and `memfd` (memfd_create)
-# to allocate per-driver shared memory, and the fd-passing helper uses
-# `socket` for SCM_RIGHTS sendmsg/recvmsg. The mmap calls themselves are
-# `unsafe` by definition (the kernel can map memory the compiler cannot
-# reason about); see the per-crate `unsafe_code = "deny"` lint override
-# below for the policy rationale.
+# Safe Unix syscall wrappers. `driver_proc` は SIGTERM のために `signal`
+# を、Linux 限定の inline ring consumer は `mman` (mmap/munmap) と
+# `nix::sys::memfd::memfd_create` を、fd-passing helper は SCM_RIGHTS の
+# sendmsg/recvmsg のために `socket` を使う。mmap 呼び出し自体は
+# `unsafe` (kernel が compiler の aliasing model 外でメモリを書換可能)
+# のため、後段の `unsafe_code = "deny"` lint override 参照。
+#
+# 注意: nix 0.30 では `memfd_create` は `mman` でも独自 feature でもなく、
+# `nix::sys::memfd` module 自体が `cfg(any(linux, android))` でゲート
+# されている（feature には現れない）。`mman` feature を有効にするだけで
+# Linux ビルド時に自動で利用可能になり、他 OS では module が存在しない。
+# 本 crate では module 利用側 (lib.rs) を `cfg(target_os = "linux")` で
+# 囲って macOS / Windows での参照を断つ運用にしている。
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30", default-features = false, features = ["signal", "mman", "fs", "socket", "uio"] }
 # Safe(-ish) wrapper around `mmap`. The `map_mut` constructor is `unsafe`

--- a/crates/midori-runtime/src/driver_proc/mod.rs
+++ b/crates/midori-runtime/src/driver_proc/mod.rs
@@ -67,8 +67,13 @@ use std::time::Duration;
 mod handshake;
 mod lifecycle;
 mod log_forward;
+mod request_ring;
 
 pub use log_forward::{non_json_line_to_log_event, LogEvent};
+pub use request_ring::{
+    try_parse_request_ring, RequestRingMessage, RingReadyMessage, RingRejectedMessage,
+    REQUEST_RING_TYPE, RING_READY_TYPE, RING_REJECTED_TYPE,
+};
 
 use handshake::{
     is_sdk_compatible, json_type_error, read_hello_line, write_hello_ack, Compatibility,

--- a/crates/midori-runtime/src/driver_proc/request_ring.rs
+++ b/crates/midori-runtime/src/driver_proc/request_ring.rs
@@ -1,0 +1,118 @@
+//! `request_ring` JSON Lines wire format。
+//!
+//! driver は handshake 中に `{"type":"request_ring","slot_size":<u32>}` を
+//! stdout に書き、Bridge は本構造体で parse する。Bridge 側は受領した
+//! `slot_size` を [`crate::ring_consumer::RingConsumer::create`] に渡す。
+//!
+//! `slot_size` の sentinel `0` は「default で確保してくれ」を意味する
+//! （詳細: `crates/midori-runtime/src/ring_handshake.rs` の
+//! `REQUEST_DEFAULT_SLOT_SIZE`）。
+//!
+//! Bridge → driver の応答は 2 種類:
+//!
+//! - 受理: `{"type":"ring_ready"}`（fd は別経路 = `SCM_RIGHTS` で渡る）
+//! - 拒否: `{"type":"ring_rejected","reason":"…"}`（driver は速やかに exit
+//!   する想定。Bridge は `SIGTERM` を発行して念押しする）
+
+use serde::{Deserialize, Serialize};
+
+/// driver → Bridge の `request_ring` メッセージ。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RequestRingMessage {
+    /// 識別子。常に `"request_ring"`。
+    #[serde(rename = "type")]
+    pub message_type: String,
+    /// 要求 `slot_size`。`0` は sentinel（`DEFAULT_SLOT_SIZE` 採用）。
+    pub slot_size: u32,
+}
+
+/// Bridge → driver の `ring_ready` 受理応答。
+#[derive(Debug, Clone, Serialize)]
+pub struct RingReadyMessage<'a> {
+    /// 識別子。常に `"ring_ready"`。
+    #[serde(rename = "type")]
+    pub message_type: &'a str,
+}
+
+/// Bridge → driver の `ring_rejected` 拒否応答。
+#[derive(Debug, Clone, Serialize)]
+pub struct RingRejectedMessage<'a> {
+    /// 識別子。常に `"ring_rejected"`。
+    #[serde(rename = "type")]
+    pub message_type: &'a str,
+    /// 人間可読な拒否理由。alignment / 上限などの判定文。
+    pub reason: &'a str,
+}
+
+/// `request_ring` メッセージのフィールド `type` 定数。
+pub const REQUEST_RING_TYPE: &str = "request_ring";
+
+/// `ring_ready` メッセージのフィールド `type` 定数。
+pub const RING_READY_TYPE: &str = "ring_ready";
+
+/// `ring_rejected` メッセージのフィールド `type` 定数。
+pub const RING_REJECTED_TYPE: &str = "ring_rejected";
+
+/// driver の stdout 行が `request_ring` メッセージとしてパースできるなら
+/// `Some(slot_size)` を返す。`type` フィールドが `"request_ring"` 以外、
+/// JSON parse 失敗、必須フィールド欠損のいずれでも `None`。
+///
+/// caller は `None` が返ったら次の行を待つ（driver は非 JSON ログ行と
+/// `request_ring` を混在させ得る、`design/10-driver-plugin.md` 参照）。
+#[must_use]
+pub fn try_parse_request_ring(line: &str) -> Option<u32> {
+    let parsed: RequestRingMessage = serde_json::from_str(line.trim_end()).ok()?;
+    if parsed.message_type != REQUEST_RING_TYPE {
+        return None;
+    }
+    Some(parsed.slot_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_should_parse_default_sentinel_slot_size_zero() {
+        let parsed = try_parse_request_ring(r#"{"type":"request_ring","slot_size":0}"#);
+        assert_eq!(parsed, Some(0));
+    }
+
+    #[test]
+    fn it_should_parse_custom_slot_size() {
+        let parsed = try_parse_request_ring(r#"{"type":"request_ring","slot_size":4104}"#);
+        assert_eq!(parsed, Some(4_104));
+    }
+
+    #[test]
+    fn it_should_ignore_messages_with_other_type_tags() {
+        // hello 行や非 JSON 行が混じるケースで誤検出しない。
+        assert!(try_parse_request_ring(r#"{"type":"hello","sdk_version":"0.1.0"}"#).is_none());
+        assert!(try_parse_request_ring("midori-driver-dummy: noisy debug").is_none());
+        assert!(try_parse_request_ring("").is_none());
+    }
+
+    #[test]
+    fn it_should_reject_messages_missing_slot_size_field() {
+        assert!(try_parse_request_ring(r#"{"type":"request_ring"}"#).is_none());
+    }
+
+    #[test]
+    fn it_should_round_trip_ring_ready_to_json() {
+        let msg = RingReadyMessage {
+            message_type: RING_READY_TYPE,
+        };
+        let encoded = serde_json::to_string(&msg).expect("encode");
+        assert_eq!(encoded, r#"{"type":"ring_ready"}"#);
+    }
+
+    #[test]
+    fn it_should_round_trip_ring_rejected_to_json_with_reason() {
+        let msg = RingRejectedMessage {
+            message_type: RING_REJECTED_TYPE,
+            reason: "slot_size 65540 は HARD_SLOT_SIZE 65536 を超えています",
+        };
+        let encoded = serde_json::to_string(&msg).expect("encode");
+        assert!(encoded.starts_with(r#"{"type":"ring_rejected","reason":"slot_size 65540"#));
+    }
+}

--- a/crates/midori-runtime/src/error.rs
+++ b/crates/midori-runtime/src/error.rs
@@ -1,4 +1,5 @@
-use crate::events_pipeline::StartupCheckError;
+use midori_runtime::events_pipeline::StartupCheckError;
+
 use crate::plugin_resolver::ResolveError;
 use crate::profile::ProfileLoadError;
 

--- a/crates/midori-runtime/src/events_pipeline/mod.rs
+++ b/crates/midori-runtime/src/events_pipeline/mod.rs
@@ -24,23 +24,13 @@
 //! - 本ファイル: [`EventSink`] / [`LoggingSink`] / [`process_inline_payload`]
 //! - `tests`: 統合テスト
 
-// `decode` / `runtime_check` 経路は SPSC ring からの実 ingest 配線後に
-// 実 caller が付く予定。それまで本ファイル直下の SPSC 連携 stub
-// (`LoggingSink` / `process_inline_payload` / `try_process` / `ProcessError`)
-// と sub-module 群はいずれも dead_code 警告を生むので、type 単位で個別に
-// allow する。`startup` は main から駆動済みのため対象外。
-#[allow(dead_code, unused_imports)]
+// `decode` / `runtime_check` は `ring_ingest` 経由の実 caller が付いた
+// ので dead_code 抑制を外す。`startup` は main から駆動済み。
 mod decode;
-#[allow(dead_code, unused_imports)]
 mod runtime_check;
 mod startup;
 
-// `decode` / `runtime_check` の type は SPSC ingest 配線で表面に出るが
-// 本 subtask の段階では caller が居ない。再 export 自体は維持して、
-// 個別 import 警告は module 内 allow に委ねる。
-#[allow(unused_imports)]
 pub use decode::{decode_event, DecodeError, DecodedPayload, FieldValue};
-#[allow(unused_imports)]
 pub use runtime_check::{check_event, RuntimeCheckError, ValidatedEvent};
 pub use startup::{check_driver_schema, DriverSchemaOutcome, StartupCheckError};
 
@@ -55,7 +45,6 @@ pub trait EventSink {
 }
 
 /// stderr に最小情報だけ書き出す `EventSink` の素朴実装。trace 用途。
-#[allow(dead_code)]
 pub struct LoggingSink;
 
 impl EventSink for LoggingSink {
@@ -76,7 +65,6 @@ impl EventSink for LoggingSink {
 /// 値検証ができないため、wire format が偶然正しくても受理しない）。caller
 /// が `LoadOutcome::Missing` を warning として扱いつつパイプラインを継続
 /// したい場合も、本関数は payload を sink へ流さない。
-#[allow(dead_code)]
 pub fn process_inline_payload(
     driver_name: &str,
     schema: Option<&EventsSchema>,
@@ -91,7 +79,6 @@ pub fn process_inline_payload(
 
 /// `process_inline_payload` の純関数版。テストでログ捕捉に頼らず
 /// 失敗種別をパターンマッチで検査するために露出する。
-#[allow(dead_code)]
 pub(crate) fn try_process(
     driver_name: &str,
     schema: Option<&EventsSchema>,
@@ -104,7 +91,6 @@ pub(crate) fn try_process(
 }
 
 /// パイプラインの 3 段が出すエラーを集約した単一型（テスト・観測用）。
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) enum ProcessError {
     Decode(DecodeError),

--- a/crates/midori-runtime/src/fd_socket.rs
+++ b/crates/midori-runtime/src/fd_socket.rs
@@ -63,7 +63,8 @@ pub fn send_fd(stream: &UnixStream, fd: BorrowedFd<'_>) -> io::Result<()> {
 ///
 /// - `recvmsg(2)` が失敗（peer が socket を閉じた、等）
 /// - 受信メッセージに `SCM_RIGHTS` 制御メッセージが無い
-/// - `SCM_RIGHTS` に fd が 0 個 or 2 個以上含まれていた
+/// - 単一 `SCM_RIGHTS` 内に fd が 0 個 or 2 個以上含まれていた
+/// - `SCM_RIGHTS` 制御メッセージが 2 件以上届いた（本 helper のコントラクト違反）
 pub fn recv_fd(stream: &UnixStream) -> io::Result<OwnedFd> {
     use std::io::IoSliceMut;
 
@@ -99,6 +100,23 @@ pub fn recv_fd(stream: &UnixStream) -> io::Result<OwnedFd> {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "fd_socket: expected exactly 1 fd in SCM_RIGHTS",
+                ));
+            }
+            // 2 件目以降の `SCM_RIGHTS` cmsg を受け取った場合、最初に格納
+            // した fd を上書きすると silent close になる。本 helper の
+            // コントラクトは「単一 cmsg」なので、追加 fd を即 close した上で
+            // error 返却する。
+            if received.is_some() {
+                #[allow(unsafe_code)]
+                for raw in fds {
+                    // SAFETY: `recvmsg` が `fds` に格納した値はちょうど今
+                    // 受信したばかりの所有 fd。重複所有は無く、`OwnedFd`
+                    // で包んで即 drop すれば close される。
+                    let _ = unsafe { OwnedFd::from_raw_fd(raw) };
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "fd_socket: multiple SCM_RIGHTS control messages received",
                 ));
             }
             // SAFETY: 同上。`recvmsg` から受け取った所有 fd を OwnedFd に

--- a/crates/midori-runtime/src/fd_socket.rs
+++ b/crates/midori-runtime/src/fd_socket.rs
@@ -1,0 +1,167 @@
+//! UNIX domain socket 越しに file descriptor を 1 個だけ受け渡しする
+//! 薄いヘルパー。
+//!
+//! Bridge は handshake で確保した shm fd を driver subprocess に渡す必要
+//! がある。pipe では fd を運べないため、`SCM_RIGHTS` を載せた `sendmsg(2)`
+//! / `recvmsg(2)` を使う。本 module は `nix::sys::socket` の薄いラッパーで:
+//!
+//! - 送信側 [`send_fd`]: 1 byte の dummy payload と一緒に `OwnedFd` 1 個を
+//!   `SCM_RIGHTS` 制御メッセージとして送る
+//! - 受信側 [`recv_fd`]: 1 byte の dummy payload と `SCM_RIGHTS` を 1 個
+//!   読み出し、`OwnedFd` を返す
+//!
+//! payload の中身は本 module では使わない（fd 1 個だけが意味を持つ）。
+//! caller が独自の handshake バイト（例: ack 種別）を載せたい場合の拡張は
+//! 別 API で行う。
+//!
+//! 設計参照: `design/15-sdk-bindings-api.md` Phase 1 / L1-2「Bridge との
+//! fd 受け渡しプロトコル」、`design/17-driver-comm/01-inline-ring.md`
+//! 「Handshake プロトコル」step 5。
+
+use std::io;
+use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd};
+use std::os::unix::net::UnixStream;
+
+use nix::sys::socket::{recvmsg, sendmsg, ControlMessage, ControlMessageOwned, MsgFlags};
+
+/// 1 byte のセンチネル payload。`sendmsg`/`recvmsg` は payload 0 byte を
+/// 受け付けない実装が多いため、最小サイズの 1 byte を載せる。値そのものは
+/// 利用せず、byte が届いた事実だけを使う。
+const HANDSHAKE_BYTE: u8 = b'\x01';
+
+/// `stream` 越しに `fd` を 1 個送る。
+///
+/// 内部で 1 byte の dummy payload と一緒に `SCM_RIGHTS(fd)` を 1 個だけ
+/// 載せた `sendmsg(2)` を発行する。fd の所有権は kernel 側にコピーされる
+/// （送信元プロセスでは引き続き有効、受信プロセスは duplicate された fd を
+/// 受け取る）。caller は呼出後に自前の `BorrowedFd` を `drop` してよい。
+///
+/// # Errors
+///
+/// `sendmsg(2)` が失敗した場合（pipe broken、shm fd 無効、等）に `Err` を返す。
+pub fn send_fd(stream: &UnixStream, fd: BorrowedFd<'_>) -> io::Result<()> {
+    use std::io::IoSlice;
+
+    let bytes = [HANDSHAKE_BYTE];
+    let iov = [IoSlice::new(&bytes)];
+    let raw = [fd.as_raw_fd()];
+    let cmsgs = [ControlMessage::ScmRights(&raw)];
+
+    sendmsg::<()>(stream.as_raw_fd(), &iov, &cmsgs, MsgFlags::empty(), None)
+        .map_err(io::Error::from)?;
+    Ok(())
+}
+
+/// `stream` から fd を 1 個受け取る。
+///
+/// 受信した `SCM_RIGHTS` の中身を [`OwnedFd`] として返す。dummy payload
+/// バイトは捨てる。
+///
+/// # Errors
+///
+/// 以下のいずれか:
+///
+/// - `recvmsg(2)` が失敗（peer が socket を閉じた、等）
+/// - 受信メッセージに `SCM_RIGHTS` 制御メッセージが無い
+/// - `SCM_RIGHTS` に fd が 0 個 or 2 個以上含まれていた
+pub fn recv_fd(stream: &UnixStream) -> io::Result<OwnedFd> {
+    use std::io::IoSliceMut;
+
+    let mut byte_buf = [0u8; 1];
+    let mut iov = [IoSliceMut::new(&mut byte_buf)];
+    // SCM_RIGHTS 1 個分のスペース（fd 1 個 = `RawFd` 4 byte + cmsghdr 分）。
+    // nix が `cmsg_space!` マクロを提供しているのでそれを使って正確な
+    // バッファサイズを取る。
+    let mut cmsg_buf = nix::cmsg_space!([std::os::fd::RawFd; 1]);
+
+    let msg = recvmsg::<()>(
+        stream.as_raw_fd(),
+        &mut iov,
+        Some(&mut cmsg_buf),
+        MsgFlags::empty(),
+    )
+    .map_err(io::Error::from)?;
+
+    let mut received: Option<OwnedFd> = None;
+    for cmsg in msg.cmsgs().map_err(io::Error::from)? {
+        if let ControlMessageOwned::ScmRights(fds) = cmsg {
+            // 「ちょうど 1 個」を要求する。0 個なら peer が SCM_RIGHTS なし
+            // で送ってきた、2 個以上なら本 helper のコントラクト違反。
+            if fds.len() != 1 {
+                // 受け取った fd をリークしないよう即 close する。
+                #[allow(unsafe_code)]
+                for raw in fds {
+                    // SAFETY: `recvmsg` が `fds` に格納した値はちょうど今
+                    // 受信したばかりの所有 fd。重複所有は無く、`OwnedFd`
+                    // で包んで即 drop すれば close される。
+                    let _ = unsafe { OwnedFd::from_raw_fd(raw) };
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "fd_socket: expected exactly 1 fd in SCM_RIGHTS",
+                ));
+            }
+            // SAFETY: 同上。`recvmsg` から受け取った所有 fd を OwnedFd に
+            // 移し替えるだけで、Drop で適切に close される。
+            #[allow(unsafe_code)]
+            let owned = unsafe { OwnedFd::from_raw_fd(fds[0]) };
+            received = Some(owned);
+        }
+    }
+
+    received.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "fd_socket: no SCM_RIGHTS control message received",
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::os::fd::AsFd;
+    use std::thread;
+
+    #[test]
+    fn it_should_round_trip_a_pipe_fd_between_two_unix_stream_endpoints() {
+        // socketpair で繋いだ 2 endpoint を、別スレッドで送受信する。
+        let (sender, receiver) = UnixStream::pair().expect("UnixStream::pair must succeed");
+
+        // 送る fd: pipe の read 側を作って渡す。受信側で同じ pipe を read
+        // できれば「同じ kernel オブジェクトを共有している」確認になる。
+        let (pipe_r, mut pipe_w) = os_pipe::pipe().expect("os_pipe must succeed");
+
+        let join = thread::spawn(move || {
+            send_fd(&sender, pipe_r.as_fd()).expect("send_fd");
+            // sender 側は元の pipe_r を drop。fd は kernel 内で複製済み。
+            drop(pipe_r);
+        });
+
+        let received_fd = recv_fd(&receiver).expect("recv_fd");
+        join.join().expect("sender thread");
+
+        // 送信側だけが pipe_w を持っているので write → 受信した fd で read。
+        pipe_w.write_all(b"X").expect("write pipe");
+        drop(pipe_w);
+
+        let mut got = [0u8; 1];
+        // `OwnedFd` から `File` への移行は `From<OwnedFd>` が安全に提供する
+        // ので unsafe 不要。fd の所有権がそのまま File に移る。
+        let mut as_file = std::fs::File::from(received_fd);
+        as_file.read_exact(&mut got).expect("read pipe");
+        assert_eq!(got, [b'X']);
+    }
+
+    #[test]
+    fn it_should_fail_when_peer_drops_socket_without_sending() {
+        let (sender, receiver) = UnixStream::pair().expect("UnixStream::pair must succeed");
+        // sender を drop すると receiver の recvmsg は EOF を返す（recvmsg
+        // 自体は Ok だが iov に 0 byte、cmsgs も空）。本 helper は SCM_RIGHTS
+        // 不在を InvalidData として拒否する。
+        drop(sender);
+        let err = recv_fd(&receiver).expect_err("peer dropped");
+        assert!(matches!(err.kind(), io::ErrorKind::InvalidData));
+    }
+}

--- a/crates/midori-runtime/src/fd_socket.rs
+++ b/crates/midori-runtime/src/fd_socket.rs
@@ -14,9 +14,12 @@
 //! caller が独自の handshake バイト（例: ack 種別）を載せたい場合の拡張は
 //! 別 API で行う。
 //!
-//! 設計参照: `design/15-sdk-bindings-api.md` Phase 1 / L1-2「Bridge との
-//! fd 受け渡しプロトコル」、`design/17-driver-comm/01-inline-ring.md`
-//! 「Handshake プロトコル」step 5。
+//! プロトコル仕様:
+//!
+//! - 1 メッセージにつき `SCM_RIGHTS` cmsg は 1 個まで
+//! - その cmsg 内に格納する fd はちょうど 1 個
+//! - 上記いずれの違反も [`recv_fd`] が `io::ErrorKind::InvalidData` で
+//!   reject する（受信側で fd を leak させない）
 
 use std::io;
 use std::os::fd::{AsRawFd, BorrowedFd, FromRawFd, OwnedFd};

--- a/crates/midori-runtime/src/lib.rs
+++ b/crates/midori-runtime/src/lib.rs
@@ -13,22 +13,29 @@
 //!   logger the CLI uses, and so integration tests can observe the layer
 //!   string used for forwarded lines.
 //! - [`ring_consumer`]: per-driver shm allocator + SPSC consumer used by
-//!   the inline-tier ingest path.
+//!   the inline-tier ingest path. Linux-only — depends on `memfd_create(2)`.
 //! - [`fd_socket`]: SCM_RIGHTS-based fd handoff helper used to deliver the
-//!   shm fd from Bridge to driver.
+//!   shm fd from Bridge to driver. Linux-only as part of the inline-tier
+//!   chain that includes [`ring_consumer`].
 //! - [`ring_ingest`]: glue that pumps the ring consumer into
 //!   [`events_pipeline::process_inline_payload`] on a dedicated thread.
+//!   Linux-only as part of the same chain.
+//!
+//! macOS / Windows 対応の inline-tier IPC は別 Issue で実装する（macOS は
+//! `shm_open(2)` ベース、Windows は `CreateFileMapping` ベースの予定）。
+//! 現状はその 3 つの module ごと `cfg(target_os = "linux")` で囲って
+//! 他 OS では存在しない扱いにしている。
 //!
 //! The CLI dispatch layer remains binary-private until there is a concrete
 //! need to expose it.
 
 pub mod driver_proc;
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub mod fd_socket;
 pub mod logging;
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub mod ring_consumer;
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 pub mod ring_ingest;
 
 // `events_pipeline` / `ring_handshake` were previously binary-private. They

--- a/crates/midori-runtime/src/lib.rs
+++ b/crates/midori-runtime/src/lib.rs
@@ -12,9 +12,30 @@
 //!   stdout-forwarding path can hand non-JSON driver lines to the same
 //!   logger the CLI uses, and so integration tests can observe the layer
 //!   string used for forwarded lines.
+//! - [`ring_consumer`]: per-driver shm allocator + SPSC consumer used by
+//!   the inline-tier ingest path.
+//! - [`fd_socket`]: SCM_RIGHTS-based fd handoff helper used to deliver the
+//!   shm fd from Bridge to driver.
+//! - [`ring_ingest`]: glue that pumps the ring consumer into
+//!   [`events_pipeline::process_inline_payload`] on a dedicated thread.
 //!
 //! The CLI dispatch layer remains binary-private until there is a concrete
 //! need to expose it.
 
 pub mod driver_proc;
+#[cfg(unix)]
+pub mod fd_socket;
 pub mod logging;
+#[cfg(unix)]
+pub mod ring_consumer;
+#[cfg(unix)]
+pub mod ring_ingest;
+
+// `events_pipeline` / `ring_handshake` were previously binary-private. They
+// are now dependencies of `ring_consumer` / `ring_ingest`, which the lib
+// surface re-exports — so the modules themselves must move to lib scope too.
+// They stay `pub` because the `midori` binary lives in a separate crate and
+// reaches them via `midori_runtime::*`.
+pub mod events_pipeline;
+pub mod events_schema;
+pub mod ring_handshake;

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -1,9 +1,6 @@
 mod error;
-mod events_pipeline;
-mod events_schema;
 mod plugin_resolver;
 mod profile;
-mod ring_handshake;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -11,9 +8,9 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 
 use crate::error::CliError;
-use crate::events_pipeline::{check_driver_schema, DriverSchemaOutcome};
 use crate::plugin_resolver::{resolve_drivers, ResolvedDrivers};
 use crate::profile::{collect_driver_names, load_from_path as load_profile};
+use midori_runtime::events_pipeline::{check_driver_schema, DriverSchemaOutcome};
 use midori_runtime::logging;
 use midori_runtime::logging::{LogFormat, LogLevel};
 
@@ -369,7 +366,7 @@ mod tests {
             matches!(
                 err,
                 CliError::StartupCheck {
-                    source: crate::events_pipeline::StartupCheckError::Validate { .. }
+                    source: midori_runtime::events_pipeline::StartupCheckError::Validate { .. }
                 }
             ),
             "expected StartupCheck::Validate, got {err:?}"
@@ -435,7 +432,8 @@ mod tests {
             matches!(
                 err,
                 CliError::StartupCheck {
-                    source: crate::events_pipeline::StartupCheckError::FeatureUnavailable { .. }
+                    source:
+                        midori_runtime::events_pipeline::StartupCheckError::FeatureUnavailable { .. }
                 }
             ),
             "expected StartupCheck::FeatureUnavailable, got {err:?}"
@@ -452,7 +450,7 @@ mod tests {
             matches!(
                 err,
                 CliError::StartupCheck {
-                    source: crate::events_pipeline::StartupCheckError::Load { .. }
+                    source: midori_runtime::events_pipeline::StartupCheckError::Load { .. }
                 }
             ),
             "expected StartupCheck::Load, got {err:?}"
@@ -473,7 +471,7 @@ mod tests {
             matches!(
                 err,
                 CliError::StartupCheck {
-                    source: crate::events_pipeline::StartupCheckError::Validate { .. }
+                    source: midori_runtime::events_pipeline::StartupCheckError::Validate { .. }
                 }
             ),
             "expected StartupCheck::Validate, got {err:?}"

--- a/crates/midori-runtime/src/ring_consumer.rs
+++ b/crates/midori-runtime/src/ring_consumer.rs
@@ -1,0 +1,417 @@
+//! Bridge 側の SPSC リング consumer 実装。
+//!
+//! driver からの handshake `request_ring(slot_size)` を受けて:
+//!
+//! 1. [`ring_handshake::resolve_requested_slot_size`] で受領値を validate
+//!    （sentinel `0` → `DEFAULT_SLOT_SIZE`、alignment / 上限を検査）
+//! 2. `memfd_create(2)` で anonymous shm を確保し
+//!    [`ring_handshake::page_aligned_shm_size`] のページ整列サイズへ truncate
+//! 3. `mmap(2)` で Bridge プロセス内に書き込み可能でマップ
+//! 4. `ShmHeader` の `slot_size` / `version` / 両 index を初期化
+//! 5. driver に渡すための [`OwnedFd`] と本構造体 [`RingConsumer`] を返す
+//!
+//! consumer 側 API は [`RingConsumer::read`] のみ:
+//!
+//! - 1 slot 分の payload を pop して `Vec<u8>` に複製して返す
+//! - リングが空のときは `None`（caller は spin / sleep 戦略を上に被せる）
+//!
+//! `RingConsumer` を drop すると `MmapMut` が `munmap(2)` を発行する。
+//!
+//! # Safety
+//!
+//! `mmap` は本質的に unsafe（kernel が任意のタイミングで内容を書き換え得る）
+//! のため、本 module 内で `unsafe { ... }` を 1 箇所だけ使う。`memmap2`
+//! crate の `MmapMut::map_mut` は `unsafe fn` であり、その呼び出し点に
+//! `# Safety` 注記を付ける。
+//!
+//! 設計参照: `design/17-driver-comm/01-inline-ring.md`「API スケッチ」
+//! 「Bridge 側」「メモリ順序」。
+
+use std::ffi::CString;
+use std::fmt;
+use std::os::fd::OwnedFd;
+use std::sync::atomic::Ordering;
+
+use memmap2::{MmapMut, MmapOptions};
+use midori_core::shm::{
+    slot_offset_in_shm, ShmHeader, RING_CAPACITY, SHM_LAYOUT_VERSION, SLOT_HEADER_SIZE,
+};
+
+use crate::ring_handshake::{page_aligned_shm_size, resolve_requested_slot_size, HandshakeError};
+
+/// [`RingConsumer::create`] が失敗する原因。
+#[derive(Debug)]
+pub enum CreateError {
+    /// driver から受け取った `slot_size` が ABI 制約を満たさない。
+    /// 内側の [`HandshakeError`] が具体内容（alignment / 最小値 / 上限）を運ぶ。
+    Handshake(HandshakeError),
+    /// `memfd_create(2)` / `ftruncate(2)` / `mmap(2)` のいずれかが失敗した。
+    /// 内側の `std::io::Error` が OS エラーを運ぶ。
+    Os {
+        operation: &'static str,
+        source: std::io::Error,
+    },
+}
+
+impl fmt::Display for CreateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Handshake(source) => write!(f, "ring 確保前の handshake で失敗: {source}"),
+            Self::Os { operation, source } => {
+                write!(f, "shm リング確保中に {operation} が失敗しました: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CreateError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Handshake(source) => Some(source),
+            Self::Os { source, .. } => Some(source),
+        }
+    }
+}
+
+/// Bridge 側 consumer 1 個分の状態。
+///
+/// `mmap` 領域と `slot_size` のキャッシュを持つ。`Drop` で `MmapMut` が
+/// 自動的に `munmap` する。
+///
+/// **スレッドモデル**: SPSC の S（single consumer）として扱うこと。本構造体
+/// は `Send` だが `Sync` を要求する API は提供しない。consumer ループは
+/// 1 スレッド内で `read()` を呼ぶ前提。
+pub struct RingConsumer {
+    /// shm 全体（ヘッダ + 全スロット）にまたがる mmap region。
+    /// `Drop` で `munmap` を発行する。
+    mmap: MmapMut,
+    /// handshake で確定した slot 全体サイズ（byte）。stride 計算に使う。
+    slot_size: u32,
+}
+
+impl fmt::Debug for RingConsumer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RingConsumer")
+            .field("slot_size", &self.slot_size)
+            .field("shm_bytes", &self.mmap.len())
+            .finish()
+    }
+}
+
+impl RingConsumer {
+    /// Driver からの handshake `request_ring(requested_slot_size)` を受けて
+    /// shm を確保し、`(consumer, fd)` を返す。
+    ///
+    /// `requested_slot_size = 0` (sentinel) の場合は `DEFAULT_SLOT_SIZE` を
+    /// 採用する。返される [`OwnedFd`] は driver subprocess に `SCM_RIGHTS`
+    /// で渡す前提で、Bridge 側でも同 fd を mmap している（Bridge と driver
+    /// が同じ kernel 領域を共有）。
+    ///
+    /// # Errors
+    ///
+    /// - [`CreateError::Handshake`]: alignment / 最小値 / 上限違反
+    /// - [`CreateError::Os`]: `memfd_create` / `ftruncate` / `mmap` の失敗
+    pub fn create(requested_slot_size: u32) -> Result<(Self, OwnedFd), CreateError> {
+        let slot_size =
+            resolve_requested_slot_size(requested_slot_size).map_err(CreateError::Handshake)?;
+        let shm_bytes = page_aligned_shm_size(slot_size);
+
+        let owned_fd = create_memfd().map_err(|source| CreateError::Os {
+            operation: "memfd_create",
+            source,
+        })?;
+
+        // ftruncate でファイルを目標サイズに拡張する。memfd は初期サイズ 0 の
+        // 仮想ファイルなので、mmap する前に必ず必要。
+        let truncate_len = i64::try_from(shm_bytes).map_err(|_| CreateError::Os {
+            operation: "ftruncate (size_t→i64 cast)",
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "shm size exceeds i64::MAX",
+            ),
+        })?;
+        nix::unistd::ftruncate(&owned_fd, truncate_len).map_err(|errno| CreateError::Os {
+            operation: "ftruncate",
+            source: std::io::Error::from(errno),
+        })?;
+
+        // SAFETY: `owned_fd` は本関数で memfd_create したばかりの fresh な fd。
+        // 同一プロセス内で他 mapping は存在しない。len は `shm_bytes`（ftruncate
+        // 済みのサイズと一致）。memmap2 の `map_mut` の安全性要件は「他者が
+        // mmap 領域を書き換えない、または書き換えに対する整合性を caller が
+        // 担保する」だが、本 ring layout 自体が「driver から concurrent に
+        // 書かれることを Acquire/Release で同期する」前提で設計されている
+        // （詳細: `design/17-driver-comm/01-inline-ring.md`「メモリ順序」）。
+        // 残る要件は overflow / null / alignment で、それらは memmap2 内部で
+        // 検査される。
+        #[allow(unsafe_code)]
+        let mmap = unsafe {
+            MmapOptions::new()
+                .len(shm_bytes)
+                .map_mut(&owned_fd)
+                .map_err(|source| CreateError::Os {
+                    operation: "mmap",
+                    source,
+                })?
+        };
+
+        let mut consumer = Self { mmap, slot_size };
+        consumer.init_header();
+        Ok((consumer, owned_fd))
+    }
+
+    /// このリングが扱う slot 全体サイズ（byte）。テスト / 観測用。
+    #[must_use]
+    pub fn slot_size(&self) -> u32 {
+        self.slot_size
+    }
+
+    /// 1 slot 分を pop し、payload バイト列を `Vec<u8>` に複製して返す。
+    /// リングが空のときは `None`。
+    ///
+    /// 戻り値の `Vec<u8>` は新規 allocate する（slot 領域は次の producer 書き込みで
+    /// 上書きされ得るため、所有を pop 側に切り離す必要がある）。
+    #[must_use]
+    pub fn read(&self) -> Option<Vec<u8>> {
+        let header = self.header();
+        // Acquire で write_index を読んだ後、対応する slot の payload までを
+        // 同じ Acquire 観測の中に取り込む（producer 側の Release 書き込みと対）。
+        let write_index = header.write_index.load(Ordering::Acquire);
+        let read_index = header.read_index.load(Ordering::Relaxed);
+        if write_index == read_index {
+            return None;
+        }
+
+        // RING_CAPACITY (= 256) で剰余を取るため、上位ビットは破棄して問題
+        // ない。usize::MAX は 32-bit プラットフォームでも 2^32-1 ≧ 256 なので
+        // truncation 後の値は剰余演算と同じ結果になる。
+        #[allow(clippy::cast_possible_truncation)]
+        let slot_index = (read_index as usize) % RING_CAPACITY;
+        let payload = self.copy_slot_payload(slot_index);
+
+        // 消費完了を producer に通知。Release で「slot 内データを読み終えた」
+        // 事実を公開する。
+        header
+            .read_index
+            .store(read_index.wrapping_add(1), Ordering::Release);
+
+        payload
+    }
+
+    /// shm 領域先頭の `ShmHeader` への参照を取り出す。`mmap.as_ptr()` から
+    /// 直接組み立てる必要があり、`unsafe` を 1 箇所封じ込めるためのヘルパー。
+    fn header(&self) -> &ShmHeader {
+        // SAFETY: `mmap` は本構造体作成時に `shm_total_size` 以上の領域を
+        // 確保しており、先頭 `size_of::<ShmHeader>()` byte は `ShmHeader` の
+        // memory layout として `init_header()` で書き込み済み。alignment は
+        // `MmapMut` がページ境界（4 KiB）に揃え、`ShmHeader` の `align_of`
+        // は 8 byte なので満たす（cast_ptr_alignment lint はそれを静的に
+        // 検出できないので個別 allow）。lifetime は `&self` に紐付くので、
+        // 戻り値の参照中に mmap 領域が unmap されることはない。
+        #[allow(unsafe_code, clippy::cast_ptr_alignment)]
+        unsafe {
+            &*self.mmap.as_ptr().cast::<ShmHeader>()
+        }
+    }
+
+    /// 指定 slot index の `payload_len` / `occupied` を読み、payload バイト列を
+    /// `Vec<u8>` に複製して返す。`payload_len == 0` または `occupied == 0` の
+    /// ときは `None`（防衛的: producer 側 race で実質空のスロットを pop した）。
+    fn copy_slot_payload(&self, slot_index: usize) -> Option<Vec<u8>> {
+        let slot_offset = slot_offset_in_shm(self.slot_size, slot_index);
+        let header_bytes = SLOT_HEADER_SIZE as usize;
+        let slot_bytes_total = self.slot_size as usize;
+        let slot_bytes = &self.mmap[slot_offset..slot_offset + slot_bytes_total];
+
+        // slot offset 0:  occupied: u8
+        // slot offset 4:  payload_len: u32 (LE; ABI は host endian だが
+        //                  Bridge と driver は同一マシン同一 endian 前提)
+        let occupied = slot_bytes[0];
+        let payload_len =
+            u32::from_ne_bytes([slot_bytes[4], slot_bytes[5], slot_bytes[6], slot_bytes[7]])
+                as usize;
+
+        if occupied == 0 || payload_len == 0 {
+            return None;
+        }
+        let payload_cap = slot_bytes_total - header_bytes;
+        if payload_len > payload_cap {
+            // ABI 違反: producer が `slot_size - 8` を超えて書いた。本来
+            // emit_event 側で -2 を返して driver で防がれる経路だが、
+            // 防衛的に drop（None で skip）する。
+            return None;
+        }
+        let payload = slot_bytes[header_bytes..header_bytes + payload_len].to_vec();
+        Some(payload)
+    }
+
+    /// `ShmHeader` の `slot_size` / `version` / 両 index を初期値で書き込む。
+    fn init_header(&mut self) {
+        // ヘッダ部のバイト列を直書きする。`AtomicU64` は `from_ne_bytes` で
+        // load/store するレイアウトと同一なので、初期化として 0u64 を 8 byte
+        // 連続で書けばよい。slot_size / version は ne バイトで書く。
+        let header_bytes = std::mem::size_of::<ShmHeader>();
+        debug_assert!(self.mmap.len() >= header_bytes, "mmap < ShmHeader size");
+
+        // write_index = 0 (offset 0..8), read_index = 0 (offset 8..16)
+        self.mmap[0..16].fill(0);
+        // slot_size (offset 16..20)
+        self.mmap[16..20].copy_from_slice(&self.slot_size.to_ne_bytes());
+        // version (offset 20..24)
+        self.mmap[20..24].copy_from_slice(&SHM_LAYOUT_VERSION.to_ne_bytes());
+        // _pad (offset 24..56)
+        self.mmap[24..header_bytes].fill(0);
+
+        // 各 slot の `occupied` / `payload_len` を 0 で初期化する。これで
+        // 万が一 `read()` が write 前に走っても確実に空判定される。
+        for slot_index in 0..RING_CAPACITY {
+            let off = slot_offset_in_shm(self.slot_size, slot_index);
+            self.mmap[off..off + (SLOT_HEADER_SIZE as usize)].fill(0);
+        }
+
+        // 念のため kernel に書き戻しを促す（mmap region 内の書き込みは
+        // 同一プロセス内では即見えるが、別プロセス（driver）が attach する
+        // 前のここで一度 sync しておくと debug 時にレースが見える）。
+        let _ = self.mmap.flush();
+    }
+
+    #[cfg(test)]
+    /// テスト専用: producer 側のように 1 件 push する。in-process
+    /// での単体テスト用ヘルパー。
+    pub(crate) fn test_push(&mut self, payload: &[u8]) -> bool {
+        let header_bytes_view: ShmHeaderView = ShmHeaderView::from_slice(&self.mmap);
+        let write_index = header_bytes_view.write_index;
+        let read_index = header_bytes_view.read_index;
+        if write_index.wrapping_sub(read_index) >= RING_CAPACITY as u64 {
+            return false;
+        }
+        // テスト経路。剰余を取るため上位ビットの破棄は影響なし。
+        #[allow(clippy::cast_possible_truncation)]
+        let slot_index = (write_index as usize) % RING_CAPACITY;
+        let off = slot_offset_in_shm(self.slot_size, slot_index);
+        let header_bytes = SLOT_HEADER_SIZE as usize;
+        let cap = self.slot_size as usize - header_bytes;
+        if payload.len() > cap {
+            return false;
+        }
+
+        let payload_len_bytes =
+            (u32::try_from(payload.len()).expect("payload < u32::MAX")).to_ne_bytes();
+        self.mmap[off] = 1; // occupied
+        self.mmap[off + 1..off + 4].fill(0); // _pad
+        self.mmap[off + 4..off + 8].copy_from_slice(&payload_len_bytes);
+        self.mmap[off + header_bytes..off + header_bytes + payload.len()].copy_from_slice(payload);
+
+        // write_index を Release 相当で更新（ne バイト書き）。
+        let new_index = write_index.wrapping_add(1);
+        self.mmap[0..8].copy_from_slice(&new_index.to_ne_bytes());
+        true
+    }
+}
+
+#[cfg(test)]
+struct ShmHeaderView {
+    write_index: u64,
+    read_index: u64,
+}
+
+#[cfg(test)]
+impl ShmHeaderView {
+    fn from_slice(bytes: &[u8]) -> Self {
+        let mut w = [0u8; 8];
+        let mut r = [0u8; 8];
+        w.copy_from_slice(&bytes[0..8]);
+        r.copy_from_slice(&bytes[8..16]);
+        Self {
+            write_index: u64::from_ne_bytes(w),
+            read_index: u64::from_ne_bytes(r),
+        }
+    }
+}
+
+/// `memfd_create(2)` の薄いラッパー。close-on-exec を立てる。
+fn create_memfd() -> std::io::Result<OwnedFd> {
+    use nix::sys::memfd::{memfd_create, MFdFlags};
+    let name = CString::new("midori-ring").expect("static C string is non-NUL");
+    memfd_create(name.as_c_str(), MFdFlags::MFD_CLOEXEC).map_err(std::io::Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use midori_core::shm::{DEFAULT_SLOT_SIZE, HARD_SLOT_SIZE};
+
+    #[test]
+    fn it_should_create_default_sized_consumer_for_sentinel_request() {
+        let (consumer, fd) = RingConsumer::create(0).expect("default sentinel must succeed");
+        assert_eq!(consumer.slot_size(), DEFAULT_SLOT_SIZE);
+        // fd が valid な OwnedFd であることは Drop で close されることで担保される。
+        drop(fd);
+        drop(consumer);
+    }
+
+    #[test]
+    fn it_should_initialize_shm_header_to_layout_version_one() {
+        let (consumer, _fd) = RingConsumer::create(0).expect("default sentinel must succeed");
+        let header = consumer.header();
+        assert_eq!(header.slot_size, DEFAULT_SLOT_SIZE);
+        assert_eq!(header.version, SHM_LAYOUT_VERSION);
+        assert_eq!(header.write_index.load(Ordering::Relaxed), 0);
+        assert_eq!(header.read_index.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn it_should_reject_request_with_unaligned_slot_size() {
+        let err = RingConsumer::create(13).expect_err("alignment 違反");
+        assert!(matches!(err, CreateError::Handshake(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn it_should_reject_request_above_hard_limit() {
+        let err = RingConsumer::create(HARD_SLOT_SIZE + 4).expect_err("hard 超過");
+        assert!(matches!(err, CreateError::Handshake(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn it_should_round_trip_a_pushed_payload_through_read() {
+        let (mut consumer, _fd) = RingConsumer::create(0).expect("default sentinel must succeed");
+        // 空 ring の read は None
+        assert!(consumer.read().is_none());
+
+        let payload = b"hello-ring".to_vec();
+        assert!(
+            consumer.test_push(&payload),
+            "push must succeed on empty ring"
+        );
+        let popped = consumer.read().expect("popped");
+        assert_eq!(popped, payload);
+        // 連続 read で消える
+        assert!(consumer.read().is_none());
+    }
+
+    #[test]
+    fn it_should_round_trip_with_custom_slot_size() {
+        // 4 KiB を超える slot_size を要求できる。
+        let custom = 4_104_u32; // page-aligned 例
+        let (mut consumer, _fd) = RingConsumer::create(custom).expect("custom slot must succeed");
+        assert_eq!(consumer.slot_size(), custom);
+
+        let payload = vec![0xAB_u8; 2000];
+        assert!(consumer.test_push(&payload));
+        let popped = consumer.read().expect("popped");
+        assert_eq!(popped, payload);
+    }
+
+    #[test]
+    fn it_should_render_create_error_display_with_inner_handshake_reason() {
+        // alignment 違反は CreateError::Handshake 経由で内側 SlotSizeError の
+        // 説明文を含む。
+        let err = RingConsumer::create(13).expect_err("alignment");
+        let rendered = err.to_string();
+        assert!(rendered.contains("handshake"), "got: {rendered}");
+        assert!(
+            rendered.contains("4 byte 倍数"),
+            "Display は内側理由を含む: {rendered}"
+        );
+    }
+}

--- a/crates/midori-runtime/src/ring_ingest.rs
+++ b/crates/midori-runtime/src/ring_ingest.rs
@@ -12,8 +12,9 @@
 //! - `IngestHandle::shutdown()` で thread を join し、`RingConsumer` を
 //!   drop して mmap を unmap する
 //!
-//! 設計参照: `design/17-driver-comm/01-inline-ring.md`「メモリ順序」、
-//! 本 Issue 受領 brief「ring 空時の spin/sleep 戦略を min/max で定数化」。
+//! 設計参照: `design/17-driver-comm/01-inline-ring.md`「メモリ順序」。
+//! ring 空時の spin / sleep 間隔は本ファイル内の `RING_POLL_SPIN_INTERVAL`
+//! と `RING_POLL_SLEEP_INTERVAL_MAX` の二定数で min / max を制御する。
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -24,14 +25,17 @@ use crate::events_pipeline::{process_inline_payload, EventSink};
 use crate::events_schema::EventsSchema;
 use crate::ring_consumer::RingConsumer;
 
-/// ring が空のときに最初に試行する busy-wait 間隔。MIDI のリアルタイム
-/// 要件（1〜3 ms）を満たすため、初動を 100 µs に置く。100 µs は CPU を
-/// ほぼ食わずに pop が連続発火するケースで latency を最小化する妥協点。
+/// ring が空のときに試行する初期 poll 間隔。100 µs は active stream
+/// 中（直前の poll で event を取れていて `backoff_step` が 0 にリセット
+/// されている状態）に MIDI の sub-1 ms latency を保つための初動値。
+/// 連続して event が流れている限りこの間隔が維持される。
 pub const RING_POLL_SPIN_INTERVAL: Duration = Duration::from_micros(100);
 
-/// 連続して空読みを繰り返したあと、`RING_POLL_SPIN_INTERVAL` を
-/// この値まで指数的にエスカレートする。10 ms はアイドル driver の
-/// CPU 占有を抑える上限。
+/// 連続して空読みが続いたときに `RING_POLL_SPIN_INTERVAL` を倍化させる
+/// 上限。アイドル driver の CPU 占有を抑えるための cap で、ここには
+/// MIDI realtime 要件は適用しない。アイドル後に最初に到着した event は
+/// 最大 10 ms 遅延し得るが、その時点で `backoff_step` は 0 にリセット
+/// され、以降は再び `RING_POLL_SPIN_INTERVAL` に戻る。
 pub const RING_POLL_SLEEP_INTERVAL_MAX: Duration = Duration::from_millis(10);
 
 /// `RING_POLL_SPIN_INTERVAL` から `RING_POLL_SLEEP_INTERVAL_MAX` へ
@@ -107,7 +111,7 @@ impl IngestHandle {
     ///
     /// 必ず呼び出すこと。呼び忘れると thread leak。
     pub fn shutdown(mut self) {
-        self.shutdown_flag.store(true, Ordering::SeqCst);
+        self.shutdown_flag.store(true, Ordering::Release);
         if let Some(join) = self.join.take() {
             // join 失敗（thread が panic した）は logger に流すだけで
             // 上位伝播はしない。bridge shutdown を止めない方針。
@@ -127,7 +131,7 @@ impl Drop for IngestHandle {
         // shutdown() を呼び忘れた場合の保険。stop signal だけ送り、join
         // できないので thread leak になり得る。warn を 1 行出す。
         if self.join.is_some() {
-            self.shutdown_flag.store(true, Ordering::SeqCst);
+            self.shutdown_flag.store(true, Ordering::Release);
             crate::logging::warn(
                 "bridge",
                 None,
@@ -187,7 +191,7 @@ fn ingest_loop(
     stats: &IngestStats,
 ) {
     let mut backoff_step: u32 = 0;
-    while !stop.load(Ordering::Relaxed) {
+    while !stop.load(Ordering::Acquire) {
         if let Some(payload) = consumer.read() {
             process_inline_payload(driver_name, schema, &payload, sink);
             stats.record_dispatched();

--- a/crates/midori-runtime/src/ring_ingest.rs
+++ b/crates/midori-runtime/src/ring_ingest.rs
@@ -1,0 +1,347 @@
+//! Ring poll thread が [`RingConsumer`] から 1 slot ずつ pop して
+//! [`process_inline_payload`] へ流す配線層。
+//!
+//! 役割:
+//!
+//! - 専用 thread で [`RingConsumer::read`] を spin / sleep しながら呼ぶ
+//! - 取得した payload を [`process_inline_payload`] に渡し、Layer 2 stub
+//!   sink まで運ぶ
+//! - 落ちた件数（producer 側 ring 満杯による drop と、Bridge 側で
+//!   `LoggingSink` 等の sink まで届かなかった件数）を観測カウンタに
+//!   集約し、warn ログとして出す
+//! - `IngestHandle::shutdown()` で thread を join し、`RingConsumer` を
+//!   drop して mmap を unmap する
+//!
+//! 設計参照: `design/17-driver-comm/01-inline-ring.md`「メモリ順序」、
+//! 本 Issue 受領 brief「ring 空時の spin/sleep 戦略を min/max で定数化」。
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::events_pipeline::{process_inline_payload, EventSink};
+use crate::events_schema::EventsSchema;
+use crate::ring_consumer::RingConsumer;
+
+/// ring が空のときに最初に試行する busy-wait 間隔。MIDI のリアルタイム
+/// 要件（1〜3 ms）を満たすため、初動を 100 µs に置く。100 µs は CPU を
+/// ほぼ食わずに pop が連続発火するケースで latency を最小化する妥協点。
+pub const RING_POLL_SPIN_INTERVAL: Duration = Duration::from_micros(100);
+
+/// 連続して空読みを繰り返したあと、`RING_POLL_SPIN_INTERVAL` を
+/// この値まで指数的にエスカレートする。10 ms はアイドル driver の
+/// CPU 占有を抑える上限。
+pub const RING_POLL_SLEEP_INTERVAL_MAX: Duration = Duration::from_millis(10);
+
+/// `RING_POLL_SPIN_INTERVAL` から `RING_POLL_SLEEP_INTERVAL_MAX` へ
+/// 倍率 2 で escalate するときの最大段数（初期 100 µs → 200 µs → … →
+/// 6.4 ms → 10 ms にキャップ）。
+const POLL_BACKOFF_STEPS_MAX: u32 = 7;
+
+/// drop 件数を warn ログに出すしきい値。1 件出るたびにログを出すと
+/// 流量が爆発するため、まとまった単位で出す。
+const DROP_LOG_BATCH: u64 = 100;
+
+/// 観測カウンタ。`IngestHandle::shutdown` 後にも参照したいので Arc で
+/// 共有する。
+#[derive(Debug, Default)]
+pub struct IngestStats {
+    /// `process_inline_payload` 内部で error log + drop された件数。
+    /// 実 stat は `process_inline_payload` 自身の eprintln 経由なので、
+    /// ここで二重計上しない。consumer thread が観測する **「sink まで
+    /// 通らなかった」件数の総和** ではなく、「pop した件数の総和」を
+    /// 入れる（drop 件数は logger 側で集計）。
+    pub events_dispatched: AtomicU64,
+    /// producer 側 ring 満杯ケース（`emit_event` が `0` を返した状況）が
+    /// driver から control channel 経由で報告された件数。本値は driver
+    /// stub から差し込むためのスロットで、ring poll thread からは増加
+    /// させない（外部からのフィード可）。
+    pub producer_drops_reported: AtomicU64,
+}
+
+impl IngestStats {
+    fn record_dispatched(&self) {
+        self.events_dispatched.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// driver 側から「`emit_event` が 0 を返して 1 件 drop した」報告を
+    /// 受けたときに caller が呼ぶ。閾値を超えるたびに warn ログを 1 行出す。
+    pub fn record_producer_drop(&self, driver_name: &str) {
+        let prev = self.producer_drops_reported.fetch_add(1, Ordering::Relaxed);
+        let current = prev + 1;
+        if current.is_multiple_of(DROP_LOG_BATCH) {
+            crate::logging::warn(
+                "bridge",
+                Some(driver_name),
+                format_args!(
+                    "driver `{driver_name}` reported {current} cumulative ring-full drops"
+                ),
+            );
+        }
+    }
+}
+
+/// poll thread を起動した結果として返るハンドル。
+///
+/// `Drop` ではなく明示的な [`shutdown`](Self::shutdown) を要求する: ingest
+/// thread が止まる前に sink を drop すると racey に dispatch が走るため、
+/// caller は必ず `shutdown()` を呼んでから sink を解放する。
+pub struct IngestHandle {
+    /// thread に「終了して」を伝える共有フラグ。
+    shutdown_flag: Arc<AtomicBool>,
+    /// poll thread の `JoinHandle`。`shutdown()` で取り出し join する。
+    join: Option<JoinHandle<()>>,
+    /// 観測カウンタ。`stats()` で参照可能。
+    stats: Arc<IngestStats>,
+}
+
+impl IngestHandle {
+    /// 観測カウンタ参照。テストや外部観測から使う。
+    #[must_use]
+    pub fn stats(&self) -> &IngestStats {
+        &self.stats
+    }
+
+    /// poll thread に shutdown を伝え、join まで待つ。
+    ///
+    /// 必ず呼び出すこと。呼び忘れると thread leak。
+    pub fn shutdown(mut self) {
+        self.shutdown_flag.store(true, Ordering::SeqCst);
+        if let Some(join) = self.join.take() {
+            // join 失敗（thread が panic した）は logger に流すだけで
+            // 上位伝播はしない。bridge shutdown を止めない方針。
+            if join.join().is_err() {
+                crate::logging::error(
+                    "bridge",
+                    None,
+                    format_args!("ring ingest thread panicked during shutdown"),
+                );
+            }
+        }
+    }
+}
+
+impl Drop for IngestHandle {
+    fn drop(&mut self) {
+        // shutdown() を呼び忘れた場合の保険。stop signal だけ送り、join
+        // できないので thread leak になり得る。warn を 1 行出す。
+        if self.join.is_some() {
+            self.shutdown_flag.store(true, Ordering::SeqCst);
+            crate::logging::warn(
+                "bridge",
+                None,
+                format_args!("IngestHandle dropped without explicit shutdown(); join skipped"),
+            );
+        }
+    }
+}
+
+/// `consumer` をサブスレッドに送り、Layer 2 stub sink へ流す。
+///
+/// `schema` は driver の events.yaml ロード結果。`None` の場合、
+/// [`process_inline_payload`] は Error ログを出して全件 drop する。
+///
+/// `sink` の所有権は thread に移る。caller が dispatch 結果を観測したい
+/// 場合は `Arc<Mutex<RecordingSink>>` のような共有型を使うこと（テスト
+/// では現にそうしている）。
+pub fn spawn_ingest<S>(
+    driver_name: String,
+    consumer: RingConsumer,
+    schema: Option<EventsSchema>,
+    mut sink: S,
+) -> IngestHandle
+where
+    S: EventSink + Send + 'static,
+{
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    let stats = Arc::new(IngestStats::default());
+
+    let stop = Arc::clone(&shutdown_flag);
+    let stats_for_thread = Arc::clone(&stats);
+    let join = thread::spawn(move || {
+        ingest_loop(
+            &driver_name,
+            &consumer,
+            schema.as_ref(),
+            &mut sink,
+            &stop,
+            &stats_for_thread,
+        );
+    });
+
+    IngestHandle {
+        shutdown_flag,
+        join: Some(join),
+        stats,
+    }
+}
+
+/// thread 本体。`stop` が立つまで poll を続ける。
+fn ingest_loop(
+    driver_name: &str,
+    consumer: &RingConsumer,
+    schema: Option<&EventsSchema>,
+    sink: &mut dyn EventSink,
+    stop: &AtomicBool,
+    stats: &IngestStats,
+) {
+    let mut backoff_step: u32 = 0;
+    while !stop.load(Ordering::Relaxed) {
+        if let Some(payload) = consumer.read() {
+            process_inline_payload(driver_name, schema, &payload, sink);
+            stats.record_dispatched();
+            backoff_step = 0;
+        } else {
+            let nap = backoff_interval(backoff_step);
+            thread::sleep(nap);
+            backoff_step = backoff_step.saturating_add(1).min(POLL_BACKOFF_STEPS_MAX);
+        }
+    }
+}
+
+/// `step` 段目の sleep 間隔を返す。`step = 0` で `RING_POLL_SPIN_INTERVAL`
+/// (= 100 µs)、step ごとに倍化し、`RING_POLL_SLEEP_INTERVAL_MAX` で頭打ち。
+fn backoff_interval(step: u32) -> Duration {
+    let base = RING_POLL_SPIN_INTERVAL;
+    let cap = RING_POLL_SLEEP_INTERVAL_MAX;
+    let scaled = base.saturating_mul(1u32 << step.min(31));
+    if scaled > cap {
+        cap
+    } else {
+        scaled
+    }
+}
+
+/// テスト専用: in-process で push → ingest が dispatch するまで待つ簡易
+/// 待機。プロダクション経路では使わない。
+#[cfg(test)]
+pub(crate) fn wait_for_dispatch(stats: &IngestStats, expected: u64, timeout: Duration) -> bool {
+    use std::time::Instant;
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if stats.events_dispatched.load(Ordering::Relaxed) >= expected {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+    false
+}
+
+/// テスト都合: `RecordingSink` を `Arc<Mutex<_>>` 越しに dispatch するための
+/// アダプタ。本ファイルのテストで使う。
+#[cfg(test)]
+pub(crate) struct SharedSink<S: EventSink + Send> {
+    inner: Arc<std::sync::Mutex<S>>,
+}
+
+#[cfg(test)]
+impl<S: EventSink + Send> SharedSink<S> {
+    pub(crate) fn new(inner: Arc<std::sync::Mutex<S>>) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(test)]
+impl<S: EventSink + Send> EventSink for SharedSink<S> {
+    fn dispatch(&mut self, event: crate::events_pipeline::ValidatedEvent) {
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.dispatch(event);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::events_pipeline::{EventSink, ValidatedEvent};
+    use rmpv::Value;
+
+    fn midi_schema() -> EventsSchema {
+        let yaml = r"
+schema_version: 1
+events:
+  noteOn:
+    fields:
+      channel:  { type: uint8, range: [1, 16] }
+      note:     { type: uint8, range: [0, 127] }
+      velocity: { type: uint8, range: [0, 127] }
+    binding_filter: [type, channel]
+    note_field: note
+";
+        serde_yaml_ng::from_str(yaml).expect("fixture parses")
+    }
+
+    fn encode_note_on() -> Vec<u8> {
+        let value = Value::Map(vec![
+            (Value::String("type".into()), Value::String("noteOn".into())),
+            (Value::String("channel".into()), Value::from(1u8)),
+            (Value::String("note".into()), Value::from(60u8)),
+            (Value::String("velocity".into()), Value::from(100u8)),
+        ]);
+        let mut buf = Vec::new();
+        rmpv::encode::write_value(&mut buf, &value).expect("encode");
+        buf
+    }
+
+    #[derive(Default)]
+    struct RecordingSink {
+        events: Vec<ValidatedEvent>,
+    }
+
+    impl EventSink for RecordingSink {
+        fn dispatch(&mut self, event: ValidatedEvent) {
+            self.events.push(event);
+        }
+    }
+
+    #[test]
+    fn it_should_compute_backoff_interval_within_design_min_and_max() {
+        // step 0 = 100 µs, それ以降倍化、最大 10 ms cap
+        assert_eq!(backoff_interval(0), RING_POLL_SPIN_INTERVAL);
+        assert!(backoff_interval(1) > RING_POLL_SPIN_INTERVAL);
+        assert!(backoff_interval(POLL_BACKOFF_STEPS_MAX) <= RING_POLL_SLEEP_INTERVAL_MAX);
+        // 上限飽和の確認
+        assert_eq!(backoff_interval(31), RING_POLL_SLEEP_INTERVAL_MAX);
+    }
+
+    #[test]
+    fn it_should_pump_a_pushed_payload_into_the_layer2_sink() {
+        let schema = midi_schema();
+        let (mut consumer, _fd) = RingConsumer::create(0).expect("default sentinel must succeed");
+        consumer.test_push(&encode_note_on());
+
+        let recording: Arc<Mutex<RecordingSink>> = Arc::new(Mutex::new(RecordingSink::default()));
+        let sink_for_thread = SharedSink::new(Arc::clone(&recording));
+        let handle = spawn_ingest("midi".into(), consumer, Some(schema), sink_for_thread);
+
+        assert!(
+            wait_for_dispatch(handle.stats(), 1, Duration::from_secs(2)),
+            "pushed event must reach the sink within 2s"
+        );
+        handle.shutdown();
+
+        let recorded = recording.lock().expect("recording lock");
+        assert_eq!(recorded.events.len(), 1);
+        assert_eq!(recorded.events[0].event_type, "noteOn");
+        assert_eq!(recorded.events[0].driver_name, "midi");
+    }
+
+    #[test]
+    fn it_should_record_producer_drops_and_log_at_batch_threshold() {
+        // record_producer_drop は driver stub から呼ぶ想定。100 件刻みで
+        // warn を出すが、本テストはカウンタ加算のみを観測する（logger
+        // 出力の subscribe は init 順序が複雑なので unit test scope 外）。
+        let stats = IngestStats::default();
+        for _ in 0..250 {
+            stats.record_producer_drop("midi-stub");
+        }
+        assert_eq!(
+            stats.producer_drops_reported.load(Ordering::Relaxed),
+            250,
+            "全 record が加算される"
+        );
+    }
+}


### PR DESCRIPTION
## 概要

driver からの inline tier event を Layer 2 stub sink まで運ぶ ingest 配線を実装する。これまで `#[allow(dead_code)]` で休眠していた `process_inline_payload` / `try_process` / `LoggingSink` に実 caller が付き、ring poll thread から呼ばれるようになる。

Closes MEW-59

## 主な変更

- **`ring_consumer`**: `RingConsumer::create(slot_size) -> (Self, OwnedFd)` を実装。`memfd_create(2)` + `ftruncate(2)` + `mmap(2)` で per-driver shm を確保し、`ShmHeader.slot_size` / `version = 1` / 両 index を初期化。`read()` で 1 slot ずつ pop（Acquire/Release で driver と同期）。
- **`fd_socket`**: `SCM_RIGHTS` を載せた `sendmsg(2)` / `recvmsg(2)` ヘルパー（`send_fd` / `recv_fd`）。
- **`ring_ingest`**: 専用 thread で `RingConsumer` を poll し `process_inline_payload` に流す。spin/sleep を 100 µs → 10 ms で指数的にエスカレートする戦略 (`RING_POLL_SPIN_INTERVAL` / `RING_POLL_SLEEP_INTERVAL_MAX`) を定数化。`IngestHandle::shutdown()` で thread join → `RingConsumer` drop で `munmap`。
- **`driver_proc/request_ring`**: handshake JSON Lines に `request_ring` / `ring_ready` / `ring_rejected` の wire 形式を追加（serde struct + `try_parse_request_ring` parser）。
- **`events_pipeline/mod.rs`**: `process_inline_payload` / `try_process` / `LoggingSink` / sub-module の `#[allow(dead_code)]` を撤去（実 caller 経由で warn が消える）。
- **lib 公開化**: `events_pipeline` / `events_schema` / `ring_handshake` を bin-private から `pub mod` に昇格（`ring_consumer` / `ring_ingest` の依存先のため）。

## 設計判断: workspace lint policy の局所的 override

mmap / `SCM_RIGHTS` は性質上 `unsafe` なシステムコール（kernel が任意のタイミングで mapping 内容を書き換え得るため、Rust の aliasing model の枠外で動く）。workspace の `unsafe_code = \"forbid\"` を維持したまま安全な crate のみを使う道（`MmapOptions::map_anon` 等）では shm fd を別プロセスへ渡せず、本 Issue の要件を満たせない。

そこで `crates/midori-runtime/Cargo.toml` だけ `lints.workspace = true` を外し、workspace lint table を inline で再宣言したうえで `unsafe_code` のみ `forbid` → `deny` に下げた。`forbid` だと `#[allow(unsafe_code)]` が効かず、cargo は `lints.workspace = true` 継承中の per-crate override をエラーにするため、この形になっている。

該当 unsafe ブロックは:

- `ring_consumer.rs::header()` — `mmap.as_ptr()` から `*const ShmHeader` への cast
- `ring_consumer.rs::create()` — `MmapOptions::new().map_mut(&fd)` の呼び出し
- `fd_socket.rs::recv_fd()` — `OwnedFd::from_raw_fd` で `recvmsg` から受けた raw fd を所有

各箇所に `# Safety` 注記を付けている。`memmap2` / `nix` の薄い safe wrapper を介し、unsafe 露出は最小化した。

**判断要点**: workspace lint を一部 crate で緩めることの是非は user の判断領域。本 PR の方針が合意できない場合は、`unsafe` を持つ層を `midori-core` 等に閉じ込めて単独で lint override する代替がある。

## 単体テスト 3 種（AC 対応）

| AC | テスト |
|---|---|
| in-process push → `LoggingSink` 到達 | `ring_ingest::tests::it_should_pump_a_pushed_payload_into_the_layer2_sink` |
| alignment / HARD 超過 で `CreateError::Handshake(_)` | `ring_consumer::tests::it_should_reject_request_with_unaligned_slot_size` / `it_should_reject_request_above_hard_limit` |
| ring 満杯ケースを driver 側 stub で simulate、drop 件数を warn | `ring_ingest::tests::it_should_record_producer_drops_and_log_at_batch_threshold`（`IngestStats::record_producer_drop` で 100 件閾値ごとに warn） |

加えて handshake wire 形式・SCM_RIGHTS round-trip・`spin/sleep` cap などをカバーする補助テストを追加（runtime crate の lib test は 113 件、全 workspace で 224 件 pass）。

## Out of Scope（本 Issue で扱わないもの）

ぼかさず明示する: AC のうち以下は **driver subprocess 経由の E2E 部分**で、driver SDK 側の `RingProducer::from_fd` 実装（本 Issue の Out of Scope に明記）が前提のため、別 Issue で完成させる必要がある:

- driver spawn flow への `request_ring` 受信 / 応答送信の組込み
- 実 driver subprocess に対する SCM_RIGHTS 経由 fd 配送
- HARD 超過 `request_ring` 受領時の SIGTERM 送出 + bridge error log

本 PR では「parse helper / fd 送受信 helper / ingest スレッド起動 API / wire 形式 serde 構造体」を提供し、in-process の単体テストで全経路を検証している。E2E は driver SDK 側 `RingProducer::from_fd` と一緒に実装する次 Issue で配線する。

## DoD

- [x] AC のうち in-process 検証可能な範囲を全て満たす
- [x] 単体テスト 3 種を実装（上表参照）
- [x] PR 本文に Issue 番号 (`Closes MEW-59`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` ゼロ
- [x] `cargo fmt --check` クリーン
- [x] `cargo test --workspace` 全件 pass
- [x] `process_inline_payload` の `#[allow(dead_code)]` 撤去
- [ ] CodeRabbit / `/code-review:code-review` レビュー → main process 側で実行待ち

## ローカル確認

```text
cargo clippy --workspace --all-targets -- -D warnings   # 警告ゼロ
cargo fmt --check                                       # 差分なし
cargo test --workspace                                  # 全 pass
```

CodeRabbit CLI は agent サンドボックスから起動できなかったため、main process 側でローカル実行をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * UNIXソケット経由でのファイル記述子送受信を追加
  * リングベースのイベント取り込み（バックグロウンド分配）と消費者APIを実装
  * JSONL形式のリクエストリング解析・検証を追加

* **改善**
  * UNIX向け依存関係とビルド／リンター設定を拡張・明確化
  * イベント処理パイプラインのモジュール公開範囲を整理し文書化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->