### PR TITLE
refactor(ipc-shm): align inline-tier public surface across 3 OS

### DIFF
--- a/crates/midori-ipc-shm/src/lib.rs
+++ b/crates/midori-ipc-shm/src/lib.rs
@@ -39,20 +39,23 @@
 //!   `CreateFileMappingW` ベースの shm 確保と Named Pipe + `DuplicateHandle`
 //!   ベースの HANDLE handoff を実装する。
 //!
-//! 公開 re-export は OS 別の cfg ゲートで露出する。Linux 上では
+//! 公開 re-export は OS 別の cfg ゲートで露出する。Linux / macOS 上では
 //! `RingConsumer` / `CreateError` (`ring_consumer` から) と `send_fd` /
 //! `recv_fd` (`fd_socket` から) を、Windows 上では `RingConsumer` /
 //! `CreateError` (`ring_consumer_windows` から) と `PipeName` /
 //! `create_pipe_server` / `accept_and_send` / `connect_and_recv` /
 //! `HandlePipeError` (`handle_pipe_windows` から) を export する。
 //!
-//! macOS では内部 module のビルド / テストはされるが、Bridge runtime 層の
-//! cfg ゲート整理が完了するまで公開 API としての解禁は保留する（その整理が
-//! 完了したら Linux 経路の `pub use` の cfg を `any(linux, macos)` に広げて
-//! symbol を解禁する）。callers that need to compile across OSes must wrap
-//! their use of OS-specific symbols in the matching
-//! `#[cfg(target_os = "...")]` themselves — this crate does not paper over
-//! the platform gap with stubs.
+//! Linux と macOS は同名 type (`RingConsumer` / `CreateError` / `send_fd` /
+//! `recv_fd`) を共有するため、`pub use` 文を 1 本にまとめて
+//! `cfg(any(target_os = "linux", target_os = "macos"))` で gating する。
+//! Windows backend は型名は同じだが内部 namespace が独立しているので
+//! `pub use` 文も別建て (`cfg(target_os = "windows")`) で持つ。
+//!
+//! callers that need to compile across OSes must wrap their use of
+//! OS-specific symbols in the matching `#[cfg(target_os = "...")]`
+//! themselves — this crate does not paper over the platform gap with
+//! stubs.
 //!
 //! # Public surface
 //!
@@ -62,11 +65,11 @@
 //!   [`resolve_requested_slot_size`], [`page_aligned_shm_size`],
 //!   [`PAGE_SIZE`]
 //!
-//! From `ring_consumer` (Linux only, until macOS public surface is unlocked):
+//! From `ring_consumer` (Linux / macOS):
 //!
 //! - [`RingConsumer`], [`CreateError`]
 //!
-//! From `fd_socket` (Linux only, until macOS public surface is unlocked):
+//! From `fd_socket` (Linux / macOS):
 //!
 //! - [`send_fd`], [`recv_fd`]
 //!
@@ -99,13 +102,13 @@ pub use ring_handshake::{
     REQUEST_DEFAULT_SLOT_SIZE,
 };
 
-// 公開 re-export は当面 Linux のみ。macOS でも内部 module はビルド /
-// テストされているが、Bridge runtime 層の cfg ゲート整理が完了するまで
-// 外部公開は保留する（その整理が完了したら下記 cfg を `any(linux, macos)`
-// に広げて symbol を解禁する）。
-#[cfg(target_os = "linux")]
+// 公開 re-export は Linux と macOS で同一 (`fd_socket` / `ring_consumer`
+// は両 OS で同名 type を露出する単一実装)。Windows backend は別 module
+// (`handle_pipe_windows` / `ring_consumer_windows`) に分かれているので
+// `pub use` 文を別建てで持つ。
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub use fd_socket::{recv_fd, send_fd};
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub use ring_consumer::{CreateError, RingConsumer};
 
 #[cfg(target_os = "windows")]

--- a/crates/midori-ipc-shm/src/ring_consumer/mod.rs
+++ b/crates/midori-ipc-shm/src/ring_consumer/mod.rs
@@ -29,7 +29,12 @@
 //!   シグネチャを公開し、本 module の [`RingConsumer::create`] が
 //!   cfg dispatch する。
 //!
