### PR TITLE
docs(release): add crate release process and versioning strategy (MEW-78)

### DIFF
--- a/design/14-repository-structure.md
+++ b/design/14-repository-structure.md
@@ -162,7 +162,7 @@ midori-core = { path = "crates/midori-core", version = "0.3.0" }
 midori-sdk  = { path = "crates/midori-sdk",  version = "0.2.0" }
 ```
 
-各クレートの `Cargo.toml` では `workspace.dependencies` を参照することで、バージョン管理を workspace root に集約する。`path` と `version` を併記する理由および bump 時の追従ルールは `release-process.md` を参照。
+各クレートの `Cargo.toml` では `workspace.dependencies` を参照することで、バージョン管理を workspace root に集約する。`path` と `version` を併記する理由および bump 時の追従ルールは `release-process/rust-crates.md` を参照。
 
 ---
 

--- a/design/14-repository-structure.md
+++ b/design/14-repository-structure.md
@@ -158,11 +158,13 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-midori-core = { path = "crates/midori-core" }
-midori-sdk  = { path = "crates/midori-sdk" }
+midori-core = { path = "crates/midori-core", version = "0.3.0" }
+midori-sdk  = { path = "crates/midori-sdk",  version = "0.2.0" }
 ```
 
 各クレートの `Cargo.toml` では `workspace.dependencies` を参照することで、バージョン管理を workspace root に集約する。
+
+`path` と `version` の両方を持たせるのは crates.io publish 用の前提（path-only の wildcard 依存は `cargo publish` が拒否し、`cargo-deny` の `bans.wildcards` ゲートでも fail する）。bump 時は本 entry の `version` を必ず追従させる。詳細な release 手順は `release-process.md` を参照。
 
 ---
 

--- a/design/14-repository-structure.md
+++ b/design/14-repository-structure.md
@@ -158,8 +158,10 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-midori-core = { path = "crates/midori-core", version = "0.3.0" }
-midori-sdk  = { path = "crates/midori-sdk",  version = "0.2.0" }
+midori-core    = { path = "crates/midori-core",    version = "0.3.0" }
+midori-sdk     = { path = "crates/midori-sdk",     version = "0.2.0" }
+midori-ipc-shm = { path = "crates/midori-ipc-shm", version = "0.1.0" }
+midori-runtime = { path = "crates/midori-runtime", version = "0.1.0" }
 ```
 
 各クレートの `Cargo.toml` では `workspace.dependencies` を参照することで、バージョン管理を workspace root に集約する。`path` と `version` を併記する理由および bump 時の追従ルールは `release-process/rust-crates.md` を参照。

--- a/design/14-repository-structure.md
+++ b/design/14-repository-structure.md
@@ -162,9 +162,7 @@ midori-core = { path = "crates/midori-core", version = "0.3.0" }
 midori-sdk  = { path = "crates/midori-sdk",  version = "0.2.0" }
 ```
 
-各クレートの `Cargo.toml` では `workspace.dependencies` を参照することで、バージョン管理を workspace root に集約する。
-
-`path` と `version` の両方を持たせるのは crates.io publish 用の前提（path-only の wildcard 依存は `cargo publish` が拒否し、`cargo-deny` の `bans.wildcards` ゲートでも fail する）。bump 時は本 entry の `version` を必ず追従させる。詳細な release 手順は `release-process.md` を参照。
+各クレートの `Cargo.toml` では `workspace.dependencies` を参照することで、バージョン管理を workspace root に集約する。`path` と `version` を併記する理由および bump 時の追従ルールは `release-process.md` を参照。
 
 ---
 

--- a/design/README.md
+++ b/design/README.md
@@ -21,9 +21,11 @@
 | [11-security/](./11-security/) | セキュリティ設計（セキュリティ水準・ドライバーサンドボックス・ウィジェット・AI） |
 | [12-distribution.md](./12-distribution.md) | 配布窓口・アップデート方針・利用規約の枠組み |
 | [13-ecosystem-readiness.md](./13-ecosystem-readiness.md) | エコシステム整備 TODO（契約・規約・導線の準備項目） |
+| [14-repository-structure.md](./14-repository-structure.md) | モノレポ構成・Cargo workspace / pnpm workspace 配置・各クレート / パッケージ役割 |
 | [15-sdk-bindings-api.md](./15-sdk-bindings-api.md) | SDK バインディング API 設計（C / Node.js / Python の L1/L2/L3 レイヤーモデル） |
 | [16-driver-events-schema.md](./16-driver-events-schema.md) | Driver `events.yaml` スキーマ仕様（型語彙・binding_filter・SysEx・GUI 流用） |
 | [17-driver-comm/](./17-driver-comm/) | Driver↔Bridge コミュニケーション戦略（tier モデル、inline ring 詳細、streamed 予約） |
