### PR TITLE
ci: draft PR では CI を走らせず実行時間を節約

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: CI
 
+# `pull_request: types` から `ready_for_review` を含めることで、draft → ready
+# の切替時に CI が起動する。draft 状態では CI を走らせず実行時間を節約する
+# (各 job に `if: github.event.pull_request.draft != true` ガードを併設)。
 on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 # Read-only is sufficient for every job in this workflow: cargo / cargo-deny
 # / pnpm-biome all consume the checked-out tree without writing to PRs,
@@ -12,10 +16,17 @@ on:
 permissions:
   contents: read
 
+# 各 job の `if:` ガードについて:
+# - `push: branches: [main]` イベントでは `github.event.pull_request` 自体が
+#   undefined なので `.draft` は null となり、null != true で条件成立 → job
+#   は走る (main への push は draft 概念が無いため CI 必須)
+# - `pull_request` イベントでは `.draft` が boolean で評価され、true の
+#   ときのみ skip
 jobs:
   rust:
     name: Rust (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft != true
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -43,6 +54,7 @@ jobs:
   rust-deny:
     name: Rust cargo-deny
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
     steps:
       - uses: actions/checkout@v6
       # cargo-deny reads only Cargo.lock plus its configuration, so one
@@ -57,6 +69,7 @@ jobs:
   js:
     name: JS
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6


### PR DESCRIPTION
## 概要

draft PR 中は CI runner 時間を消費しない構成に変更。draft → ready で切り替えた瞬間に最新 commit で 1 回 CI が走る。

## 変更点

- `on.pull_request.types` に `[opened, synchronize, reopened, ready_for_review]` を明示
- 各 job (`rust` / `rust-deny` / `js`) に `if: github.event.pull_request.draft != true` ガードを追加
- main への push は `github.event.pull_request` が undefined のため null != true で条件成立、従来通り CI が走る

## 動作期待値

| イベント | 旧挙動 | 新挙動 |
|---|---|---|
| push to main | 走る | 走る |
| PR opened (draft) | 走る | skip |
| PR opened (ready) | 走る | 走る |
| draft PR に push (synchronize) | 走る | skip |
| ready PR に push (synchronize) | 走る | 走る |
| draft → ready (`ready_for_review`) | 走らない | **走る** (新規) |
| reopen | 走る | 走る |

## CodeQL について

Repo settings の default code scanning で動いており本ファイル外。draft skip させたい場合は repo settings 側で別途設定要。

## Test plan

- [ ] CI が green
- [ ] このコメントを書いてる時点で本 PR は draft、CI 起動を観察
- [ ] ready 化したタイミングで CI 起動を観察
- [ ] その後 draft に戻す → push → CI が skip されること観察

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI ワークフローを改善しました。ドラフト PR が準備完了状態になった際に CI が実行されるようになります。
  * ドラフト PR 段階では Rust、Rust-deny、JavaScript ジョブをスキップし、リソースを効率的に活用します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->