-//! Windows backend (`CreateFileMapping` ベース) は未実装（将来対応予定）。
+//! Windows backend (`CreateFileMappingW` + Named Pipe + `DuplicateHandle`
+//! ベース) は同 crate の `ring_consumer_windows` module 側で別実装として
+//! 提供される。fd と HANDLE で OS 抽象が異なる (前者は `OwnedFd` /
+//! `SCM_RIGHTS`、後者は `OwnedHandle` / Named Pipe) ため、本 module の
+//! Linux / macOS 共通 `RingConsumer` とは型シグネチャを共有せず、cfg で
+//! 排他に export する形を採る (詳細は crate root doc 参照)。
 //!
 //! # Safety
 //!

--- a/crates/midori-runtime/src/lib.rs
+++ b/crates/midori-runtime/src/lib.rs
@@ -14,7 +14,10 @@
 //!   string used for forwarded lines.
 //! - [`ring_ingest`]: glue that pumps the ring consumer into
 //!   [`events_pipeline::process_inline_payload`] on a dedicated thread.
-//!   Linux-only because it owns a [`midori_ipc_shm::RingConsumer`].
+//!   Linux / macOS only because it owns a [`midori_ipc_shm::RingConsumer`]
+//!   built from the `OwnedFd` / `SCM_RIGHTS` backend of `midori-ipc-shm`.
+//!   Windows は同 crate の `OwnedHandle` / Named Pipe backend に対応する
+//!   ingest glue が未整備のため、本 cfg からは外している。
 //!
 //! Inline-tier IPC primitives themselves (`RingConsumer`, `send_fd` /
 //! `recv_fd`, ring handshake validation) live in the `midori-ipc-shm`
@@ -22,20 +25,20 @@
 //! `mmap` and `SCM_RIGHTS` reception stay confined to that crate, and this
 //! crate can keep `unsafe_code = "forbid"` via `lints.workspace = true`.
 //!
-//! 現状 inline-tier IPC の **公開 API** は Linux 専用（`memfd_create(2)`
-//! 依存）。macOS 向け実装 (`shm_open(2)` + `shm_unlink(2)` ベース) は
-//! `midori-ipc-shm` 内部に存在しビルド / テストされているが、Bridge
-//! runtime 層の cfg ゲート整理が完了するまで公開 surface としての解禁は
-//! 保留している。Windows backend (`CreateFileMapping` ベース) は未実装。
-//! それまでは [`ring_ingest`] および `midori_ipc_shm` の公開 API を
-//! `cfg(target_os = "linux")` で囲って他 OS では参照しない運用。
+//! `midori-ipc-shm` 側は inline-tier の OS 別実装をすべて公開している
+//! （Linux: `memfd_create(2)` + `SCM_RIGHTS` / macOS: `shm_open(2)` +
+//! `shm_unlink(2)` + `SCM_RIGHTS` / Windows: `CreateFileMappingW` +
+//! Named Pipe + `DuplicateHandle`）。本 crate の [`ring_ingest`] は
+//! Linux / macOS の同名 type (`midori_ipc_shm::RingConsumer`) を 1 本の
+//! 配線でカバーし、Windows backend (`OwnedHandle` + Named Pipe handoff)
+//! を取り込む差分は別途必要なため、本 lib では Windows を cfg から外す。
 //!
 //! The CLI dispatch layer remains binary-private until there is a concrete
 //! need to expose it.
 
 pub mod driver_proc;
 pub mod logging;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub mod ring_ingest;
 
 // `events_pipeline` was previously binary-private. It is now a dependency

--- a/design/17-driver-comm/01-inline-ring.md
+++ b/design/17-driver-comm/01-inline-ring.md
@@ -1,7 +1,7 @@
 # Inline Tier — Variable-Sized Ring Slot
 
 > ステータス：設計フェーズ
-> 最終更新：2026-04-28
+> 最終更新：2026-05-03
 
 本書は driver↔bridge 配送の **inline tier**（速度保証あり、shm SPSC ring 経由）の詳細仕様。tier モデル全体・他 tier との関係は [00-overview.md](./00-overview.md) を参照。
 