+| [release-process.md](./release-process.md) | Rust crate（`midori-core` / `midori-sdk`）の crates.io release 運用手順 |
 | [layers/cross/timing.md](./layers/cross/timing.md) | tick 仕様・pulse リセット・MIDI タイミング |
 | [config/00-component-types.md](./config/00-component-types.md) | component type 一覧（primitive value・必須フィールド・描画コンポーネント） |
 | [config/01-preferences.md](./config/01-preferences.md) | Preferences（非配布・環境固有） |

--- a/design/README.md
+++ b/design/README.md
@@ -25,7 +25,7 @@
 | [15-sdk-bindings-api.md](./15-sdk-bindings-api.md) | SDK バインディング API 設計（C / Node.js / Python の L1/L2/L3 レイヤーモデル） |
 | [16-driver-events-schema.md](./16-driver-events-schema.md) | Driver `events.yaml` スキーマ仕様（型語彙・binding_filter・SysEx・GUI 流用） |
 | [17-driver-comm/](./17-driver-comm/) | Driver↔Bridge コミュニケーション戦略（tier モデル、inline ring 詳細、streamed 予約） |
-| [release-process.md](./release-process.md) | Rust crate（`midori-core` / `midori-sdk`）の crates.io release 運用手順 |
+| [release-process/](./release-process/) | release MECHANICS（track 一覧・各 track の publish 手順・横断考慮事項。Rust crate / Electron / npm の各 sibling docs） |
 | [layers/cross/timing.md](./layers/cross/timing.md) | tick 仕様・pulse リセット・MIDI タイミング |
 | [config/00-component-types.md](./config/00-component-types.md) | component type 一覧（primitive value・必須フィールド・描画コンポーネント） |
 | [config/01-preferences.md](./config/01-preferences.md) | Preferences（非配布・環境固有） |

