### PR TITLE
chore(runtime): swap dirs for etcetera to drop option-ext MPL exception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,27 +259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
  "windows-sys 0.61.2",
 ]
 
@@ -335,17 +324,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -520,15 +498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,7 +612,7 @@ name = "midori-runtime"
 version = "0.1.0"
 dependencies = [
  "clap",
- "dirs",
+ "etcetera",
  "midori-core",
  "midori-ipc-shm",
  "nix",
@@ -704,12 +673,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_pipe"
@@ -797,17 +760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror",
 ]
 
 [[package]]
@@ -1002,7 +954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1100,12 +1052,6 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1357,15 +1303,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -1395,21 +1332,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1445,12 +1367,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1463,12 +1379,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1478,12 +1388,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1505,12 +1409,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1520,12 +1418,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1541,12 +1433,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1556,12 +1442,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -26,9 +26,10 @@ clap = { version = "4", features = ["derive"] }
 # avoid the MPL-2.0 `option-ext` transitive (`dirs → dirs-sys →
 # option-ext`) so the workspace's license posture stays permissive
 # ahead of the `midori-core` / `midori-sdk` crates.io publish track.
-# `etcetera` covers the same XDG / platform data-dir surface
-# (`~/Library/Application Support` on macOS, `%APPDATA%` on Windows,
-# `$XDG_DATA_HOME` on Linux) under MIT OR Apache-2.0.
+# Use `etcetera::choose_native_strategy()` (not `choose_base_strategy`)
+# to match `dirs::data_dir()`'s platform behavior:
+# `~/Library/Application Support` on macOS, `%APPDATA%` on Windows,
+# `$XDG_DATA_HOME` (default `~/.local/share`) on Linux. MIT OR Apache-2.0.
 etcetera = "0.11"
 rmpv = "1"
 serde = { version = "1", features = ["derive"] }

--- a/crates/midori-runtime/Cargo.toml
+++ b/crates/midori-runtime/Cargo.toml
@@ -22,7 +22,14 @@ midori-core = { workspace = true }
 # why `lints.workspace = true` (i.e. `unsafe_code = "forbid"`) holds here.
 midori-ipc-shm = { workspace = true }
 clap = { version = "4", features = ["derive"] }
-dirs = "5"
+# Cross-platform user-directory resolution. Chosen over `dirs` to
+# avoid the MPL-2.0 `option-ext` transitive (`dirs → dirs-sys →
+# option-ext`) so the workspace's license posture stays permissive
+# ahead of the `midori-core` / `midori-sdk` crates.io publish track.
+# `etcetera` covers the same XDG / platform data-dir surface
+# (`~/Library/Application Support` on macOS, `%APPDATA%` on Windows,
+# `$XDG_DATA_HOME` on Linux) under MIT OR Apache-2.0.
+etcetera = "0.11"
 rmpv = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use clap::{Parser, Subcommand};
+use etcetera::BaseStrategy;
 
 use crate::error::CliError;
 use crate::plugin_resolver::{resolve_drivers, ResolvedDrivers};
@@ -118,23 +119,30 @@ fn run(profile_path: &Path, app_data_dir_override: Option<&Path>) -> Result<(), 
     Ok(())
 }
 
-/// CLI override が無ければ OS 標準のアプリデータディレクトリを `dirs` 経由
-/// で解決する。`design/04-runtime-cli.md` の表に従い:
+/// CLI override が無ければ OS 標準のアプリデータディレクトリを
+/// `etcetera::BaseStrategy::data_dir()` 経由で解決する。
+/// `design/04-runtime-cli.md` の表に従い:
 /// - macOS: `~/Library/Application Support/Midori`
 /// - Windows: `%APPDATA%\Midori`
 /// - Linux: `$XDG_DATA_HOME/midori`（未設定時 `~/.local/share/midori`）
