### PR TITLE
docs(sdk-bindings): handshake 文脈の "fd" を OS 中立な handle に正規化

### DIFF
--- a/design/15-sdk-bindings-api.md
+++ b/design/15-sdk-bindings-api.md
@@ -563,7 +563,7 @@ const char* midori_sdk_last_error(void);
 
 ### 設計上の注意
 
-- **`emit_event` は SPSC ハンドルを引数に取らない。** L1 内部に Bridge と共有するハンドル（プロセス起動時に Bridge から fd で渡される）を 1 個持ち、`midori_sdk_run` の中で初期化する
+- **`emit_event` は SPSC ハンドルを引数に取らない。** L1 内部に Bridge と共有するハンドル（プロセス起動時に Bridge から OS 中立な handle として渡される。Linux / macOS は `OwnedFd`、Windows は `OwnedHandle`）を 1 個持ち、`midori_sdk_run` の中で初期化する
 - **文字列はすべて UTF-8。** event の key / 文字列 value はいずれも UTF-8 として msgpack に encode する
 - **`config_json` は L1 が文字列のまま L2/L3 に渡す。** JSON のパースは言語側で行う（Python なら `json.loads`、Node なら `JSON.parse`）。L1 が型を持たないことで、ドライバー固有の `config` スキーマ拡張が L1 ABI 変更を要求しない
 - **`list_devices` のメモリ:** ドライバーが返す `value` / `label` ポインタは **コールバック return まで有効** であればよい。L1 がコールバック内で JSON にシリアライズし stdout に書き出す
@@ -754,7 +754,7 @@ SysEx 1KB 級は SPSC スロットの `PAYLOAD_INLINE_MAX` を超えるので **
 | Issue 案 | 内容 | 想定 SP |
 |---|---|---|
 | L1-1 | `midori_sdk_run` / `midori_driver_callbacks_t` の Rust 実装と extern "C" エクスポート（`struct_size`/シグナル opt-out 含む） | 5 |
-| L1-2 | `midori_event_t` ビルダー + `midori_sdk_emit_event`（msgpack encode → SPSC push）＋ Bridge との fd 受け渡しプロトコル | 5 |
+| L1-2 | `midori_event_t` ビルダー + `midori_sdk_emit_event`（msgpack encode → SPSC push）＋ Bridge との handle 受け渡しプロトコル（Linux / macOS は `OwnedFd`、Windows は `OwnedHandle`） | 5 |
 | L1-3 | `midori_sdk_log` 実装と stdout 非 JSON 行への書き出し | 2 |
 | L1-4 | cbindgen の更新と C ヘッダ自動生成テスト拡張 | 2 |
 


### PR DESCRIPTION
## Summary

- `design/15-sdk-bindings-api.md` に残っていた Linux 固有の "fd" 表現を、`design/17-driver-comm/` で確立した OS 中立パターン (`handle` 抽象 + Linux / macOS は `OwnedFd`、Windows は `OwnedHandle` を併記) に揃える。
- 書き換え箇所は 2 箇所: 「設計上の注意」(L566) の Bridge から SDK へ handle が渡される旨の記述と、Phase 1 の L1-2 タスク行 (L757) の handshake プロトコル説明。
- doc only の変更で挙動・API 変更なし。

## Changes

- L566「Bridge から fd で渡される」→「Bridge から OS 中立な handle として渡される。Linux / macOS は `OwnedFd`、Windows は `OwnedHandle`」
- L757「Bridge との fd 受け渡しプロトコル」→「Bridge との handle 受け渡しプロトコル（Linux / macOS は `OwnedFd`、Windows は `OwnedHandle`）」

## Verification

- 同 file 内を `\bfd\b` / `file descriptor` / `\bfds\b` で grep し残存ゼロを確認。
- `design/17-driver-comm/01-inline-ring.md` の handshake プロトコル / handle 抽象テーブルと用語整合 (`OwnedFd` / `OwnedHandle` 併記) を確認。
- `design/17-driver-comm/00-overview.md` 側は `15-sdk-bindings-api.md` への単純な cross-reference のみで、用語衝突なし。
- CodeRabbit ローカルレビュー (`coderabbit review --agent -t committed --base main`) で findings 0。

## Test plan

- [x] 該当ファイル内の "fd" 言及を grep で網羅し、handshake 文脈の残存ゼロを確認
- [x] `design/17-driver-comm/00-overview.md` `01-inline-ring.md` との用語整合を確認
- [x] CodeRabbit CLI のローカルレビュー実行
- [ ] User による最終レビューと merge

Closes MEW-74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * SDK バインディング API の設計ドキュメントを更新し、L1 内での handle の受け渡し方法の仕様をより明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->