--- a/design/release-process.md
+++ b/design/release-process.md
@@ -1,0 +1,193 @@
+# Crate Release Process
+
+> ステータス：運用ドキュメント
+> 最終更新：2026-05-04
+
+このドキュメントは Rust crates（`midori-core`, `midori-sdk`）の crates.io への release 運用を定める。エンドユーザー向けアプリ配布（`design/12-distribution.md`）とは別物で、対象は **crate を消費する開発者**および**メンテナ自身**。
+
+リポジトリの crate 構成と公開先方針は `design/14-repository-structure.md` が前提。本ドキュメントは「どのクレートを publish するか」ではなく「**いつ・どうやって publish するか**」を扱う。
+
+---
+
+## 公開対象クレート
+
+| クレート | 公開先 | 理由 |
+|---|---|---|
+| `midori-core` | crates.io | 型・プロトコル定義。`midori-sdk` が依存する |
+| `midori-sdk` | crates.io | ドライバー作者が直接依存するライブラリ |
+| `midori-runtime` | 公開しない | バイナリ配布（`design/12-distribution.md`）と npm shim 経由 |
+| `midori-driver-midi` / `midori-driver-osc` | 公開しない | 公式ドライバーバイナリ。`midori-runtime` に同梱 |
+| `midori-ipc-shm` | 公開しない | workspace 内部 crate（`unsafe` 隔離目的） |
+
+publish 対象 crate には `Cargo.toml` の `description` / `license` / `repository` / `readme` が揃っている必要がある。`midori-ipc-shm` のような workspace 内部専用 crate はこれらの整備義務を負わない。
+
+---
+
+## バージョニング戦略
+
+### Semver 適用境界
+
+| 区分 | 適用条件 |
+|---|---|
+| major bump (`X.0.0`) | wire / ABI / public API の **後方互換のない変更** |
+| minor bump (`x.Y.0`) | public API への **後方互換のある追加** |
+| patch bump (`x.y.Z`) | バグ修正・内部リファクタのみ。public API・ABI 双方に影響しない |
+
+各クレートは **独立にバージョン管理**する。workspace 統一バージョンは採用しない。`midori-core` と `midori-sdk` は依存関係上連動して bump されることが多いが、bump 規模は別個に判断する。
+
+### major bump の判断基準
+
+以下のいずれかに該当する変更は major bump を要する：
+
+- `#[repr(C)]` 構造体のレイアウト変更（フィールドの追加・削除・並び替え・型変更）
+- C FFI シグネチャの変更（引数追加 / 戻り値型変更 / 関数削除）
+- `cbindgen` で生成される C ヘッダの ABI 影響変更
+- `pub` 構造体のフィールド削除・型変更
+- `pub` 関数のシグネチャ変更（引数追加・型変更を含む）
+- `pub` re-export の削除
+- 公開 trait のメソッド追加（既存実装が壊れる）
+
+迷う場合は major bump を選ぶ。crates.io は publish 後の version 削除をサポートしないため、互換性を弱く宣言してしまう方がリスクが大きい。
+
+例外として `design/15-sdk-bindings-api.md` で確立済みのパターン（`struct_size` guard を持つ `#[repr(C)]` 構造体への末尾追加、`#[non_exhaustive]` enum へのバリアント追加）は **minor bump で扱える**。これらは旧バイナリ / 旧 enum match を壊さないことが構造的に保証されているため。詳細な適用条件は `15-sdk-bindings-api.md` の該当節に従う。
+
+### `Cargo.lock` と `[workspace.dependencies].version`
+
+workspace dependency entry は `path` と `version` の両方を持たせる：
+
+```toml
+[workspace.dependencies]
+midori-core = { path = "crates/midori-core", version = "0.3.0" }
+midori-sdk  = { path = "crates/midori-sdk",  version = "0.2.0" }
+```
+
+`version` を欠いた path-only エントリは `cargo publish` 時に wildcard 扱いとなり、`cargo-deny` の `bans.wildcards = "deny"` ゲートで失敗する。bump のたびに該当 crate の `version` も更新する。
+
+---
+
+## タグ命名規則
+
+`<crate-name>-vX.Y.Z` 形式（例: `midori-core-v0.3.0`, `midori-sdk-v0.2.0`）。
+
+| 採用しない理由 | |
+|---|---|
+| `vX.Y.Z` 統一タグ | 複数 crate を独立に bump するため、どの crate の release か判別できない |
+| `release/midori-core/0.3.0` 等のスラッシュ区切り | `git tag` の listing と GitHub Release の sort で扱いづらい |
+
+タグは publish 完了 commit に打つ。`cargo publish` が成功してから tag を push する順序を守る（publish 失敗時の retry をクリーンに保つため）。
+
+---
+
+## CHANGELOG 運用
+
+各 publish 対象 crate は `CHANGELOG.md` を持つ：
+
+```
+crates/midori-core/CHANGELOG.md
+crates/midori-sdk/CHANGELOG.md
+```
+
+形式は [Keep a Changelog](https://keepachangelog.com/) を緩く踏襲する：
+
+```markdown
+# Changelog — <crate-name>
+
+## X.Y.Z — YYYY-MM-DD
+
+### Breaking changes
+
+- 破壊変更の説明（major bump 時のみセクションを起こす）
+
+### Added
+
+- 追加された public API / 機能
+
+### Changed
+
+- 既存挙動の変更（破壊しない範囲）
+
+### Fixed
+
+- バグ修正
+```
+
+major bump がない release では `### Breaking changes` セクションは省略する。`### Added` / `### Changed` / `### Fixed` も該当変更がない場合は省略する。
+
+`midori-sdk` は現時点で `CHANGELOG.md` を持たないが、初回 publish 時に作成する。
+
+---
+
+## 手動 publish 手順
+
+GitHub Actions workflow が整うまで、または ad-hoc release では本手順を踏む。
+
+### 前提
+
+- `cargo login <token>` 済み（`crates.io` で発行した API token）
+- 対象 crate の `Cargo.toml` の `version` を bump 済み
+- 対象 crate の `CHANGELOG.md` に該当 version のエントリを追加済み
+- workspace ルートの `[workspace.dependencies]` にある対象 crate の `version` も bump 済み（依存側の crate が壊れないこと）
+- main ブランチにマージ済み（publish の起点 commit が main から外れていないこと）
+
+### 実行
+
+依存順序に注意する。`midori-sdk` は `midori-core` に依存するため、`midori-core` を先に publish して crates.io 側で resolvable になってから `midori-sdk` を publish する。
+
+```bash
+# 1. dry-run で検証（package のビルド・lint・依存解決まで通すが publish はしない）
+cargo publish --dry-run -p midori-core
+
+# 2. dry-run が green なら本 publish
+cargo publish -p midori-core
+
+# 3. crates.io 側で index 反映を待つ（数秒〜数十秒）
+#    反映されないうちに依存 crate を publish するとエラーになる
+
+# 4. 依存 crate の dry-run で「公開済 midori-core」が見えることを確認
+cargo publish --dry-run -p midori-sdk
+
+# 5. midori-sdk を publish
+cargo publish -p midori-sdk
+
+# 6. tag を打って push（手順 4 の dry-run まで成功してから打つ）
+git tag midori-core-v0.3.0 <publish-commit>
+git tag midori-sdk-v0.2.0 <publish-commit>
+git push origin midori-core-v0.3.0 midori-sdk-v0.2.0
+```
+
+### 失敗時の挙動
+
+- `cargo publish` が途中で失敗した場合、既に publish 済みの crate は yank できるが完全削除はできない。version を捨てて次の patch / minor へ進めるのが基本対応
+- index 反映遅延で dry-run が失敗するケースは時間を置いて retry すれば通る
+- 一度 publish した version の中身は変更不可。修正が必要なら次の version を切る
+
+---
+
+## GitHub Actions release workflow
+
+`.github/workflows/release.yml` を canonical な publish 経路として維持する（実装は別 subtask）。
+
+### トリガー
+
+- `<crate>-vX.Y.Z` パターンの tag push（main へマージ後の自然な release flow）
+- もしくは `workflow_dispatch`（crate 名と version を input、dry-run flag 付き）
+
+### Secrets
+
+- `secrets.CRATES_IO_TOKEN` を repository secret として登録する（メンテナの `cargo login` token）
+
+### 推奨デフォルト
+
+- `workflow_dispatch` の `dry-run` input を **デフォルト true** にし、本 publish は明示的に false にしてから実行する
+- workflow の permissions は最小（`contents: read` を基本、Release 作成連携が要るなら `contents: write`）
+- publish 失敗ログは job の output で確認できるようにし、retry 判断の材料を残す
+
+手動手順は workflow が落ちたとき / ad-hoc release のための fallback として常に維持する。
+
+---
+
+## バージョニング詳細ルール（保留）
+
+semver 適用境界の細かい運用ルール（例: deprecation 期間、`#[non_exhaustive]` 適用ガイドラインの拡張、breaking 範囲のグレーゾーン判定）は本ドキュメントに含めない。`design/15-sdk-bindings-api.md` で SDK 側の構造体・enum 拡張ポリシーが既に確立されているため、運用上のオーバーラップが顕在化した時点で別ドキュメントに切り出す。
+
+現状の運用粒度: 「迷ったら major bump」「破壊変更は CHANGELOG の `### Breaking changes` で必ず予告する」だけで十分機能する。

--- a/design/release-process.md
+++ b/design/release-process.md
@@ -17,6 +17,7 @@
 | `midori-sdk` | crates.io | ドライバー作者が直接依存するライブラリ |
 | `midori-runtime` | 公開しない | バイナリ配布（`design/12-distribution.md`）と npm shim 経由 |
 | `midori-driver-midi` / `midori-driver-osc` | 公開しない | 公式ドライバーバイナリ。`midori-runtime` に同梱 |
+| `midori-driver-dummy` | 公開しない | runtime の lifecycle / handshake 統合テスト用ハーネス。本番 runtime には含めない |
 | `midori-ipc-shm` | 公開しない | workspace 内部 crate（`unsafe` 隔離目的） |
 
 publish 対象 crate には `Cargo.toml` の `description` / `license` / `repository` / `readme` が揃っている必要がある。`midori-ipc-shm` のような workspace 内部専用 crate はこれらの整備義務を負わない。
@@ -53,12 +54,14 @@ publish 対象 crate には `Cargo.toml` の `description` / `license` / `reposi
 
 ### `Cargo.lock` と `[workspace.dependencies].version`
 
-workspace dependency entry は `path` と `version` の両方を持たせる：
+workspace dependency entry は **公開する / しないに関わらず** `path` と `version` の両方を持たせる。`cargo-deny` の wildcard ゲートは publish 対象だけを見るのではなく workspace 全体の依存グラフを評価するため、内部 crate も例外にできない:
 
 ```toml
 [workspace.dependencies]
-midori-core = { path = "crates/midori-core", version = "0.3.0" }
-midori-sdk  = { path = "crates/midori-sdk",  version = "0.2.0" }
+midori-core    = { path = "crates/midori-core",    version = "0.3.0" }
+midori-sdk     = { path = "crates/midori-sdk",     version = "0.2.0" }
+midori-ipc-shm = { path = "crates/midori-ipc-shm", version = "0.1.0" }
+midori-runtime = { path = "crates/midori-runtime", version = "0.1.0" }
 ```
 
 `version` を欠いた path-only エントリは `cargo publish` 時に wildcard 扱いとなり、`cargo-deny` の `bans.wildcards = "deny"` ゲートで失敗する。bump のたびに該当 crate の `version` も更新する。
@@ -82,7 +85,7 @@ midori-sdk  = { path = "crates/midori-sdk",  version = "0.2.0" }
 
 各 publish 対象 crate は `CHANGELOG.md` を持つ：
 
-```
+```text
 crates/midori-core/CHANGELOG.md
 crates/midori-sdk/CHANGELOG.md
 ```
@@ -134,7 +137,7 @@ GitHub Actions workflow が整うまで、または ad-hoc release では本手�
 依存順序に注意する。`midori-sdk` は `midori-core` に依存するため、`midori-core` を先に publish して crates.io 側で resolvable になってから `midori-sdk` を publish する。
 
 ```bash
-# 1. dry-run で検証（package のビルド・lint・依存解決まで通すが publish はしない）
+# 1. dry-run で midori-core の package をローカル検証（package build / lint / 依存解決を通すが publish はしない）
 cargo publish --dry-run -p midori-core
 
 # 2. dry-run が green なら本 publish
@@ -143,13 +146,15 @@ cargo publish -p midori-core
 # 3. crates.io 側で index 反映を待つ（数秒〜数十秒）
 #    反映されないうちに依存 crate を publish するとエラーになる
 
-# 4. 依存 crate の dry-run で「公開済 midori-core」が見えることを確認
+# 4. midori-sdk の package をローカルで dry-run（lint / FFI 整合チェック）
+#    workspace path 依存があるためこの dry-run は midori-core を crates.io から
+#    解決しない。crates.io 側の resolvability は手順 5 の本 publish が真に検証する
 cargo publish --dry-run -p midori-sdk
 
-# 5. midori-sdk を publish
+# 5. midori-sdk を publish（ここで初めて crates.io から midori-core を解決する）
 cargo publish -p midori-sdk
 
-# 6. tag を打って push（手順 4 の dry-run まで成功してから打つ）
+# 6. 両 publish 成功後に tag を打って push（手順 5 まで通ってから）
 git tag midori-core-v0.3.0 <publish-commit>
 git tag midori-sdk-v0.2.0 <publish-commit>
 git push origin midori-core-v0.3.0 midori-sdk-v0.2.0
@@ -165,7 +170,7 @@ git push origin midori-core-v0.3.0 midori-sdk-v0.2.0
 
 ## GitHub Actions release workflow
 
-`.github/workflows/release.yml` を canonical な publish 経路として維持する（実装は別 subtask）。
+`.github/workflows/release.yml` を canonical な publish 経路として維持する。本ファイルが repo 内に存在しない場合は、本セクションの規約（トリガー / Secrets / 推奨デフォルト）に従って新規追加する。
 
 ### トリガー
 
@@ -188,6 +193,8 @@ git push origin midori-core-v0.3.0 midori-sdk-v0.2.0
 
 ## バージョニング詳細ルール（保留）
 
-semver 適用境界の細かい運用ルール（例: deprecation 期間、`#[non_exhaustive]` 適用ガイドラインの拡張、breaking 範囲のグレーゾーン判定）は本ドキュメントに含めない。`design/15-sdk-bindings-api.md` で SDK 側の構造体・enum 拡張ポリシーが既に確立されているため、運用上のオーバーラップが顕在化した時点で別ドキュメントに切り出す。
+semver 適用境界の細かい運用ルール（例: deprecation 期間、`#[non_exhaustive]` 適用ガイドラインの拡張、breaking 範囲のグレーゾーン判定）は本ドキュメントに含めない。
+
+`design/15-sdk-bindings-api.md` は **特定の拡張パターン**（`struct_size` guard を持つ `#[repr(C)]` 構造体への末尾追加、`#[non_exhaustive]` enum へのバリアント追加）を minor bump で扱える根拠として確立しているが、semver 境界線そのものの確定は同ドキュメントの「スコープに入れないもの」に明記されている。本ドキュメントの上記「major bump の判断基準」が運用上の境界の現時点での合意。運用上のオーバーラップが顕在化した時点で別ドキュメントに切り出す。
 
 現状の運用粒度: 「迷ったら major bump」「破壊変更は CHANGELOG の `### Breaking changes` で必ず予告する」だけで十分機能する。

--- a/design/release-process/README.md
+++ b/design/release-process/README.md
@@ -1,0 +1,52 @@
+# Release Process
+
+> ステータス：運用ドキュメント
+> 最終更新：2026-05-05
+
+このディレクトリは midori プロジェクトの **release MECHANICS**（成果物をどうやって公開するか）を扱う。track ごとに独立したサブドキュメントを置き、本 README はその一覧と横断的な考慮事項に絞る。
+
+エンドユーザー視点の配布方針（配布窓口・自動アップデート・セキュリティマニフェスト・利用規約）は `../12-distribution.md` の責務。本ディレクトリと `12-distribution.md` の境界は次節で定義する。
+
+---
+
+## Track 一覧
+
+| Track | 成果物 | 公開先 | ドキュメント | 状態 |
+|---|---|---|---|---|
+| Rust crates | `midori-core` / `midori-sdk` の crate | crates.io | [`rust-crates.md`](./rust-crates.md) | 確定 |
+| Electron デスクトップアプリ | midori 本体バイナリ | 公式サイト / Booth | （未着手） | 計画 |
+| JS パッケージ | `@midori/runtime` 系 npm shim、`@midori/ui` 等 | npm | （未着手） | 計画 |
+
+各 track は **独立にリリースサイクルを持つ**。Rust crate の publish タイミング、Electron アプリの release 周期、npm パッケージの version 切り直しは互いに従属しない。横断的にバージョンを揃える運用ルールは現時点で導入しない（必要になった時点で本 README に追加する）。
+
+未着手 track のドキュメントは、当該 track の最初の release 着手時に新規追加する。空ファイルや placeholder は作らない。
+
+---
+
+## このディレクトリと `12-distribution.md` の境界
+
+両者を区別する単一の問い: **誰が読む文書か**。
+
+| 観点 | `release-process/` | `12-distribution.md` |
+|---|---|---|
+| 読者 | メンテナ / contributor（成果物を**送り出す**側） | エンドユーザー / プラグイン作者（成果物を**受け取る**側） |
+| 扱う事項 | publish コマンド、tag 規則、CHANGELOG 形式、CI workflow、token / secret 管理 | 配布窓口、自動アップデート方式、セキュリティマニフェスト、利用規約 |
+| 不変の範囲 | 内部運用ルール（変更しても外向きには見えない） | ユーザーとの契約（変更時は移行手順が要る） |
+
+例: 「`midori-core-v0.4.0` を crates.io に publish するときの dry-run 順序」は本ディレクトリ。「midori デスクトップアプリの 1.5.0 リリース時に `forced_below` をどうセットするか」は `12-distribution.md`。
+
+境界が曖昧になるケース（例: アプリと crate を同タイミングで release する場合の version 整合）は、両ドキュメントの該当箇所が互いに参照しあう形で解決する。本 README にも横断的考慮事項として追記する。
+
+---
+
+## 横断的考慮事項
+
+現時点では **無し**。Rust crate と Electron アプリと npm パッケージはそれぞれ独立に進化させる前提。version 整合・同時 release・tag の統一などのニーズが顕在化した時点で本節に追加する。
+
+候補として将来検討するもの（着手時期未定）:
+
+- Rust crate の major bump と Electron アプリの user-visible 変更の調整（midori-core ABI 変更がアプリ側にどう波及するか）
+- `@midori/runtime-{platform}` の npm version と内部に同梱する Rust binary の version 関係
+- workspace 全体の release ノート / CHANGELOG をまとめるか各 track 個別に持つかの方針
+
+これらは「実際にコンフリクトを起こした最初のリリース」で議論するのが妥当。現時点で先回りして規約化はしない。

--- a/design/release-process/rust-crates.md
+++ b/design/release-process/rust-crates.md
@@ -5,7 +5,7 @@
 
 このドキュメントは midori プロジェクトの release 運用のうち **Rust crates（`midori-core`, `midori-sdk`）の crates.io への publish** を扱う。Electron デスクトップアプリのバイナリ配布や JS パッケージの npm 公開は別トラックで、各 sibling ドキュメント（`./README.md` の一覧参照）が独立して扱う。エンドユーザー向けアプリ配布の方針は `../12-distribution.md`。
 
-リポジトリの crate 構成と公開先方針は `../14-repository-structure.md` が前提。本ドキュメントは「どのクレートを publish するか」ではなく「**いつ・どうやって publish するか**」を扱う。
+公開対象クレートと公開先方針の決定は `../14-repository-structure.md` が一次ソース。本ドキュメントは release 作業手順の前提として要点を再掲しつつ、「**いつ・どうやって publish するか**」の手順を定める。
 
 ---
 
@@ -46,7 +46,7 @@ publish 対象 crate には `Cargo.toml` の `description` / `license` / `reposi
 - `pub` 構造体のフィールド削除・型変更
 - `pub` 関数のシグネチャ変更（引数追加・型変更を含む）
 - `pub` re-export の削除
-- 公開 trait のメソッド追加（既存実装が壊れる）
+- 公開 trait への **デフォルト実装なし** メソッド追加（既存 implementor に新メソッドの実装を強制するため）。デフォルト実装ありの追加は後方互換 = minor
 
 迷う場合は major bump を選ぶ。crates.io は publish 後の version 削除をサポートしないため、互換性を弱く宣言してしまう方がリスクが大きい。
 
@@ -83,14 +83,14 @@ midori-runtime = { path = "crates/midori-runtime", version = "0.1.0" }
 
 ## CHANGELOG 運用
 
-各 publish 対象 crate は `CHANGELOG.md` を持つ：
+各 publish 対象 crate は `CHANGELOG.md` を持ち、以降は本ルール（[Keep a Changelog](https://keepachangelog.com/) 準拠）で版管理する。`midori-sdk` は現時点で `CHANGELOG.md` を持たないため、初回 publish の前提（後述）として作成し、その後は他の crate と同様に運用する：
 
 ```text
 crates/midori-core/CHANGELOG.md
 crates/midori-sdk/CHANGELOG.md
 ```
 
-形式は [Keep a Changelog](https://keepachangelog.com/) を緩く踏襲する：
+形式は次の通り：
 
 ```markdown
 # Changelog — <crate-name>
@@ -115,8 +115,6 @@ crates/midori-sdk/CHANGELOG.md
 ```
 
 major bump がない release では `### Breaking changes` セクションは省略する。`### Added` / `### Changed` / `### Fixed` も該当変更がない場合は省略する。
-
-`midori-sdk` は現時点で `CHANGELOG.md` を持たないが、初回 publish 時に作成する。
 
 ---
 
@@ -146,15 +144,19 @@ cargo publish -p midori-core
 # 3. crates.io 側で index 反映を待つ（数秒〜数十秒）
 #    反映されないうちに依存 crate を publish するとエラーになる
 
-# 4. midori-sdk の package をローカルで dry-run（lint / FFI 整合チェック）
-#    workspace path 依存があるためこの dry-run は midori-core を crates.io から
-#    解決しない。crates.io 側の resolvability は手順 5 の本 publish が真に検証する
+# 4. midori-sdk の dry-run。`cargo publish --dry-run` は package 化のとき
+#    `path` 依存を stripped し、`version` 要件のみを crates.io index に対して
+#    解決する（path は registry に存在しない / 公開できないため）。よって本 step
+#    は「公開済 midori-core が crates.io から resolvable か」の検証として機能する。
+#    `index 反映遅延` のために手順 3 の wait が短すぎるとここで失敗する → retry
 cargo publish --dry-run -p midori-sdk
 
-# 5. midori-sdk を publish（ここで初めて crates.io から midori-core を解決する）
+# 5. midori-sdk を publish（手順 4 と同じ resolution path で本適用）
 cargo publish -p midori-sdk
 
 # 6. 両 publish 成功後に tag を打って push（手順 5 まで通ってから）
+#    <publish-commit> は通常 HEAD（main にマージ済みの release 起点 commit）。
+#    過去の commit を release する場合は対応する commit hash を指定する
 git tag midori-core-v0.3.0 <publish-commit>
 git tag midori-sdk-v0.2.0 <publish-commit>
 git push origin midori-core-v0.3.0 midori-sdk-v0.2.0
@@ -163,7 +165,7 @@ git push origin midori-core-v0.3.0 midori-sdk-v0.2.0
 ### 失敗時の挙動
 
 - `cargo publish` が途中で失敗した場合、既に publish 済みの crate は yank できるが完全削除はできない。version を捨てて次の patch / minor へ進めるのが基本対応
-- index 反映遅延で dry-run が失敗するケースは時間を置いて retry すれば通る
+- 手順 4 の `--dry-run` が "no matching package named `midori-core`" 等で失敗する場合は、手順 3 の index 反映待ちが不足している。時間を置いて retry すれば通る
 - 一度 publish した version の中身は変更不可。修正が必要なら次の version を切る
 
 ---

--- a/design/release-process/rust-crates.md
+++ b/design/release-process/rust-crates.md
@@ -1,11 +1,11 @@
-# Crate Release Process
+# Rust Crates Release Process
 
 > ステータス：運用ドキュメント
-> 最終更新：2026-05-04
+> 最終更新：2026-05-05
 
-このドキュメントは Rust crates（`midori-core`, `midori-sdk`）の crates.io への release 運用を定める。エンドユーザー向けアプリ配布（`design/12-distribution.md`）とは別物で、対象は **crate を消費する開発者**および**メンテナ自身**。
+このドキュメントは midori プロジェクトの release 運用のうち **Rust crates（`midori-core`, `midori-sdk`）の crates.io への publish** を扱う。Electron デスクトップアプリのバイナリ配布や JS パッケージの npm 公開は別トラックで、各 sibling ドキュメント（`./README.md` の一覧参照）が独立して扱う。エンドユーザー向けアプリ配布の方針は `../12-distribution.md`。
 
-リポジトリの crate 構成と公開先方針は `design/14-repository-structure.md` が前提。本ドキュメントは「どのクレートを publish するか」ではなく「**いつ・どうやって publish するか**」を扱う。
+リポジトリの crate 構成と公開先方針は `../14-repository-structure.md` が前提。本ドキュメントは「どのクレートを publish するか」ではなく「**いつ・どうやって publish するか**」を扱う。
 
 ---
 
@@ -15,7 +15,7 @@
 |---|---|---|
 | `midori-core` | crates.io | 型・プロトコル定義。`midori-sdk` が依存する |
 | `midori-sdk` | crates.io | ドライバー作者が直接依存するライブラリ |
-| `midori-runtime` | 公開しない | バイナリ配布（`design/12-distribution.md`）と npm shim 経由 |
+| `midori-runtime` | 公開しない | バイナリ配布（`../12-distribution.md`）と npm shim 経由 |
 | `midori-driver-midi` / `midori-driver-osc` | 公開しない | 公式ドライバーバイナリ。`midori-runtime` に同梱 |
 | `midori-driver-dummy` | 公開しない | runtime の lifecycle / handshake 統合テスト用ハーネス。本番 runtime には含めない |
 | `midori-ipc-shm` | 公開しない | workspace 内部 crate（`unsafe` 隔離目的） |
@@ -50,7 +50,7 @@ publish 対象 crate には `Cargo.toml` の `description` / `license` / `reposi
 
 迷う場合は major bump を選ぶ。crates.io は publish 後の version 削除をサポートしないため、互換性を弱く宣言してしまう方がリスクが大きい。
 
-例外として `design/15-sdk-bindings-api.md` で確立済みのパターン（`struct_size` guard を持つ `#[repr(C)]` 構造体への末尾追加、`#[non_exhaustive]` enum へのバリアント追加）は **minor bump で扱える**。これらは旧バイナリ / 旧 enum match を壊さないことが構造的に保証されているため。詳細な適用条件は `15-sdk-bindings-api.md` の該当節に従う。
+例外として `../15-sdk-bindings-api.md` で確立済みのパターン（`struct_size` guard を持つ `#[repr(C)]` 構造体への末尾追加、`#[non_exhaustive]` enum へのバリアント追加）は **minor bump で扱える**。これらは旧バイナリ / 旧 enum match を壊さないことが構造的に保証されているため。詳細な適用条件は同ドキュメントの該当節に従う。
 
 ### `Cargo.lock` と `[workspace.dependencies].version`
 
@@ -195,6 +195,6 @@ git push origin midori-core-v0.3.0 midori-sdk-v0.2.0
 
 semver 適用境界の細かい運用ルール（例: deprecation 期間、`#[non_exhaustive]` 適用ガイドラインの拡張、breaking 範囲のグレーゾーン判定）は本ドキュメントに含めない。
 
-`design/15-sdk-bindings-api.md` は **特定の拡張パターン**（`struct_size` guard を持つ `#[repr(C)]` 構造体への末尾追加、`#[non_exhaustive]` enum へのバリアント追加）を minor bump で扱える根拠として確立しているが、semver 境界線そのものの確定は同ドキュメントの「スコープに入れないもの」に明記されている。本ドキュメントの上記「major bump の判断基準」が運用上の境界の現時点での合意。運用上のオーバーラップが顕在化した時点で別ドキュメントに切り出す。
+`../15-sdk-bindings-api.md` は **特定の拡張パターン**（`struct_size` guard を持つ `#[repr(C)]` 構造体への末尾追加、`#[non_exhaustive]` enum へのバリアント追加）を minor bump で扱える根拠として確立しているが、semver 境界線そのものの確定は同ドキュメントの「スコープに入れないもの」に明記されている。本ドキュメントの上記「major bump の判断基準」が運用上の境界の現時点での合意。運用上のオーバーラップが顕在化した時点で別ドキュメントに切り出す。
 
 現状の運用粒度: 「迷ったら major bump」「破壊変更は CHANGELOG の `### Breaking changes` で必ず予告する」だけで十分機能する。


### PR DESCRIPTION
Closes the MEW-78 subtask of MEW-46 (publish midori-core to crates.io).

## Summary
- New `design/release-process.md` documents the operational flow for releasing `midori-core` / `midori-sdk` to crates.io: publish targets, semver boundaries with concrete major-bump triggers, per-crate tag convention (`<crate>-vX.Y.Z`), CHANGELOG sectioning rules, the manual `cargo publish` procedure (with the midori-core → midori-sdk dependency-order requirement), and the GitHub Actions workflow contract that the sibling subtask MEW-79 implements.
- `design/14-repository-structure.md`: update the `[workspace.dependencies]` example to include `version` alongside `path`. Path-only entries would fail both `cargo publish` (wildcard) and the `cargo-deny` `bans.wildcards` gate, so the example now matches the actual Cargo.toml and the release-process doc's pinning rule.
- `design/README.md`: add the new doc to the index and pick up `14-repository-structure.md` (which was missing).

## Why

Without a written release process, the `cargo publish --dry-run` failure that surfaced in MEW-37 has no canonical resolution path; each release would require rediscovering the sequence (publish midori-core, wait for index reflection, dry-run sdk, tag, push). Document it once, link it from `14-repository-structure.md`, and the operational knowledge stops living in commit messages.

## Acceptance Criteria

- [x] `design/12-distribution.md` or `design/release-process.md` carries the Crate Release Process section (chose the latter to avoid mixing app-binary distribution with crate publish concerns)
- [x] semver boundaries documented (major / minor / patch with explicit triggers)
- [x] tag naming convention (`<crate>-vX.Y.Z`) documented; alternatives explicitly rejected with reasons
- [x] manual `cargo publish` procedure documented with prerequisites and dependency order
- [x] CHANGELOG operations documented (Keep a Changelog format, `### Breaking changes` section pattern)
- [x] GitHub Actions workflow contract documented (trigger, secrets, permissions, dry-run default)
- [x] No contradictions with `design/14-repository-structure.md` (workspace.dependencies example aligned), `design/15-sdk-bindings-api.md` (struct_size / `#[non_exhaustive]` exception acknowledged), or `design/17-driver-comm/01-inline-ring.md` (shm version counter is independent of crate semver — clarified by leaving the existing wording untouched)
- [x] `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` pass

## Out of Scope (per Issue)
- Detailed semver operational rules (deprecation periods etc.) — deferred to a separate Low Issue if it grows
- npm / PyPI distribution flow (Phase 3 Dist-1/2)

## Test plan
- [x] No code changes; design-doc only
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manually grepped `design/` for `crates.io`, `cargo publish`, `workspace.dependencies`, `major bump`, `semver` to surface contradictions; only the `[workspace.dependencies]` example in `14-repository-structure.md` was inconsistent and is fixed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * リポジトリ構造と Cargo ワークスペースのバージョン管理方針を追加・明確化（workspace で版管理を集約、path＋version 表記の運用ルール）。
  * release-process の概要を整備し、各トラック別のリリース責務と運用方針を提示。
  * Rust crates 向け公開手順、バージョニングルール、CHANGELOG/タグ運用、および公開時の順序・失敗時対応を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->