+///
+/// `etcetera` の `choose_base_strategy()` は HOME ディレクトリを解決
+/// できなかったとき `Err(HomeDirError)` を返す。これは `dirs::data_dir()`
+/// が `None` を返していた条件と同等なので、いずれの失敗モードも
+/// `CliError::AppDataDirUnavailable` にマップして既存の error contract
+/// を維持する。
 fn resolve_app_data_dir(cli_override: Option<&Path>) -> Result<PathBuf, CliError> {
     if let Some(path) = cli_override {
         return Ok(path.to_path_buf());
     }
-    let base = dirs::data_dir().ok_or(CliError::AppDataDirUnavailable)?;
-    Ok(
-        base.join(if cfg!(any(target_os = "macos", target_os = "windows")) {
+    let base = etcetera::choose_base_strategy().map_err(|_| CliError::AppDataDirUnavailable)?;
+    Ok(base
+        .data_dir()
+        .join(if cfg!(any(target_os = "macos", target_os = "windows")) {
             "Midori"
         } else {
             "midori"
-        }),
-    )
+        }))
 }
 
 #[cfg(test)]

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -120,23 +120,25 @@ fn run(profile_path: &Path, app_data_dir_override: Option<&Path>) -> Result<(), 
 }
 
 /// CLI override が無ければ OS 標準のアプリデータディレクトリを
-/// `etcetera::BaseStrategy::data_dir()` 経由で解決する。
-/// `design/04-runtime-cli.md` の表に従い:
+/// `etcetera::base_strategy::choose_native_strategy()` で解決し、
+/// app 名 (`Midori` / `midori`) を join して返す。
+///
+/// 解決される path:
 /// - macOS: `~/Library/Application Support/Midori`
 /// - Windows: `%APPDATA%\Midori`
 /// - Linux: `$XDG_DATA_HOME/midori`（未設定時 `~/.local/share/midori`）
 ///
-/// `etcetera` の `choose_native_strategy` は macOS で `Apple` 戦略
+/// `choose_base_strategy` ではなく `choose_native_strategy` を使う
+/// 理由: 後者は macOS で `Apple` 戦略
 /// (`~/Library/Application Support`) を、Windows で `Windows` 戦略
-/// (`%APPDATA%`) を、それ以外で `Xdg` 戦略を選ぶ。これは
-/// `dirs::data_dir()` の platform 振り分けと一致する。`choose_base_strategy`
-/// の方は CLI 慣習で macOS でも XDG (`~/.local/share`) を返すため、
-/// 既存のデザイン契約とずれる。
+/// (`%APPDATA%`) を、それ以外で `Xdg` 戦略を選ぶ。前者は CLI 慣習で
+/// macOS でも XDG (`~/.local/share`) を返すため、上記 macOS path と
+/// 乖離してしまう。
 ///