@@ -100,6 +100,24 @@ fn slot_ptr(base: *mut u8, header: &ShmHeader, idx: u64) -> *mut u8 {
 
 ---
 
+## OS 別実装方針
+
+inline tier の実体は「**Bridge プロセスが page-backed shared memory セグメントを 1 個確保し、そこへの参照 (handle) を driver subprocess へ受け渡す**」ことに尽きる。この抽象は OS を問わず同一だが、shm 確保の syscall と handle handoff の搬送機構は OS が直接提供するものを使う。3 OS で対応する API を以下に並列に示す:
+
+| OS | shm セグメント確保 | Bridge → driver の handle 受け渡し | handle 抽象 |
+|---|---|---|---|
+| Linux | `memfd_create(2)` で anonymous shm を作成し `ftruncate(2)` でサイズ確定 | Unix domain socket 上の `sendmsg(2)` + `SCM_RIGHTS` 制御メッセージ | `OwnedFd` |
+| macOS | `shm_open(2) (O_CREAT \| O_EXCL)` で名前付き shm を作成 → `ftruncate(2)` でサイズ確定 → `shm_unlink(2)` で名前空間からエントリ除去 (open + unlink イディオム、fd と mmap は有効なまま継続) | Unix domain socket 上の `sendmsg(2)` + `SCM_RIGHTS` 制御メッセージ | `OwnedFd` |
+| Windows | `CreateFileMappingW(INVALID_HANDLE_VALUE, ...)` で page-file backed の名前なし shared memory section を作成 | Named Pipe (`\\.\pipe\midori-shm-<pid>-<random>`) を経由し、`OpenProcess(PROCESS_DUP_HANDLE)` + `DuplicateHandle(... DUPLICATE_SAME_ACCESS)` で driver アドレス空間に複製した HANDLE 値 (u64) を pipe に書き込む | `OwnedHandle` |
+
+handshake プロトコル (本書の `request_ring` / `ring_ready` / `ring_rejected` JSON Lines メッセージ) は OS を問わず共通で、**異なるのは fd / HANDLE を運ぶ control channel の機構のみ**。Bridge と driver はそれぞれの OS で対応する handle 抽象 (`OwnedFd` / `OwnedHandle`) を受け取り、同じ `MapViewOfFile` / `mmap` 相当の API で同一 shm セグメントを自プロセスのアドレス空間にマップする。
+
+mmap 後の `ShmHeader` レイアウト・ring slot レイアウト・メモリ順序は **すべての OS で完全同一**（後述「ShmHeader レイアウト」「メモリ順序」節）。OS 差異は本節で示す確保 / handoff API のみに局所化する設計とする。
+
+実装責務の所在: Bridge 側の OS 別 backend は `crates/midori-ipc-shm` crate に集約され、`memfd` / `shm_open` / `CreateFileMappingW` を呼ぶ `unsafe` ブロックはすべて同 crate の `ring_consumer` / `ring_consumer_windows` module 内に閉じ込める。上位の `midori-runtime` ring poll thread は OS を意識せず `RingConsumer::read()` を呼ぶ。
+
+---
+
 ## Handshake プロトコル
 
 ### limit 規約
@@ -148,10 +166,12 @@ driver 起動時、Bridge 側で shm を確保するまでの流れ:
    - **上限チェック**: `slot_size > HARD_SLOT_SIZE` なら reject（events.yaml 見直し or `tier: streamed` 化を促す）
    - **shm 全体サイズの確定**: `shm_total = sizeof(ShmHeader) + RING_CAPACITY × slot_size`。これを **ページサイズ（4 KiB）で切り上げ** て allocate。具体式は `shm_mmap_size = (shm_total + PAGE_SIZE - 1) & !(PAGE_SIZE - 1)`（`PAGE_SIZE = 4096`。mmap 単位がページなので shm 全体のみページ整列でよく、slot 単位の page-align は不要）
    - `ShmHeader.slot_size` に確定値を書き込み、`ShmHeader.version = 1`（初期版）で初期化
-5. **Bridge → driver** に shm fd を返す
-6. **driver は fd を mmap し、`ShmHeader.slot_size` を読み込んで stride 計算を確立**
+5. **Bridge → driver** に shm への参照 (handle) を返す。具体機構は OS 別:
+   - Linux / macOS: 事前に確立した Unix domain socket で `sendmsg(2)` + `SCM_RIGHTS` を使い `OwnedFd` を 1 個だけ送る
+   - Windows: 事前に確立した Named Pipe で `DuplicateHandle(... DUPLICATE_SAME_ACCESS)` 済みの HANDLE 値 (u64) を sentinel 1 byte と一緒に送る
+6. **driver は受け取った handle を mmap (`mmap(2)` / `MapViewOfFile`) し、`ShmHeader.slot_size` を読み込んで stride 計算を確立**
 
-control channel は `design/15-sdk-bindings-api.md` の Phase 1 / L1-2「Bridge との fd 受け渡しプロトコル」と統合する。具体的なソケット手順は実装 Issue で詰める。
+control channel は `design/15-sdk-bindings-api.md` の Phase 1 / L1-2「Bridge との fd 受け渡しプロトコル」と統合する (Linux / macOS は Unix domain socket、Windows は Named Pipe を使う、上述「OS 別実装方針」節参照)。`request_ring` / `ring_ready` / `ring_rejected` の JSON 本体は OS を問わず driver stdout 経由で運ぶ (詳細は実装 Issue)。
 
 ### reject 時の挙動
 

--- a/design/17-driver-comm/01-inline-ring.md
+++ b/design/17-driver-comm/01-inline-ring.md
@@ -155,7 +155,7 @@ driver 起動時、Bridge 側で shm を確保するまでの流れ:
    - **必要 `slot_size = ((max_payload_size + 8) + 3) & !3`**（ヘッダ 8 byte 加算後、`payload_len: u32` の natural alignment 維持のため 4 byte 倍数へ切り上げ。`!3` は bitwise NOT で `0xFFFF...FFFC` を生成し下位 2 bit をマスクするイディオム。算術等価式: `((max_payload_size + 8 + 3) / 4) * 4`）
 
    この algorithm は本書を **唯一の規範** とする（[00-overview.md](./00-overview.md) は summary で参照するのみ）。
-3. **driver → Bridge** へ `request_ring(slot_size)` を送信（control channel 経由、handshake 必須メッセージ）
+3. **driver → Bridge** へ `request_ring(slot_size)` を送信（JSON Lines control channel = driver stdin/stdout 経由、handshake 必須メッセージ）
    - `slot_size <= DEFAULT_SLOT_SIZE` の場合: `slot_size = 0`（sentinel）を送信 → Bridge は DEFAULT で確保
    - 超える場合: 計算した `slot_size` を送信 → Bridge は受信値を採用（ただし上限チェックあり、step 4 参照）
 4. **Bridge 側で受領**:
@@ -171,7 +171,10 @@ driver 起動時、Bridge 側で shm を確保するまでの流れ:
    - Windows: 事前に確立した Named Pipe で `DuplicateHandle(... DUPLICATE_SAME_ACCESS)` 済みの HANDLE 値 (u64 host endian) を 1 byte の sentinel (`0x01`、空メッセージを許容しない pipe API のための最小 payload) と一緒に送る (合計 9 byte)
 6. **driver は受け取った handle を mmap (`mmap(2)` / `MapViewOfFile`) し、`ShmHeader.slot_size` を読み込んで stride 計算を確立**
 
-control channel は `design/15-sdk-bindings-api.md` の Phase 1 / L1-2 の handshake protocol (Bridge ↔ driver の handle / fd 受け渡し) と統合する。Linux / macOS は Unix domain socket で fd を、Windows は Named Pipe で HANDLE を送る (上述「OS 別実装方針」節参照)。`request_ring` / `ring_ready` / `ring_rejected` の JSON 本体は OS を問わず driver stdout 経由で運ぶ (詳細は実装 Issue)。
+handshake は **2 系統のチャネル** で構成される。両者の役割を混同しないよう明示する:
+
+- **JSON Lines control channel (driver stdin/stdout)**: `request_ring` / `ring_ready` / `ring_rejected` の JSON メッセージ本体を OS を問わず運ぶ。wire format は `design/15-sdk-bindings-api.md` の Phase 1 / L1-2 の handshake protocol と統合する
+- **handle handoff channel (OS 別)**: shm への参照 (fd / HANDLE) を運ぶための OS native な機構。Linux / macOS は Unix domain socket 上の `SCM_RIGHTS`、Windows は Named Pipe 上の `DuplicateHandle` 値転送（上述「OS 別実装方針」節参照）
 
 ### reject 時の挙動
 
@@ -370,8 +373,8 @@ fn validate_compat(header: &ShmHeader) -> Result<(), CompatError> {
 
 本書で **触らない** もの:
 
-- handshake の具体的なソケット / control channel 実装
-- mmap 確保コード・アンマップ手順
+- driver stdin/stdout 上の JSON Lines wire format 詳細（メッセージ encoding / framing 規約は `design/15-sdk-bindings-api.md` 参照。本書は protocol step が JSON Lines control channel に乗ることだけを規定する）
+- mmap 確保 / handle handoff の具体的なコード（call site レベルの Rust 実装は `crates/midori-ipc-shm` を参照。本書は API 抽象と OS 別 syscall 選択までを規定する）
 - L1 FFI の C ABI 詳細
 - driver lifetime 中の slot_size 変更
 - 圧縮、multi-producer

--- a/design/17-driver-comm/01-inline-ring.md
+++ b/design/17-driver-comm/01-inline-ring.md
@@ -168,10 +168,10 @@ driver 起動時、Bridge 側で shm を確保するまでの流れ:
    - `ShmHeader.slot_size` に確定値を書き込み、`ShmHeader.version = 1`（初期版）で初期化
 5. **Bridge → driver** に shm への参照 (handle) を返す。具体機構は OS 別:
    - Linux / macOS: 事前に確立した Unix domain socket で `sendmsg(2)` + `SCM_RIGHTS` を使い `OwnedFd` を 1 個だけ送る
-   - Windows: 事前に確立した Named Pipe で `DuplicateHandle(... DUPLICATE_SAME_ACCESS)` 済みの HANDLE 値 (u64) を sentinel 1 byte と一緒に送る
+   - Windows: 事前に確立した Named Pipe で `DuplicateHandle(... DUPLICATE_SAME_ACCESS)` 済みの HANDLE 値 (u64 host endian) を 1 byte の sentinel (`0x01`、空メッセージを許容しない pipe API のための最小 payload) と一緒に送る (合計 9 byte)
 6. **driver は受け取った handle を mmap (`mmap(2)` / `MapViewOfFile`) し、`ShmHeader.slot_size` を読み込んで stride 計算を確立**
 
-control channel は `design/15-sdk-bindings-api.md` の Phase 1 / L1-2「Bridge との fd 受け渡しプロトコル」と統合する (Linux / macOS は Unix domain socket、Windows は Named Pipe を使う、上述「OS 別実装方針」節参照)。`request_ring` / `ring_ready` / `ring_rejected` の JSON 本体は OS を問わず driver stdout 経由で運ぶ (詳細は実装 Issue)。
+control channel は `design/15-sdk-bindings-api.md` の Phase 1 / L1-2 の handshake protocol (Bridge ↔ driver の handle / fd 受け渡し) と統合する。Linux / macOS は Unix domain socket で fd を、Windows は Named Pipe で HANDLE を送る (上述「OS 別実装方針」節参照)。`request_ring` / `ring_ready` / `ring_rejected` の JSON 本体は OS を問わず driver stdout 経由で運ぶ (詳細は実装 Issue)。
 
 ### reject 時の挙動
 


### PR DESCRIPTION
## サマリ

並列 subtask MEW-71 (macOS backend) / MEW-72 (Windows backend) の merge を受けて、`midori-ipc-shm` の公開 re-export と `midori-runtime::ring_ingest` 配線層の `cfg(target_os = \"linux\")` ゲートを撤去し、3 OS で inline tier IPC を同一抽象として運用できる状態に揃える。design doc も実装と整合させる。

### コード変更

- `crates/midori-ipc-shm/src/lib.rs`: `RingConsumer` / `CreateError` / `send_fd` / `recv_fd` の `pub use` を `cfg(target_os = \"linux\")` → `cfg(any(target_os = \"linux\", target_os = \"macos\"))` に拡張。両 OS は同名 type シグネチャを共有するため 1 本の export 文で覆う。Windows backend は型抽象 (`OwnedHandle` + Named Pipe) が異なるため別建ての `pub use` を維持。
- `crates/midori-runtime/src/lib.rs`: `pub mod ring_ingest` を `cfg(any(linux, macos))` に拡張。これで CI macos-latest job でも ring poll thread の単体テストが走る。Windows backend (`OwnedHandle` 系) を取り込む ingest glue は別途必要なため Windows は cfg から外したまま。
- `crates/midori-ipc-shm/src/ring_consumer/mod.rs`: doc コメントが「Windows backend は未実装（将来対応予定）」と書いていたが、実装は `ring_consumer_windows` 別 module として既に存在。実装と矛盾していたため scope 内で書き直し（write-self-contained-comments / Integrity-driven development の方針に沿う scope 内整合化）。

### Doc 変更

- `design/17-driver-comm/01-inline-ring.md`:
  - 新規セクション「OS 別実装方針」を追加。Linux (`memfd_create` + `SCM_RIGHTS`) / macOS (`shm_open` + `shm_unlink` + `SCM_RIGHTS`) / Windows (`CreateFileMappingW` + Named Pipe + `DuplicateHandle`) を「shm 確保 + handle handoff」という同一抽象の OS 並列実装として表で並列提示する（Linux 中心比較ではなく中立記述）。
  - Handshake プロトコル節 step 5「Bridge → driver に shm fd を返す」を「shm への参照 (handle) を返す」に書き直し、Linux / macOS / Windows それぞれの control channel 機構を OS 別 bullet で記述。
  - 末尾段落の control channel 言及も Linux/macOS = Unix domain socket、Windows = Named Pipe である旨を補足。

## ローカル検証

- `cargo build --workspace`: success
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: all pass (Linux 上)
- `cargo fmt --all --check`: clean
- `cargo deny check`: advisories ok, bans ok, licenses ok, sources ok
- `coderabbit review --agent -t committed --base main`: findings 0

## find-contradiction 結果

- `design/17-driver-comm/00-overview.md`: OS 名や fd / HANDLE への直接言及がなく、`design/17-driver-comm/01-inline-ring.md` を参照する形なので新セクション追加とは矛盾なし。
- `design/15-sdk-bindings-api.md`: L1-2 行 (`Bridge との fd 受け渡しプロトコル`) と本文 L566 (`Bridge から fd で渡される`) の `fd` 表現が、Windows backend (HANDLE) 解禁後は厳密には OS 中立性を欠く。ただし本 PR scope（cfg ゲート整理 + 17-driver-comm 配下 doc 更新）の外側で、変更には HANDLE/handle 等への正規化判断が要るため本 PR では触らず別 Issue に倒す候補とする。

## CI 期待

- `Rust (ubuntu-latest)`: 既存 Linux 経路は変更なし、green を維持する見込み。
- `Rust (macos-latest)`: 公開 re-export 解禁により `midori-ipc-shm` の inline tier ユニットテスト + `midori-runtime::ring_ingest` ユニットテストが macOS 上で実行される。これが本 PR の AC「macos-latest job が green」の検証点。
- `Rust (windows-latest)`: 既存 Windows 経路（`ring_consumer_windows` / `handle_pipe_windows`）への cfg 影響なし、`cargo check` も `cargo test` も green を維持する見込み。

Closes MEW-73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * macOSでのファイルディスクリプタ送受信機能をサポート
  * macOSでのリング情報取得（リング ingest）をサポート

* **ドキュメンテーション**
  * プラットフォーム対応状況を「Linux / macOS」へ更新
  * IPCおよびハンドオフに関する設計ドキュメントをOS別実装方針に合わせて更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->