### PR TITLE
feat(driver-midi): events.yaml と list_devices を実装 (MEW-52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,13 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
 
+      # `midori-driver-midi` pulls in `midir`, which on Linux links the
+      # ALSA C library via `alsa-sys`. macOS uses CoreMIDI and Windows
+      # uses WinMM, so the headers are only required on the Linux runner.
+      - name: install ALSA headers (Linux)
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev
+        if: matrix.os == 'ubuntu-latest'
+
       - name: fmt
         run: cargo fmt --all --check
         if: matrix.os == 'ubuntu-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,37 @@
 version = 4
 
 [[package]]
+name = "alsa"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
+dependencies = [
+ "alsa-sys",
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "android-build"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac4c64175d504608cf239756339c07f6384a476f97f20a7043f92920b0b8fd"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +102,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "cbindgen"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +136,22 @@ dependencies = [
  "tempfile",
  "toml",
 ]
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -147,6 +212,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "coremidi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f32f5d3e1b800aa7ea10e9e83c87cbc1daef1397ee86cd599458b3c3b136428a"
+dependencies = [
+ "block",
+ "core-foundation",
+ "core-foundation-sys",
+ "coremidi-sys",
+]
+
+[[package]]
+name = "coremidi-sys"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9504310988d938e49fff1b5f1e56e3dafe39bb1bae580c19660b58b83a191e"
+dependencies = [
+ "core-foundation-sys",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,10 +302,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -218,6 +360,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -271,6 +419,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "java-locator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "java-locator",
+ "jni-sys 0.3.1",
+ "libloading",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-min-helper"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3c57d31c3b3c1d49c7a7b5d7089f9bf0bf1ab9ed5b482d9840eeb6e1334bfd"
+dependencies = [
+ "android-build",
+ "jni",
+ "log",
+ "ndk-context",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +508,16 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libredox"
@@ -296,6 +533,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -328,6 +574,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "midir"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c12e74a8604bc07f9a3fcf3d5889a81bc96ca6e07d6a114d63fc0371f3e5a4"
+dependencies = [
+ "alsa",
+ "cc",
+ "coremidi",
+ "jni",
+ "jni-min-helper",
+ "js-sys",
+ "libc",
+ "log",
+ "ndk-context",
+ "parking_lot",
+ "wasm-bindgen",
+ "web-sys",
+ "windows",
+]
+
+[[package]]
 name = "midori-core"
 version = "0.3.0"
 dependencies = [
@@ -347,7 +614,10 @@ dependencies = [
 name = "midori-driver-midi"
 version = "0.1.0"
 dependencies = [
+ "midir",
+ "midori-runtime",
  "midori-sdk",
+ "serde_yaml_ng",
 ]
 
 [[package]]
@@ -394,6 +664,12 @@ dependencies = [
  "serde_json",
  "signal-hook",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -446,6 +722,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +789,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -522,10 +842,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -600,6 +941,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +965,18 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -733,6 +1092,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +1123,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -791,10 +1205,155 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
 
 [[package]]
 name = "windows-sys"
@@ -802,7 +1361,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -816,18 +1384,64 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -836,10 +1450,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -848,10 +1486,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -860,16 +1528,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ missing_panics_doc      = "allow"
 midori-core    = { path = "crates/midori-core",    version = "0.3.0" }
 midori-sdk     = { path = "crates/midori-sdk",     version = "0.2.0" }
 midori-ipc-shm = { path = "crates/midori-ipc-shm", version = "0.1.0" }
+midori-runtime = { path = "crates/midori-runtime", version = "0.1.0" }

--- a/crates/midori-driver-midi/Cargo.toml
+++ b/crates/midori-driver-midi/Cargo.toml
@@ -15,7 +15,7 @@ midir = "0.11.0"
 midori-sdk = { workspace = true }
 
 [dev-dependencies]
-midori-runtime = { path = "../midori-runtime" }
+midori-runtime = { workspace = true }
 serde_yaml_ng = "0.10"
 
 [lints]

--- a/crates/midori-driver-midi/Cargo.toml
+++ b/crates/midori-driver-midi/Cargo.toml
@@ -11,7 +11,12 @@ name = "midori-driver-midi"
 path = "src/main.rs"
 
 [dependencies]
+midir = "0.11.0"
 midori-sdk = { workspace = true }
+
+[dev-dependencies]
+midori-runtime = { path = "../midori-runtime" }
+serde_yaml_ng = "0.10"
 
 [lints]
 workspace = true

--- a/crates/midori-driver-midi/events.yaml
+++ b/crates/midori-driver-midi/events.yaml
@@ -1,0 +1,75 @@
+schema_version: 1
+
+# TODO(MEW-75): SysEx (system exclusive) event を追加する。streamed tier
+# 実装完了が前提（inline tier の HARD_SLOT_SIZE = 64 KiB では Electone
+# bulk dump 等の可変長 / 大型 SysEx を運べないため）。
+
+# 全イベント共通の field 宣言。loader は単独で validate するだけで、
+# 各 event への自動 merge はしない（merge は将来の runtime 層で実装予定）。
+# DRY としての意図は「MIDI channel の意味論を 1 箇所で固定し、
+# 各 event の channel 宣言と乖離しないことをレビュー時に確認するため」。
+defaults:
+  channel: { type: uint8, range: [1, 16] }
+
+events:
+  noteOn:
+    tier: inline
+    fields:
+      channel:  { type: uint8, range: [1, 16] }
+      note:     { type: uint8, range: [0, 127] }
+      velocity: { type: uint8, range: [0, 127] }
+    binding_filter: [type, channel]
+    note_field: note
+
+  noteOff:
+    tier: inline
+    fields:
+      channel:  { type: uint8, range: [1, 16] }
+      note:     { type: uint8, range: [0, 127] }
+      velocity: { type: uint8, range: [0, 127], optional: true, default: 0 }
+    binding_filter: [type, channel]
+    note_field: note
+
+  polyAftertouch:
+    tier: inline
+    fields:
+      channel:  { type: uint8, range: [1, 16] }
+      note:     { type: uint8, range: [0, 127] }
+      pressure: { type: uint8, range: [0, 127] }
+    binding_filter: [type, channel]
+    note_field: note
+
+  channelAftertouch:
+    tier: inline
+    fields:
+      channel:  { type: uint8, range: [1, 16] }
+      pressure: { type: uint8, range: [0, 127] }
+    binding_filter: [type, channel]
+
+  controlChange:
+    tier: inline
+    fields:
+      channel:    { type: uint8, range: [1, 16] }
+      controller: { type: uint8, range: [0, 127] }
+      value:      { type: uint8, range: [0, 127] }
+    binding_filter: [type, channel, controller]
+
+  pitchBend:
+    tier: inline
+    fields:
+      channel: { type: uint8, range: [1, 16] }
+      value:   { type: int16, range: [-8192, 8191] }
+    binding_filter: [type, channel]
+
+  programChange:
+    tier: inline
+    fields:
+      channel: { type: uint8, range: [1, 16] }
+      program: { type: uint8, range: [0, 127] }
+    binding_filter: [type, channel]
+
+  realtime:
+    tier: inline
+    fields:
+      message: { type: enum, values: [start, stop, continue, clock] }
+    binding_filter: [type, message]

--- a/crates/midori-driver-midi/src/main.rs
+++ b/crates/midori-driver-midi/src/main.rs
@@ -1,7 +1,66 @@
-fn main() {}
+//! Official MIDI driver binary for the Midori signal bridge.
+
+use midir::MidiInput;
+use std::process::ExitCode;
+
+use midori_sdk::{ControlCommand, DeviceEntry, Driver, DriverError};
+
+fn collect_devices() -> Vec<DeviceEntry> {
+    let Ok(midi_in) = MidiInput::new("midori-driver-midi") else {
+        return Vec::new();
+    };
+
+    midi_in
+        .ports()
+        .iter()
+        .filter_map(|port| {
+            Some(DeviceEntry {
+                value: port.id(),
+                label: midi_in.port_name(port).ok()?,
+            })
+        })
+        .collect()
+}
+
+struct MidiDriver;
+
+impl Driver for MidiDriver {
+    fn list_devices(&mut self) -> Vec<DeviceEntry> {
+        collect_devices()
+    }
+
+    fn handle_command(&mut self, _command: ControlCommand) -> Result<(), DriverError> {
+        Ok(())
+    }
+
+    fn shutdown(&mut self) -> Result<(), DriverError> {
+        Ok(())
+    }
+}
+
+fn main() -> ExitCode {
+    midori_sdk::driver::run(MidiDriver)
+}
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use midori_runtime::events_schema::{validate, EventsSchema};
+
+    const EVENTS_YAML: &str = include_str!("../events.yaml");
+
     #[test]
-    fn it_works() {}
+    fn it_should_load_events_yaml_as_valid_schema() {
+        let schema: EventsSchema = serde_yaml_ng::from_str(EVENTS_YAML)
+            .expect("events.yaml must deserialize as EventsSchema");
+
+        validate(&schema).expect("events.yaml must pass schema validation");
+    }
+
+    #[test]
+    fn it_should_return_device_list_without_panic() {
+        // Hardware-less environment may return an empty Vec.
+        // Goal: ensure collect_devices() does not panic.
+        let _devices = collect_devices();
+    }
 }

--- a/crates/midori-driver-midi/src/main.rs
+++ b/crates/midori-driver-midi/src/main.rs
@@ -1,10 +1,44 @@
 //! Official MIDI driver binary for the Midori signal bridge.
+//!
+//! This is a skeleton: it wires the SDK's CLI scaffold (`<driver> list` /
+//! `<driver> start`) to a `Driver` implementation that enumerates MIDI
+//! input ports via `midir` and parks all command handlers as no-ops.
+//! Actual MIDI message reception, connection lifecycle management, and
+//! event emission are deferred to follow-up work and live behind no-op
+//! handlers here.
+//!
+//! # What this binary currently does
+//!
+//! - `list`: enumerates MIDI input ports via `midir::MidiInput` and prints
+//!   a JSON array of `DeviceEntry { value, label }`. `value` is the stable
+//!   `MidiInputPort::id()` (the key the bridge passes back through
+//!   `Connect`); `label` is the human-readable `port_name()`. Ports whose
+//!   name lookup fails are silently skipped. If `MidiInput::new` itself
+//!   fails, an empty array is returned — the bridge treats this as "no
+//!   devices to offer" rather than as a hard error.
+//! - `start`: emits the SDK `hello` message, waits for `hello_ack`, then
+//!   accepts and silently drops any control commands (`connect`,
+//!   `configure`, `disconnect`) until stdin EOF or SIGTERM/SIGINT.
+//!
+//! Returning `Ok(())` from every command handler keeps the bridge's
+//! lifecycle tests against this driver passing: the bridge sees a clean
+//! handshake, can issue commands without errors, and observes a graceful
+//! exit on shutdown. When real MIDI support lands, the handler bodies are
+//! the place to spawn the input thread, dispatch incoming events through
+//! the SDK SPSC ring, and tear down resources on shutdown.
 
 use midir::MidiInput;
 use std::process::ExitCode;
 
 use midori_sdk::{ControlCommand, DeviceEntry, Driver, DriverError};
 
+/// Enumerate available MIDI input ports through `midir`.
+///
+/// Returns an empty `Vec` if `MidiInput::new` fails (treated as "no
+/// devices available" rather than surfaced to the bridge as an error).
+/// Ports whose `port_name()` lookup fails are silently skipped — the
+/// listing reports only ports that can be addressed by both stable id
+/// and human-readable label.
 fn collect_devices() -> Vec<DeviceEntry> {
     let Ok(midi_in) = MidiInput::new("midori-driver-midi") else {
         return Vec::new();
@@ -22,6 +56,9 @@ fn collect_devices() -> Vec<DeviceEntry> {
         .collect()
 }
 
+/// Skeleton driver state. Holds no resources today; future MIDI work will
+/// add a `midir::MidiInput` client, an `Option<MidiInputConnection<...>>`,
+/// and an SPSC `Producer` here.
 struct MidiDriver;
 
 impl Driver for MidiDriver {
@@ -30,10 +67,16 @@ impl Driver for MidiDriver {
     }
 
     fn handle_command(&mut self, _command: ControlCommand) -> Result<(), DriverError> {
+        // Accept and drop. Returning Ok keeps the SDK's command loop alive
+        // so the bridge can drive the full lifecycle (connect → configure →
+        // disconnect) against this skeleton without surfacing spurious
+        // protocol errors.
         Ok(())
     }
 
     fn shutdown(&mut self) -> Result<(), DriverError> {
+        // No resources to release yet. Real implementations will close the
+        // midir connection and join worker threads here.
         Ok(())
     }
 }

--- a/crates/midori-driver-midi/src/main.rs
+++ b/crates/midori-driver-midi/src/main.rs
@@ -101,9 +101,10 @@ mod tests {
     }
 
     #[test]
-    fn it_should_return_device_list_without_panic() {
-        // Hardware-less environment may return an empty Vec.
-        // Goal: ensure collect_devices() does not panic.
+    fn it_should_not_panic_when_collecting_devices() {
+        // Hardware-less CI runners can return any number of ports
+        // (typically zero), so the only stable contract worth asserting
+        // here is "the call returns without panicking".
         let _devices = collect_devices();
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -50,6 +50,16 @@ allow = [
 confidence-threshold = 0.8
 
 [[licenses.exceptions]]
+# Transitive dep of `midir` via the Android JNI backend
+# (`midir → jni-min-helper → jni → libloading`). ISC is an
+# OSI-approved permissive license (functionally equivalent to
+# MIT / 2-clause BSD); it is not in the global allow list because
+# libloading is currently the sole crate using it. Scoped per-crate
+# so introducing ISC anywhere else still requires an explicit review.
+name = "libloading"
+allow = ["ISC"]
+
+[[licenses.exceptions]]
 # Build-time C-header generator for the SDK FFI surface. MPL-2.0 is
 # file-level weak copyleft; using cbindgen as an unmodified tool does
 # not propagate to the consuming workspace.


### PR DESCRIPTION
## 概要

`midori-driver-midi` 完成までの第 1 段階。ドライバーが提供するイベント語彙を `events.yaml` で宣言し、`midir` を使った MIDI 入力ポート列挙を `list_devices()` 経由で取得できる状態にする。

実際の MIDI メッセージ受信・接続管理は次 Issue (MEW-53) に分離。

Closes MEW-52

## 変更点

### `crates/midori-driver-midi/events.yaml` 新規

inline-tier 8 イベントを宣言:

- `noteOn` / `noteOff` (note_field: note)
- `controlChange` (binding_filter: type, channel, controller)
- `polyAftertouch` / `channelAftertouch`
- `pitchBend` (value: int16, range [-8192, 8191])
- `programChange`
- `realtime` (enum)

`defaults.channel` を共通宣言として宣言し、各 event で同じ意味で参照される MIDI channel の意味論を 1 箇所で固定。

SysEx は意図的に除外。可変長 / 大型 (Electone bulk dump 等) 対応には streamed tier 実装が前提のため、follow-up Issue (MEW-75) で対応する。`events.yaml` 内で `# TODO(MEW-75)` marker を残置。

### `crates/midori-driver-midi/Cargo.toml`

- `midir = "0.11.0"` を `[dependencies]` に追加 (cross-platform MIDI library、Core MIDI / ALSA / WinMM / WebMIDI 対応)
- `[dev-dependencies]` に `midori-runtime` と `serde_yaml_ng = "0.10"` を追加 (テストで `EventsSchema` deserialize + `validate` を借用するため)

### `crates/midori-driver-midi/src/main.rs`

- `Driver::list_devices()` を `midir::MidiInput` ベースで実装
  - `MidiInput::new()` 失敗時は `Vec::new()` で「デバイス無し」扱い
  - `value` は `MidiInputPort::id()` (安定識別子、`Connect` コマンドの参照キー)
  - `label` は `MidiInput::port_name()` (人間表示名)
  - `port_name` 取得失敗 port は filter_map で skip
- `let-else` 構文で `midi_in` 取得失敗時の早 return を簡潔化 (clippy::manual_let_else 対応)
- `handle_command` / `shutdown` は skeleton のまま (`Ok(())` 返すだけ、実装は MEW-53)
- `#[cfg(test)] mod tests` に 2 ケース追加:
  - `it_should_load_events_yaml_as_valid_schema`: `include_str!` で events.yaml を埋め込み、`EventsSchema` への deserialize と `validate` 通過を検証
  - `it_should_return_device_list_without_panic`: `collect_devices()` が hardware-less 環境でも panic せず Vec を返すことを確認

### `Cargo.lock`

`midir` + `alsa` 等の transitive deps を反映。

## DoD

- [x] events.yaml schema doc (`design/16-driver-events-schema.md`) 準拠 (8 events + defaults + tier inline)
- [x] `Cargo.toml` に midir 追加
- [x] `Driver::list_devices()` 実装 (port.id() ベース、hardware-less で空 Vec)
- [x] ユニットテスト 2 件追加、`cargo test -p midori-driver-midi` 通過
- [x] `cargo check -p midori-driver-midi` / `cargo clippy -p midori-driver-midi -- -D warnings` / `cargo fmt --all --check` 全通過

## Out of Scope (Issue 通り)

- Connect / Disconnect / Configure コマンド実処理
- 実 MIDI メッセージ受信とイベント emit
- SysEx (MEW-75 で対応、streamed tier 待ち)
- 出力方向 (Bridge → Driver)

## Test plan

- [ ] CI green
- [ ] `cargo test -p midori-driver-midi` (ローカル)
- [ ] `cargo run -p midori-driver-midi -- list` で実機 MIDI port が列挙される (Linux 環境では少なくとも Midi Through 仮想 port が確認できる)
- [ ] ローカル `/code-review:code-review` 完走
- [ ] `coderabbit review --agent -t committed --base main` findings 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * MIDI ドライバの実装：デバイス列挙と各種 MIDI イベント（ノート、アフタートッチ、コントロールチェンジ、ピッチベンド、プログラムチェンジ、リアルタイム等）をサポートするランタイムを追加しました。

* **テスト**
  * イベントスキーマ検証とデバイス列挙のテストを追加しました。

* **CI**
  * Linux 環境向けに ALSA 開発ヘッダをインストールする手順を追加しました。

* **その他**
  * ランタイム依存とライセンス例外を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->