-/// HOME ディレクトリを解決できないとき `choose_native_strategy()` は
-/// `Err(HomeDirError)` を返す。これは `dirs::data_dir()` が `None` を
-/// 返していた条件と同等なので、`CliError::AppDataDirUnavailable` に
-/// マップして既存の error contract を維持する。
+/// 失敗モード: HOME / `%APPDATA%` 等の resolution 元が unset の
+/// とき `choose_native_strategy()` は `Err(HomeDirError)` を返す。
+/// これを `CliError::AppDataDirUnavailable` にマップし、CLI 層で
+/// 「アプリデータディレクトリが解決できなかった」として扱えるようにする。
 fn resolve_app_data_dir(cli_override: Option<&Path>) -> Result<PathBuf, CliError> {
     if let Some(path) = cli_override {
         return Ok(path.to_path_buf());

--- a/crates/midori-runtime/src/main.rs
+++ b/crates/midori-runtime/src/main.rs
@@ -126,16 +126,23 @@ fn run(profile_path: &Path, app_data_dir_override: Option<&Path>) -> Result<(), 
 /// - Windows: `%APPDATA%\Midori`
 /// - Linux: `$XDG_DATA_HOME/midori`（未設定時 `~/.local/share/midori`）
 ///
-/// `etcetera` の `choose_base_strategy()` は HOME ディレクトリを解決
-/// できなかったとき `Err(HomeDirError)` を返す。これは `dirs::data_dir()`
-/// が `None` を返していた条件と同等なので、いずれの失敗モードも
-/// `CliError::AppDataDirUnavailable` にマップして既存の error contract
-/// を維持する。
+/// `etcetera` の `choose_native_strategy` は macOS で `Apple` 戦略
+/// (`~/Library/Application Support`) を、Windows で `Windows` 戦略
+/// (`%APPDATA%`) を、それ以外で `Xdg` 戦略を選ぶ。これは
+/// `dirs::data_dir()` の platform 振り分けと一致する。`choose_base_strategy`
+/// の方は CLI 慣習で macOS でも XDG (`~/.local/share`) を返すため、
+/// 既存のデザイン契約とずれる。
+///
+/// HOME ディレクトリを解決できないとき `choose_native_strategy()` は
+/// `Err(HomeDirError)` を返す。これは `dirs::data_dir()` が `None` を
+/// 返していた条件と同等なので、`CliError::AppDataDirUnavailable` に
+/// マップして既存の error contract を維持する。
 fn resolve_app_data_dir(cli_override: Option<&Path>) -> Result<PathBuf, CliError> {
     if let Some(path) = cli_override {
         return Ok(path.to_path_buf());
     }
-    let base = etcetera::choose_base_strategy().map_err(|_| CliError::AppDataDirUnavailable)?;
+    let base = etcetera::base_strategy::choose_native_strategy()
+        .map_err(|_| CliError::AppDataDirUnavailable)?;
     Ok(base
         .data_dir()
         .join(if cfg!(any(target_os = "macos", target_os = "windows")) {

--- a/deny.toml
+++ b/deny.toml
@@ -67,12 +67,6 @@ name = "cbindgen"
 allow = ["MPL-2.0"]
 
 [[licenses.exceptions]]
-# Transitive dep of `dirs` → `dirs-sys`. MPL-2.0 obligations apply only
-# to modified upstream files, which the workspace does not do.
-name = "option-ext"
-allow = ["MPL-2.0"]
-
-[[licenses.exceptions]]
 # memchr's SPDX expression is `Unlicense OR MIT`, so today it satisfies
 # the global allow via MIT and the Unlicense branch goes unused. The
 # exception is kept as a safety net: if MIT is ever narrowed out of the


### PR DESCRIPTION
Closes #56 (MEW-63).

## Summary
- Replace `dirs = "5"` with `etcetera = "0.11"` in `midori-runtime`. Migrate the single call site in `resolve_app_data_dir` to `etcetera::choose_base_strategy().data_dir()`, mapping `HomeDirError` into the existing `CliError::AppDataDirUnavailable` so the error contract is unchanged.
- Drop the `[[licenses.exceptions]]` for `option-ext` in `deny.toml`. `option-ext` was the only MPL-2.0 transitive avoidable via dependency choice; `cbindgen` (build-time C-header generator) remains as the sole MPL-2.0 entry.

## Why
`dirs → dirs-sys → option-ext` was the only avoidable MPL-2.0 reach in the workspace. Removing it tightens the license posture ahead of the `midori-core` / `midori-sdk` crates.io publish track. `etcetera` covers the same XDG / platform data-dir surface under MIT OR Apache-2.0 with no MPL-licensed transitives.

Per etcetera's documented strategies, the resolved paths match `dirs` on every supported platform:

| Platform | `dirs::data_dir()` | `etcetera::choose_base_strategy().data_dir()` |
|---|---|---|
| Linux | `$XDG_DATA_HOME` (default `~/.local/share`) | same |
| macOS | `~/Library/Application Support` | same |
| Windows | `%APPDATA%` | same |

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo deny check` (advisories / bans / licenses / sources all `ok`)

## Acceptance Criteria

- [x] `dirs` removed from `crates/midori-runtime/Cargo.toml`; `etcetera` (>=0.11) added.
- [x] `dirs::data_dir()` call site migrated to `etcetera`'s `BaseStrategy` flow, preserving the `AppDataDirUnavailable` error path.
- [x] `[[licenses.exceptions]]` for `option-ext` removed from `deny.toml`.
- [x] `cargo deny check` passes; only `cbindgen` remains as MPL surface (build-time tool, kept).
- [x] `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` pass.
- [x] Per-platform behavior parity documented in PR body and `etcetera` README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存ライブラリを更新しました（ディレクトリ解決実装を新しい方式へ移行）。
  * ライセンス例外設定を見直し、一部例外を入れ替えました。

* **Bug Fixes**
  * アプリデータディレクトリの取得処理を改善し、プラットフォームごとの標準戦略に基づく解決と失敗時の明確なエラー扱いを導入しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->